### PR TITLE
Load config files based on URL passed UID and lang params

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
         "vue-papa-parse": "^3.0.4",
         "vue-progressive-image": "^3.2.0",
         "vue-property-decorator": "^9.1.2",
+        "vue-router": "^3.5.3",
         "vue-scrollama": "^2.0.2",
         "vue-tippy": "^4.10.0",
         "vue2-smooth-scroll": "^1.5.0"

--- a/src/app.vue
+++ b/src/app.vue
@@ -1,52 +1,14 @@
 <template>
     <div id="app" class="storyramp-app bg-white">
-        <header class="sticky top-0 z-50 w-full h-16 leading-9 bg-white border-b border-gray-200">
-            <div class="flex w-full px-6 py-3 mx-auto">
-                <div class="flex-none font-semibold">
-                    <span class="text-lg">{{ config.title }}</span>
-                </div>
-                <div class="flex justify-end flex-auto space-x-6">
-                    <!-- Any links we want in the header can go here -->
-                </div>
-            </div>
-        </header>
-
-        <introduction :config="config.introSlide"></introduction>
-
-        <div class="w-full mx-auto pb-10" id="story">
-            <StoryV :config="config" />
-        </div>
-
-        <footer class="p-8 pt-2 text-right text-sm">
-            Context:
-            <a class="text-blue-500 font-semibold" :href="config.contextLink" target="_NEW">{{
-                config.contextLabel
-            }}</a>
-            |
-            <a href="https://github.com/ramp4-pcar4/story-ramp" target="_NEW" class="font-semibold text-blue-500"
-                >ramp4-pcar4/story-ramp</a
-            >
-        </footer>
+        <router-view :key="$route.path"></router-view>
     </div>
 </template>
 
 <script lang="ts">
 import { Component, Vue } from 'vue-property-decorator';
-import StoryV from '@/components/story/story.vue';
-import IntroV from '@/components/story/introduction.vue';
 
-import config from '../public/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000_en';
-import { StoryRampConfig } from '@/definitions';
-
-@Component({
-    components: {
-        StoryV,
-        introduction: IntroV
-    }
-})
-export default class App extends Vue {
-    config: StoryRampConfig = config;
-}
+@Component({})
+export default class App extends Vue {}
 </script>
 
 <style lang="scss">
@@ -91,25 +53,6 @@ body {
             transform: translateY(0);
             animationtimingfunction: cubic-bezier(0, 0, 0.2, 1);
         }
-    }
-}
-
-.storyramp-app {
-    h1,
-    h2,
-    h3,
-    h4,
-    h5,
-    h6,
-    .h1,
-    .h2,
-    .h3,
-    .h4,
-    .h5,
-    .h6 {
-        font-family: $font-list;
-        line-height: 1.5;
-        border-bottom: 0px;
     }
 }
 </style>

--- a/src/components/panels/chart-panel.vue
+++ b/src/components/panels/chart-panel.vue
@@ -8,6 +8,7 @@
 
 <script lang="ts">
 import { Component, Vue, Prop } from 'vue-property-decorator';
+
 import { Chart } from 'highcharts-vue';
 import { ChartPanel } from '@/definitions';
 import Highcharts from 'highcharts';
