### PR TITLE
create basic slide and panel components

### DIFF
--- a/src/app.vue
+++ b/src/app.vue
@@ -34,7 +34,9 @@
                 />
             </svg>
 
-            <h1 class="m-10 text-5xl font-bold text-gray-800">{{ story.title }}</h1>
+            <h1 class="m-10 text-5xl font-bold text-gray-800">
+                {{ story.title }}
+            </h1>
             <p class="w-1/2 m-auto text-2xl font-semibold text-gray-500">
                 {{ story.subTitle }}
             </p>
@@ -70,20 +72,27 @@
         </main>
 
         <footer class="p-8 text-center">
-            2021 - Design by <span class="font-semibold text-accent-blue">BeSD UX Team</span>
+            2021 - Design by
+            <span class="font-semibold text-accent-blue">BeSD UX Team</span>
         </footer>
+
+        <div class="w-3/4 pb-10" style="margin: 0 auto">
+            <slide></slide>
+        </div>
     </div>
 </template>
 
 <script lang="ts">
 import { Component, Vue } from 'vue-property-decorator';
 import StoryV from '@/components/story.vue';
+import SlideV from '@/components/slide.vue';
 
 import story, { StoryConfig } from '@/story-config';
 
 @Component({
     components: {
-        StoryV
+        StoryV,
+        slide: SlideV
     }
 })
 export default class App extends Vue {

--- a/src/components/panel.vue
+++ b/src/components/panel.vue
@@ -1,0 +1,42 @@
+<template>
+    <div class="flex flex-col">
+        <component :is="getTemplate()" :config="config"></component>
+    </div>
+</template>
+
+<script lang="ts">
+import { Component, Vue, Prop } from 'vue-property-decorator';
+import TextPanelV from './text-panel.vue';
+
+enum panelTypes {
+    'text',
+    'map',
+    'multimedia',
+    'dqvchart'
+}
+
+@Component({
+    components: {
+        TextPanelV
+    }
+})
+export default class PanelV extends Vue {
+    @Prop() config!: any; // TODO: replace with a proper TypeScript type
+
+    /**
+     * Returns the corresponding component for this panel.
+     */
+    getTemplate() {
+        const panelTemplates: any = {
+            text: TextPanelV,
+            [panelTypes.map]: undefined,
+            [panelTypes.multimedia]: undefined,
+            [panelTypes.dqvchart]: undefined
+        };
+
+        return panelTemplates[this.config.type];
+    }
+}
+</script>
+
+<style lang="scss" scoped></style>

--- a/src/components/slide.vue
+++ b/src/components/slide.vue
@@ -1,0 +1,39 @@
+<template>
+    <div class="w-full h-full flex flex-row">
+        <panel v-for="(panel, idx) in config.panel" :key="idx" :config="panel" :index="idx"></panel>
+    </div>
+</template>
+
+<script lang="ts">
+import { Component, Vue, Prop } from 'vue-property-decorator';
+import PanelV from './panel.vue';
+
+@Component({
+    components: {
+        panel: PanelV
+    }
+})
+export default class SlideV extends Vue {
+    @Prop() config!: any; // TODO: replace with a proper TypeScript type
+
+    // TODO: remove this. For demo purposes.
+    beforeMount() {
+        this.config = {
+            panel: [
+                {
+                    type: 'text',
+                    title: 'Hello World',
+                    content: 'o/'
+                },
+                {
+                    type: 'text',
+                    title: 'Hello from the other side',
+                    content: 'o7'
+                }
+            ]
+        };
+    }
+}
+</script>
+
+<style lang="scss" scoped></style>

--- a/src/components/text-panel.vue
+++ b/src/components/text-panel.vue
@@ -1,0 +1,15 @@
+<template>
+    <div>
+        <div class="font-bold block text-lg">{{ config.title }}</div>
+        <div class="block">{{ config.content }}</div>
+    </div>
+</template>
+
+<script lang="ts">
+import { Component, Vue, Prop } from 'vue-property-decorator';
+
+@Component({})
+export default class TextPanelV extends Vue {
+    @Prop() config!: any; // TODO: replace with TypeScript type
+}
+</script>


### PR DESCRIPTION
Basic implementation for slides and panels.

Given a config, the slide component will display either one or two panels. If one panel is provided, it will take up the whole slide. If two are provided, the panels will be displayed next to each other.

The panel component acts as a base class for the individual panel types. Because we don't currently have any of the panel types created, most of these are `undefined` for now. I've created a very simple text component for demo purposes only.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/38)
<!-- Reviewable:end -->
