### PR TITLE
add slide anchors

### DIFF
--- a/src/components/slide.vue
+++ b/src/components/slide.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="w-full h-full flex flex-row">
+    <div :id="this.$vnode.key" class="w-full h-full flex flex-row">
         <panel
             v-for="(panel, idx) in config.panel"
             :key="idx"


### PR DESCRIPTION
Closes #30 

Adds anchor points for each slide based on the order they appear in the config file. For now, the anchor point is simply an ID, but if we want it to be fancier (i.e., using one of the headers in the slide for example), we can have a discussion on this during a planning meeting.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/50)
<!-- Reviewable:end -->