@@ -23,8 +24,7 @@ dataModule(Highcharts);
 export default class ChartPanelV extends Vue {
     @Prop() config!: ChartPanel;
 
-    /* eslint-disable @typescript-eslint/no-explicit-any */
-    $papa: any; // not sure how to fix this in shims
+    $papa: any; // TODO: fix this in shims
     chartConfig: any = {};
     chartOptions: any = {};
     title = '';

--- a/src/components/story/story-ramp.vue
+++ b/src/components/story/story-ramp.vue
@@ -1,0 +1,104 @@
+<template>
+    <div class="storyramp-app bg-white">
+        <header class="sticky top-0 z-50 w-full h-16 leading-9 bg-white border-b border-gray-200">
+            <div class="flex w-full px-6 py-3 mx-auto">
+                <div class="flex-none font-semibold">
+                    <span class="text-lg">{{ config.title }}</span>
+                </div>
+                <div class="flex justify-end flex-auto space-x-6">
+                    <!-- Any links we want in the header can go here -->
+                </div>
+            </div>
+        </header>
+
+        <introduction :config="config.introSlide"></introduction>
+
+        <div class="w-full mx-auto pb-10" id="story">
+            <StoryV :config="config" />
+        </div>
+
+        <footer class="p-8 pt-2 text-right text-sm">
+            Context:
+            <a class="text-blue-500 font-semibold" :href="config.contextLink" target="_NEW">{{
+                config.contextLabel
+            }}</a>
+            |
+            <a href="https://github.com/ramp4-pcar4/story-ramp" target="_NEW" class="font-semibold text-blue-500"
+                >ramp4-pcar4/story-ramp</a
+            >
+        </footer>
+    </div>
+</template>
+
+<script lang="ts">
+import { Component, Vue } from 'vue-property-decorator';
+import { Route } from 'vue-router';
+import StoryV from '@/components/story/story.vue';
+import IntroV from '@/components/story/introduction.vue';
+
+import config from '@/../public/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000_en';
+import { StoryRampConfig } from '@/definitions';
+
+@Component({
+    components: {
+        StoryV,
+        introduction: IntroV
+    }
+})
+export default class StoryRampV extends Vue {
+    config: StoryRampConfig = config;
+    $route: any; // TODO: fix this in shims
+
+    created(): void {
+        const uid = this.$route.params.uid;
+        const lang = this.$route.params.lang;
+        if (uid) {
+            this.fetchConfig(uid, lang);
+        }
+    }
+
+    // react to param changes in URL
+    beforeRouteUpdate(to: Route, from: Route, next: () => void): void {
+        const uid = to.params.uid;
+        const lang = to.params.lang;
+        this.fetchConfig(uid, lang);
+        next();
+    }
+
+    fetchConfig(uid: string, lang?: string): void {
+        // default to 'en'
+        lang = lang ? lang : 'en';
+        import(`@/../public/${uid}/${uid}_${lang}.ts`)
+            .then((res) => {
+                this.config = res.default;
+            })
+            .catch((err) => {
+                // redirect to canada.ca 404 page on invalid URL params
+                window.location.href = 'https://www.canada.ca/errors/404.html';
+            });
+    }
+}
+</script>
+
+<style lang="scss">
+$font-list: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+
+.storyramp-app {
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6,
+    .h1,
+    .h2,
+    .h3,
+    .h4,
+    .h5,
+    .h6 {
+        font-family: $font-list;
+        line-height: 1.5;
+        border-bottom: 0px;
+    }
+}
+</style>

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,9 +1,13 @@
+import './router/componentHooks';
 import Vue from 'vue';
 import App from './app.vue';
+import router from './router';
 import './style.css';
 
 import VueSmoothScroll from 'vue2-smooth-scroll';
-Vue.use(VueSmoothScroll);
+Vue.use(VueSmoothScroll, {
+    updateHistory: false
+});
 
 import VueTippy, { TippyComponent } from 'vue-tippy';
 
@@ -22,5 +26,6 @@ Vue.use(VueProgressiveImage);
 Vue.config.productionTip = false;
 
 new Vue({
-    render: (h) => h(App)
+    render: (h) => h(App),
+    router
 }).$mount('#app');

--- a/src/router/componentHooks.ts
+++ b/src/router/componentHooks.ts
@@ -1,0 +1,4 @@
+import Component from 'vue-class-component';
+
+// register router hooks
+Component.registerHooks(['beforeRouterEnter', 'beforeRouteLeave', 'beforeRouteUpdate']);

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,0 +1,24 @@
+import Vue from 'vue';
+import StoryRampV from '@/components/story/story-ramp.vue';
+import Router from 'vue-router';
+
+Vue.use(Router);
+
+const routes = [
+    {
+        path: '/',
+        component: StoryRampV
+    },
+    {
+        path: '/:uid',
+        component: StoryRampV
+    },
+    {
+        path: '/:lang/:uid',
+        component: StoryRampV
+    }
+];
+
+export default new Router({
+    routes: routes
+});


### PR DESCRIPTION
Closes #75 

Now accepts `uid` and `lang` parameters in the form of `/[lang]/[uid]` to load the specified config. Added `vue-router` and created three routes: one as the home page that loads in the default test page (no params passed), one that accepts only the `uid` (`/[uid]` ) and defaults to `en` for the language, and one with both params. It is able to perform dynamic route matching, but I'm not sure if that is needed here.  

If an invalid set of params are passed, the page redirects to the canada.ca 404 [page](https://www.canada.ca/errors/404.html).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/94)
<!-- Reviewable:end -->
