### PR TITLE
Connect paginator to new slides/panels layout

### DIFF
--- a/OilSandsConfig_en.ts
+++ b/OilSandsConfig_en.ts
@@ -8,6 +8,7 @@ const config = {
     },
     slides: [
         {
+            title: 'Overview',
             panel: [
                 {
                     title: 'Overview',
@@ -23,6 +24,7 @@ Businesses, institutions and other facilities across Canada must report their re
             ]
         },
         {
+            title: 'Oil sands deposits',
             panel: [
                 {
                     title: 'Oil sands deposits',
@@ -90,6 +92,7 @@ This map shows the three oil sands areas. The actual geological deposits themsel
             ]
         },
         {
+            title: 'Oil sands extraction',
             panel: [
                 {
                     title: 'Oil sands extraction',
@@ -107,6 +110,7 @@ Surface mining involves digging up large areas with large excavators. The result
             ]
         },
         {
+            title: 'In-situ extraction',
             panel: [
                 {
                     title: 'In-situ extraction',
@@ -122,6 +126,7 @@ Thermal in-situ facilities have a much smaller physical footprint than surface m
             ]
         },
         {
+            title: 'Where are facilities located?',
             panel: [
                 {
                     title: 'Where are facilities located?',
@@ -176,6 +181,7 @@ Thermal in-situ facilities have a much smaller physical footprint than surface m
             ]
         },
         {
+            title: 'NPRI substances reported for oil sands mining facilities',
             panel: [
                 {
                     title: 'NPRI substances reported for oil sands mining facilities',
@@ -241,6 +247,7 @@ Satellite imagery as of 2011.`,
             ]
         },
         {
+            title: 'Criteria air contaminant releases from oil sands mines',
             panel: [
                 {
                     title: 'Criteria air contaminant releases from oil sands mines',
@@ -254,6 +261,7 @@ Satellite imagery as of 2011.`,
             ]
         },
         {
+            title: 'Mine tailings reported',
             panel: [
                 {
                     title: 'Mine tailings reported',
@@ -308,6 +316,7 @@ While the tailings reported by these mines have large amounts of manganese, ammo
             ]
         },
         {
+            title: 'Reported mine tailings from oil sands surface mining facilities',
             panel: [
                 {
                     title: 'Reported mine tailings from oil sands surface mining facilities',
@@ -366,6 +375,7 @@ Satellite imagery as of 2011.`,
             ]
         },
         {
+            title: 'Trends in mine tailings reported from surface mining facilities',
             panel: [
                 {
                     title: 'Trends in mine tailings reported from surface mining facilities',
@@ -412,6 +422,7 @@ Satellite imagery as of 2011.`,
             ]
         },
         {
+            title: 'Thermal in situ facilities',
             panel: [
                 {
                     title: 'Thermal in situ facilities',
@@ -429,6 +440,7 @@ Compared to surface mining, thermal in-situ operations are much more energy inte
             ]
         },
         {
+            title: 'NPRI releases from thermal in-situ facilities',
             panel: [
                 {
                     title: 'NPRI releases from thermal in-situ facilities',
@@ -484,6 +496,7 @@ The air releases reported by thermal in-situ facilities is almost entirely (99%)
             ]
         },
         {
+            title: 'Trends in NPRI substances released from in-situ facilities',
             panel: [
                 {
                     title: 'Trends in NPRI substances released from in-situ facilities',
@@ -533,6 +546,7 @@ This change in the number of facilities reporting over time follows changes in t
             ]
         },
         {
+            title: 'NPRI releases from thermal in-situ facilities - Part 2',
             panel: [
                 {
                     title: 'NPRI releases from thermal in-situ facilities - Part 2',
@@ -550,6 +564,7 @@ While thermal in-situ facilities have reported an increase in reported CAC emiss
             ]
         },
         {
+            title: 'Managing environmental impacts',
             panel: [
                 {
                     title: 'Managing environmental impacts',
@@ -569,6 +584,7 @@ Oil sands surface mining facilities in Alberta take much of their water from the
             ]
         },
         {
+            title: 'Pollution in your neighbourhood',
             panel: [
                 {
                     title: 'Pollution in your neighbourhood',

--- a/schema.json
+++ b/schema.json
@@ -9,11 +9,15 @@
             "type": "object",
             "description": "A universal StoryRAMP slide",
             "properties": {
+                "title": {
+                    "type": "string",
+                    "description": "The title for the slide."
+                },
                 "panel": {
                     "$ref": "#/$defs/panel"
                 }
             },
-            "required": ["panel"]
+            "required": ["title", "panel"]
         },
 
         "panel": {
@@ -49,7 +53,7 @@
             "properties": {
                 "title": {
                     "type": "string",
-                    "description": "The title for the text slide."
+                    "description": "The title for the text panel."
                 },
                 "content": {
                     "type": "string",

--- a/src/app.vue
+++ b/src/app.vue
@@ -3,7 +3,7 @@
         <header class="sticky top-0 z-50 w-full h-16 leading-9 bg-white border-b border-gray-200">
             <div class="flex w-full px-6 py-3 mx-auto max-w-9xl">
                 <div class="flex-none font-semibold">
-                    <span class="text-lg">{{ story.title }}</span>
+                    <span class="text-lg">{{ config.introSlide.title }}</span>
                 </div>
                 <div class="flex justify-end flex-auto space-x-6">
                     <!-- Any links we want in the header can go here -->
@@ -34,10 +34,10 @@
             </svg>
 
             <h1 class="m-10 text-5xl font-bold text-gray-800">
-                {{ story.title }}
+                {{ config.introSlide.title }}
             </h1>
             <p class="w-1/2 m-auto text-2xl font-semibold text-gray-500">
-                {{ story.subTitle }}
+                {{ config.introSlide.subtitle }}
             </p>
 
             <a href="#story" class="inline-block mt-10 scroll-arrow" title="scroll to story" v-smooth-scroll>
@@ -66,9 +66,13 @@
             </a>
         </div>
 
-        <main class="w-full mx-auto max-w-9xl" id="story">
+        <!-- <main class="w-full mx-auto max-w-9xl" id="story">
             <StoryV :value="story" />
-        </main>
+        </main> -->
+
+        <div class="w-full mx-auto max-w-9xl pb-10" id="story">
+            <StoryV :config="config" />
+        </div>
 
         <footer class="p-8 pt-2 text-right">
             <a
@@ -78,30 +82,22 @@
                 >ramp4-pcar4/story-ramp</a
             >
         </footer>
-
-        <div class="w-full pb-10" style="margin: 0 auto">
-            <slide v-for="(story, idx) in config.slides" :key="idx" :config="story"></slide>
-        </div>
     </div>
 </template>
 
 <script lang="ts">
 import { Component, Vue } from 'vue-property-decorator';
-import StoryV from '@/components/story.vue';
-import SlideV from '@/components/slide.vue';
+import StoryV from '@/components/story/story.vue';
 
-import story, { StoryConfig } from '@/story-config';
 import config from '../OilSandsConfig_en';
-import { StoryRampConfig } from './definitions';
+import { StoryRampConfig } from '@/definitions';
 
 @Component({
     components: {
-        StoryV,
-        slide: SlideV
+        StoryV
     }
 })
 export default class App extends Vue {
-    story: StoryConfig = story;
     config: StoryRampConfig = config;
 }
 </script>

--- a/src/components/story/chapter-menu.vue
+++ b/src/components/story/chapter-menu.vue
@@ -31,17 +31,13 @@
         </div>
 
         <ul class="menu">
-            <li
-                v-for="(chapter, index) in chapters"
-                :key="index"
-                :class="{ 'is-active': activeChapterIndex === index }"
-            >
-                <tippy :to="`menu-options-tippy-${index}`" delay="200" placement="right" v-if="!isMenuOpen">{{
-                    chapter.title
+            <li v-for="(slide, idx) in slides" :key="idx" :class="{ 'is-active': activeChapterIndex === idx }">
+                <tippy :to="`menu-options-tippy-${idx}`" delay="200" placement="right" v-if="!isMenuOpen">{{
+                    slide.title
                 }}</tippy>
                 <a
-                    :name="`menu-options-tippy-${index}`"
-                    :href="`#${chapter.title.toLowerCase().replaceAll(' ', '-')}`"
+                    :name="`menu-options-tippy-${idx}`"
+                    :href="`#${slide.title.toLowerCase().replaceAll(' ', '-')}`"
                     class="flex items-center px-2 py-1 mx-1"
                     v-smooth-scroll
                 >
@@ -60,7 +56,7 @@
                         />
                     </svg>
                     <span class="flex-1 ml-4 overflow-hidden leading-none overflow-ellipsis whitespace-nowrap">{{
-                        chapter.title
+                        slide.title
                     }}</span>
                 </a>
             </li>
@@ -69,12 +65,12 @@
 </template>
 
 <script lang="ts">
-import { ChapterConfig } from '@/story-config';
 import { Component, Vue, Prop } from 'vue-property-decorator';
+import { Slide } from '@/definitions';
 
 @Component
 export default class ChapterMenuV extends Vue {
-    @Prop() chapters!: ChapterConfig[];
+    @Prop() slides!: Slide[];
     @Prop() activeChapterIndex!: number;
 
     isMenuOpen = false;

--- a/src/components/story/slide.vue
+++ b/src/components/story/slide.vue
@@ -13,7 +13,7 @@
 <script lang="ts">
 import { Component, Vue, Prop } from 'vue-property-decorator';
 
-import PanelV from './panels/panel.vue';
+import PanelV from '@/components/panels/panel.vue';
 import { PanelType, Slide } from '@/definitions';
 
 @Component({
@@ -29,9 +29,9 @@ export default class SlideV extends Vue {
     mounted(): void {
         const panels = this.config.panel;
         // check if there is one text panel and one non-text panel in the slide and user did not specify a width in config
-        if (panels.length == 2 && !panels[0].width && !panels[1].width) {
-            const panelText1 = panels[0].type === PanelType.Text;
-            const panelText2 = panels[1].type === PanelType.Text;
+        if (panels.length == 2 && !panels[0]?.width && !panels[1]?.width) {
+            const panelText1 = panels[0]?.type === PanelType.Text;
+            const panelText2 = panels[1]?.type === PanelType.Text;
 
             // set a default ratio to be set so that non-text panel takes up more flexbox space
             if ((panelText1 && !panelText2) || (!panelText1 && panelText2)) {

--- a/src/components/story/story.vue
+++ b/src/components/story/story.vue
@@ -1,26 +1,15 @@
 <template>
     <div class="flex items-stretch">
-        <ChapterMenuV :active-chapter-index="activeChapterIndex" :chapters="value.chapters" />
+        <ChapterMenuV :active-chapter-index="activeChapterIndex" :slides="config.slides" />
 
         <Scrollama class="relative story-scrollama" @step-enter="stepEnter">
             <div
-                v-for="(chapter, index) in value.chapters"
-                :key="index"
+                v-for="(slide, idx) in config.slides"
+                :key="idx"
                 class="flex pt-24"
-                :data-chapter-index="index"
-                :id="chapter.title.toLowerCase().replaceAll(' ', '-')"
+                :id="slide.title.toLowerCase().replaceAll(' ', '-')"
             >
-                <ChapterV :value="chapter" :chapter-index="index" />
-
-                <div class="sticky flex self-start justify-center flex-2 top-16">
-                    <component
-                        v-if="chapter.graphic"
-                        :is="chapter.graphic.type"
-                        :payload="chapter.graphic.payload"
-                        :chapter-index="index"
-                        :active-chapter-index="activeChapterIndex"
-                    ></component>
-                </div>
+                <slide :config="slide"></slide>
             </div>
         </Scrollama>
     </div>
@@ -29,26 +18,25 @@
 <script lang="ts">
 import 'intersection-observer';
 import Scrollama from 'vue-scrollama';
-import ChapterV from '@/components/chapter.vue';
-import ChapterMenuV from '@/components/chapter-menu.vue';
-
 import { Component, Vue, Prop } from 'vue-property-decorator';
 
-import { StoryConfig } from '@/story-config';
+import ChapterMenuV from './chapter-menu.vue';
+import SlideV from './slide.vue';
+import { StoryRampConfig } from '@/definitions';
 
 @Component({
     components: {
         Scrollama,
-        ChapterV,
-        ChapterMenuV
+        ChapterMenuV,
+        slide: SlideV
     }
 })
 export default class StoryV extends Vue {
-    @Prop() value!: StoryConfig;
+    @Prop() config!: StoryRampConfig;
 
     activeChapterIndex = -1;
 
-    stepEnter({ element, index }: { element: HTMLElement; index: number }): void {
+    stepEnter({ element }: { element: HTMLElement }): void {
         this.activeChapterIndex = parseInt(element.dataset.chapterIndex || '-1');
     }
 }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -17,6 +17,9 @@ export interface Intro {
 }
 
 export interface Slide {
+    title: string;
+    // tuple definition to restrict array size
+    // panel: [BasePanel, BasePanel | undefined];
     panel: BasePanel[];
 }
 


### PR DESCRIPTION
Closes #47 

Reorganizes some Vue component files and connect paginator to using the new slides/panels. Adds a title property to slides in the config/schema that was discussed. The old story map has also been removed with this PR but the files remain (unused).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/53)
<!-- Reviewable:end -->
