### PR TITLE
Image panels + add default width ratio for panels in slides

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -60,7 +60,7 @@
                     "enum": ["text"]
                 }
             },
-            "required": ["content", "type"]
+            "required": ["content", "type", "title"]
         },
 
         "multimediaPanel": {
@@ -415,6 +415,10 @@
                 "altText": {
                     "type": "string",
                     "description": "The supporting text for the image."
+                },
+                "class": {
+                    "type": "string",
+                    "description": "Styling class properties for the image."
                 },
                 "tooltip": {
                     "type": "string",

--- a/src/app.vue
+++ b/src/app.vue
@@ -76,7 +76,7 @@
             <span class="font-semibold text-accent-blue">BeSD UX Team</span>
         </footer>
 
-        <div class="w-3/4 pb-10" style="margin: 0 auto">
+        <div class="w-full pb-10" style="margin: 0 auto">
             <slide v-for="(story, idx) in config.slides" :key="idx" :config="story"></slide>
         </div>
     </div>

--- a/src/components/panels/image-panel.vue
+++ b/src/components/panels/image-panel.vue
@@ -1,6 +1,6 @@
 <template>
-    <div class="bg-gray-100 text-center inline-block h-full align-middle">
-        <h1 class="align-middle">Temporary Image Panel</h1>
+    <div class="text-center inline-block h-full align-middle">
+        <img :src="config.src" :class="config.class" :alt="config.altText" class="block my-8 bg-gray-200 max-w-full" />
     </div>
 </template>
 

--- a/src/components/panels/image-panel.vue
+++ b/src/components/panels/image-panel.vue
@@ -1,6 +1,6 @@
 <template>
-    <div class="text-center inline-block h-full align-middle">
-        <img :src="config.src" :class="config.class" :alt="config.altText" class="block my-8 bg-gray-200 max-w-full" />
+    <div class="justify-center flex h-full align-middle py-5">
+        <img :src="config.src" :class="config.class" :alt="config.altText" class="px-10 my-8 block max-w-full" />
     </div>
 </template>
 

--- a/src/components/panels/panel.vue
+++ b/src/components/panels/panel.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="flex flex-col">
+    <div :class="ratio && config.type !== 'text' ? 'flex-2' : 'flex'" class="flex-col">
         <component :is="getTemplate()" :config="config"></component>
     </div>
 </template>
@@ -23,6 +23,7 @@ import ChartPanelV from './chart-panel.vue';
 })
 export default class PanelV extends Vue {
     @Prop() config!: BasePanel;
+    @Prop() ratio!: boolean;
 
     /**
      * Returns the corresponding component for this panel.

--- a/src/components/panels/text-panel.vue
+++ b/src/components/panels/text-panel.vue
@@ -1,5 +1,5 @@
 <template>
-    <Scrollama class="flex-1 prose max-w-none">
+    <Scrollama class="flex-1 prose max-w-none my-5">
         <h2 class="px-10 mb-0 chapter-title top-20">
             {{ config.title }}
         </h2>

--- a/src/components/slide.vue
+++ b/src/components/slide.vue
@@ -1,6 +1,12 @@
 <template>
     <div class="w-full h-full flex flex-row">
-        <panel v-for="(panel, idx) in config.panel" :key="idx" :config="panel" :index="idx"></panel>
+        <panel
+            v-for="(panel, idx) in config.panel"
+            :key="idx"
+            :config="panel"
+            :index="idx"
+            :ratio="defaultRatio"
+        ></panel>
     </div>
 </template>
 
@@ -8,7 +14,7 @@
 import { Component, Vue, Prop } from 'vue-property-decorator';
 
 import PanelV from './panels/panel.vue';
-import { Slide } from '@/definitions';
+import { PanelType, Slide } from '@/definitions';
 
 @Component({
     components: {
@@ -17,6 +23,22 @@ import { Slide } from '@/definitions';
 })
 export default class SlideV extends Vue {
     @Prop() config!: Slide;
+
+    defaultRatio = false;
+
+    mounted(): void {
+        const panels = this.config.panel;
+        // check if there is one text panel and one non-text panel in the slide and user did not specify a width in config
+        if (panels.length == 2 && !panels[0].width && !panels[1].width) {
+            const panelText1 = panels[0].type === PanelType.Text;
+            const panelText2 = panels[1].type === PanelType.Text;
+
+            // set a default ratio to be set so that non-text panel takes up more flexbox space
+            if ((panelText1 && !panelText2) || (!panelText1 && panelText2)) {
+                this.defaultRatio = true;
+            }
+        }
+    }
 }
 </script>
 

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -32,6 +32,7 @@ export enum PanelType {
 
 export interface BasePanel {
     type: string;
+    width?: number;
 }
 
 export interface TextPanel extends BasePanel {

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -12,7 +12,7 @@ export interface Intro {
         altText?: string;
     };
     title: string;
-    subtitle: string;
+    subtitle?: string;
     blurb?: string;
 }
 
@@ -35,53 +35,54 @@ export interface BasePanel {
 }
 
 export interface TextPanel extends BasePanel {
-    title?: string;
     type: PanelType.Text;
+    title: string;
     content: string; // in md format
 }
 
 export interface MapPanel extends BasePanel {
+    type: PanelType.Map;
     config: any; // TODO: replace with proper Typescript type
     expandable?: boolean;
-    type: PanelType.Map;
 }
 
 export interface ImagePanel extends BasePanel {
+    type: PanelType.Image;
+    src: string;
     width?: number;
     height?: number;
-    src: string;
+    class?: string;
     altText?: string;
     tooltip?: string;
-    type: PanelType.Image;
 }
 
 export interface VideoPanel extends BasePanel {
+    type: PanelType.Video;
     width?: number;
     height?: number;
     src: string;
     caption?: string;
-    type: PanelType.Video;
 }
 
 export interface AudioPanel extends BasePanel {
+    type: PanelType.Audio;
     src: string;
     caption?: string;
-    type: PanelType.Audio;
 }
 
 export interface SlideshowPanel extends BasePanel {
+    type: PanelType.Slideshow;
     images: ImagePanel[];
     loop?: boolean;
     caption?: string;
-    type: PanelType.Slideshow;
 }
 
 export interface ChartPanel extends BasePanel {
+    type: PanelType.Chart;
     json: string;
     width?: number;
     height?: number;
     expandable?: boolean;
-    type: PanelType.Chart;
 }
 
 // TODO: add more definitions here as needed


### PR DESCRIPTION
Adds image panel component that is centered. Also adds a check if no panel width is specified in config and it is a text panel + graphic panel combination, then set a default ratio of 2/3 width taken up by the graphic content. 