### PR TITLE
support for HTML text in config file + markdown support for captions

### DIFF
--- a/src/components/panels/slideshow-panel.vue
+++ b/src/components/panels/slideshow-panel.vue
@@ -15,15 +15,15 @@
             <hooper-pagination slot="hooper-addons"></hooper-pagination>
         </hooper>
 
-        <div v-if="config.caption" class="text-center mt-5 text-sm">
-            {{ config.caption }}
-        </div>
+        <div v-if="config.caption" class="text-center mt-5 text-sm" v-html="md.render(config.caption)"></div>
     </div>
 </template>
 
 <script lang="ts">
 import { Hooper, Slide, Navigation as HooperNavigation, Pagination as HooperPagination } from 'hooper';
 import 'hooper/dist/hooper.css';
+
+import MarkdownIt from 'markdown-it';
 
 import { SlideshowPanel } from '@/definitions';
 import { Component, Vue, Prop } from 'vue-property-decorator';
@@ -40,6 +40,8 @@ export default class SlideshowPanelV extends Vue {
     @Prop() config!: SlideshowPanel;
 
     width = -1;
+
+    md = new MarkdownIt({ html: true });
 
     mounted(): void {
         setTimeout(() => {

--- a/src/components/panels/text-panel.vue
+++ b/src/components/panels/text-panel.vue
@@ -23,7 +23,7 @@ import { TextPanel } from '@/definitions';
 export default class TextPanelV extends Vue {
     @Prop() config!: TextPanel;
 
-    md = new MarkdownIt();
+    md = new MarkdownIt({ html: true });
 
     mounted(): void {
         document.querySelectorAll('a:not([target])').forEach((el) => (el.target = '_blank'));


### PR DESCRIPTION
Closes #78 

This PR adds HTML support to text slides. Now, both markdown and HTML text will be displayed as intended.

I've also added this same functionality to captions (which only currently exist for the slideshow panel).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/84)
<!-- Reviewable:end -->
