### PR TITLE
add highchart config options to the StoryRAMP config file

### DIFF
--- a/StoryRampSchema.json
+++ b/StoryRampSchema.json
@@ -131,6 +131,9 @@
                 "type": {
                     "type": "string",
                     "enum": ["chart"]
+                },
+                "options": {
+                    "$ref": "#/$defs/dqvchartOptions"
                 }
             },
             "required": ["src", "type"]
@@ -247,7 +250,37 @@
                 }
             },
             "required": ["images", "type"]
-        }
+        },
+        "dqvchartOptions": {
+            "type": "object",
+            "description": "Configuration for a dqvchart.",
+            "properties": {
+                "title": {
+                    "type": "string",
+                    "description": "The title of the chart."
+                },
+                "subtitle": {
+                    "type": "string",
+                    "description": "The subtitle of the chart."
+                },
+                "type": {
+                    "type": "string",
+                    "description": "The type of chart.",
+                    "enum": ["line", "spline", "area", "areaspline", "column", "bar", "pie", "scatter", "gauge", "arearange", "areasplinerange", "columnrange"]
+                },
+                "credits": {
+                    "type": "boolean",
+                    "description": "Specify whether credits are enabled."
+                },
+                "xAxisLabel": {
+                    "type": "string",
+                    "description": "The title of the x-axis."
+                },
+                "yAxisLabel": {
+                    "type": "string",
+                    "description": "The title of the y-axis."
+                }
+            }
     },
 
     "properties": {

--- a/public/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000_en.ts
+++ b/public/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000_en.ts
@@ -462,7 +462,13 @@ These easy-to-use files let you dig deeper into the data in a variety of ways
                 {
                     src:
                         'ea24000c-7dc3-49a9-baac-c55d28dcaeb9/charts/en/Ethlyene.glycol.release.trends.by.sector.2010-2019.tonnes.csv',
-                    type: 'chart'
+                    type: 'chart',
+                    options: {
+                        xAxisLabel: 'X Axis Test From Config',
+                        yAxisLabel: 'Y Axis Test From Config',
+                        title: 'Hello World',
+                        subtitle: 'I am a DQVChart and this is from the config file'
+                    }
                 }
             ]
         }

--- a/src/components/panels/chart-panel.vue
+++ b/src/components/panels/chart-panel.vue
@@ -54,6 +54,8 @@ export default class ChartPanelV extends Vue {
      */
     parseCSVFile(): any {
         fetch(this.config.src).then((data) => {
+            const dqvOptions = this.config.options;
+
             // download: true needed for local files which is treated as an URL
             this.$papa.parse(data.url, {
                 header: true,
@@ -65,7 +67,7 @@ export default class ChartPanelV extends Vue {
                     const cato = res.meta.fields.shift();
                     const xAxis = {
                         title: {
-                            text: 'Report Year'
+                            text: dqvOptions?.xAxisLabel ? dqvOptions?.xAxisLabel : ''
                         },
                         categories: res.data.map((row: any[]) => row[cato])
                     };
@@ -78,7 +80,7 @@ export default class ChartPanelV extends Vue {
                         series.push({
                             name: f,
                             data: colData,
-                            type: 'line'
+                            type: dqvOptions?.type ? dqvOptions?.type : 'line'
                         });
                     });
 
@@ -87,14 +89,17 @@ export default class ChartPanelV extends Vue {
                         series: series,
                         xAxis: xAxis,
                         title: {
-                            text: 'Ethlyene Glycol Release Trends by Sector 2010-2019 (Tonnes)'
+                            text: dqvOptions?.title ? dqvOptions?.title : ''
+                        },
+                        subtitle: {
+                            text: dqvOptions?.subtitle ? dqvOptions?.subtitle : ''
                         },
                         credits: {
-                            enabled: false
+                            enabled: dqvOptions?.credits ? dqvOptions?.credits : false
                         },
                         yAxis: {
                             title: {
-                                text: 'Sector'
+                                text: dqvOptions?.yAxisLabel ? dqvOptions?.yAxisLabel : ''
                             }
                         }
                     };

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -7,6 +7,15 @@ export interface StoryRampConfig {
     contextLabel: string;
 }
 
+export interface DQVOptions {
+    title: string;
+    subtitle: string;
+    xAxisLabel: string;
+    yAxisLabel: string;
+    credits: boolean;
+    type: string;
+}
+
 export interface Intro {
     logo: {
         src: string;
@@ -86,6 +95,7 @@ export interface ChartPanel extends BasePanel {
     type: PanelType.Chart;
     src: string;
     expandable?: boolean;
+    options?: DQVOptions;
 }
 
 // TODO: add more definitions here as needed


### PR DESCRIPTION
Closes #85 

Adds some highchart configurable options to the StoryRAMP configuration file, which are used for charts that have a CSV input.  The ones I've included for now are `title`, `subtitle`, `xAxis` and `yAxis` labels, `type`, and `credits`. We can add more as needed later.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/92)
<!-- Reviewable:end -->
