### PR TITLE
remove header links, add link to github repo

### DIFF
--- a/src/app.vue
+++ b/src/app.vue
@@ -6,8 +6,7 @@
                     <span class="text-lg">{{ story.title }}</span>
                 </div>
                 <div class="flex justify-end flex-auto space-x-6">
-                    <a href="#">Sharepoint</a>
-                    <a href="https://github.com/ramp4-pcar4/story-ramp">Github</a>
+                    <!-- Any links we want in the header can go here -->
                 </div>
             </div>
         </header>
@@ -71,9 +70,13 @@
             <StoryV :value="story" />
         </main>
 
-        <footer class="p-8 text-center">
-            2021 - Design by
-            <span class="font-semibold text-accent-blue">BeSD UX Team</span>
+        <footer class="p-8 pt-2 text-right">
+            <a
+                href="https://github.com/ramp4-pcar4/story-ramp"
+                target="_NEW"
+                class="font-semibold text-blue-500 text-sm"
+                >ramp4-pcar4/story-ramp</a
+            >
         </footer>
 
         <div class="w-full pb-10" style="margin: 0 auto">

--- a/src/components/panels/panel.vue
+++ b/src/components/panels/panel.vue
@@ -40,8 +40,6 @@ export default class PanelV extends Vue {
             [PanelType.Chart]: ChartPanelV
         };
 
-        console.log(this.config.type, panelTemplates[this.config.type]);
-
         return panelTemplates[this.config.type];
     }
 }


### PR DESCRIPTION
Closes #5 and #6 

This PR removes the Sharepoint and Github links from the header bar, and adds in a small link to the StoryRAMP repo at the bottom. I also removed a console.log statement that I forgot to remove when working on the panel PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/48)
<!-- Reviewable:end -->
