### PR TITLE
open all markdown links in new tab

### DIFF
--- a/src/components/panels/text-panel.vue
+++ b/src/components/panels/text-panel.vue
@@ -24,6 +24,10 @@ export default class TextPanelV extends Vue {
     @Prop() config!: TextPanel;
 
     md = new MarkdownIt();
+
+    mounted(): void {
+        document.querySelectorAll('a:not([target])').forEach((el) => (el.target = '_blank'));
+    }
 }
 </script>
 


### PR DESCRIPTION
Closes #62

Adds target blank attribute to all Markdown `href` links in StoryRamp

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/69)
<!-- Reviewable:end -->
