### PR TITLE
Add dynamic panel to allow panel switching

### DIFF
--- a/StoryRampSchema.json
+++ b/StoryRampSchema.json
@@ -36,6 +36,9 @@
                     },
                     {
                         "$ref": "#/$defs/dqvchartPanel"
+                    },
+                    {
+                        "$ref": "#/$defs/dynamicPanel"
                     }
                 ]
             },
@@ -65,6 +68,59 @@
                 }
             },
             "required": ["content", "type", "title"]
+        },
+
+        "dynamicPanel": {
+            "type": "object",
+            "description": "A dynamic slide component.",
+            "properties": {
+                "title": {
+                    "type": "string",
+                    "description": "The title for the text panel."
+                },
+                "content": {
+                    "type": "string",
+                    "description": "The main text body."
+                },
+                "children": {
+                    "type": "array",
+                    "description": "The panels to display dynamically.",
+                    "items": {
+                        "$ref": "#/$defs/dynamicChildItem"
+                    },
+                    "minItems": 1
+                },
+                "type": {
+                    "type": "string",
+                    "enum": ["dynamic"]
+                }
+            },
+            "required": ["content", "type", "children", "title"]
+        },
+
+        "dynamicChildItem": {
+            "type": "object",
+            "description": "A child screen of a dynamic panel. Contains an ID and a panel config.",
+            "properties": {
+                "id": "string",
+                "panel": {
+                    "oneOf": [
+                        {
+                            "$ref": "#/$defs/textPanel"
+                        },
+                        {
+                            "$ref": "#/$defs/mapPanel"
+                        },
+                        {
+                            "$ref": "#/$defs/multimediaPanel"
+                        },
+                        {
+                            "$ref": "#/$defs/dqvchartPanel"
+                        }
+                    ]
+                }
+            },
+            "required": ["id", "panel"]
         },
 
         "multimediaPanel": {

--- a/public/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000_en.ts
+++ b/public/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000_en.ts
@@ -27,6 +27,48 @@ Businesses, institutions and other facilities across Canada must report their re
             ]
         },
         {
+            title: 'Dynamic Panel Test',
+            panel: [
+                {
+                    title: 'This Slide Is Dynamic!',
+                    type: 'dynamic',
+                    content: `You can click on one of the following links to change the right panel.
+
+- <a panel="panel-1">Text Panel</a>
+- <a panel="panel-2">Image Panel</a>
+- <a panel="panel-3">Map Panel</a>
+
+Fun stuff.`,
+                    children: [
+                        {
+                            id: 'panel-1',
+                            panel: {
+                                title: 'Hello World',
+                                content: `I am a text panel. I am a child of the dynamic panel config.`,
+                                type: 'text'
+                            }
+                        },
+                        {
+                            id: 'panel-2',
+                            panel: {
+                                src:
+                                    '00000000-0000-0000-0000-000000000000/assets/en/GettyImages-187242601__1554821467033__w1920.jpg',
+                                type: 'image'
+                            }
+                        },
+                        {
+                            id: 'panel-3',
+                            panel: {
+                                config:
+                                    '00000000-0000-0000-0000-000000000000/ramp-config/en/OilSandsFacilityLocations2019.json',
+                                type: 'map'
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
             title: 'Oil sands deposits',
             panel: [
                 {

--- a/src/components/panels/dynamic-panel.vue
+++ b/src/components/panels/dynamic-panel.vue
@@ -1,0 +1,65 @@
+<template>
+    <div :id="this.$vnode.key" class="story-slide w-full h-full flex flex-row">
+        <Scrollama class="flex-1 prose max-w-none my-5">
+            <h2 class="px-10 mb-0 chapter-title top-20">
+                {{ config.title }}
+            </h2>
+
+            <div class="px-10 md-content" v-html="md.render(config.content)"></div>
+        </Scrollama>
+        <panel class="flex-2" :config="activeConfig" :ratio="false"></panel>
+    </div>
+</template>
+
+<script lang="ts">
+import Scrollama from 'vue-scrollama';
+import MarkdownIt from 'markdown-it';
+
+import { Component, Prop, Vue } from 'vue-property-decorator';
+import { DynamicPanel, BasePanel } from '@/definitions';
+
+@Component({
+    components: {
+        panel: () => import('./panel.vue'),
+        Scrollama
+    }
+})
+export default class DynamicPanelV extends Vue {
+    @Prop() config!: DynamicPanel;
+
+    // By default, the active config is set to the first child in the children list.
+    activeConfig: BasePanel = this.config.children[0].panel;
+
+    md = new MarkdownIt({ html: true });
+
+    mounted(): void {
+        document.querySelectorAll('a:not([target])').forEach((el: any) => (el.target = '_blank'));
+
+        this.addDynamicURLs();
+    }
+
+    /**
+     * Adds panel-switching functionality to URLs.
+     */
+    addDynamicURLs() {
+        // Find all URLs that contain the `panel` attribute.
+        const urls = Array.from(this.$el.querySelectorAll('a[panel]'));
+        urls.forEach((el: any) => {
+            // Find the target panel and add an event listener to the URL.
+            const target = el.attributes['panel'].value;
+
+            el.onclick = () => {
+                // Find the panel.
+                const panel = this.config.children.find((el) => {
+                    return target == el.id;
+                });
+
+                // If the panel exists, switch the displayed panel.
+                if (panel) this.activeConfig = panel.panel;
+            };
+        });
+    }
+}
+</script>
+
+<style scoped lang="scss"></style>

--- a/src/components/panels/panel.vue
+++ b/src/components/panels/panel.vue
@@ -15,6 +15,7 @@ import AudioPanelV from './audio-panel.vue';
 import VideoPanelV from './video-panel.vue';
 import SlideshowPanelV from './slideshow-panel.vue';
 import ChartPanelV from './chart-panel.vue';
+import DynamicPanelV from './dynamic-panel.vue';
 
 @Component({
     components: {
@@ -38,7 +39,8 @@ export default class PanelV extends Vue {
             [PanelType.Audio]: AudioPanelV,
             [PanelType.Video]: VideoPanelV,
             [PanelType.Slideshow]: SlideshowPanelV,
-            [PanelType.Chart]: ChartPanelV
+            [PanelType.Chart]: ChartPanelV,
+            [PanelType.Dynamic]: DynamicPanelV
         };
 
         return panelTemplates[this.config.type];

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -40,7 +40,8 @@ export enum PanelType {
     Chart = 'chart',
     Video = 'video',
     Audio = 'audio',
-    Slideshow = 'slideshow'
+    Slideshow = 'slideshow',
+    Dynamic = 'dynamic'
 }
 
 export interface BasePanel {
@@ -58,6 +59,18 @@ export interface MapPanel extends BasePanel {
     type: PanelType.Map;
     config: any; // TODO: replace with proper Typescript type
     expandable?: boolean;
+}
+
+export interface DynamicPanel extends BasePanel {
+    type: PanelType.Dynamic;
+    title: string;
+    content: string;
+    children: DynamicChildItem[];
+}
+
+export interface DynamicChildItem {
+    id: string;
+    panel: BasePanel;
 }
 
 export interface ImagePanel extends BasePanel {


### PR DESCRIPTION
Closes #77 

This PR adds a new panel type: the `dynamic` panel, a single panel component that acts as a double panel. On the left side it displays text, and on the right side it displays some other type of panel. This right panel can be changed dynamically by clicking on links on the text panel.

In the StoryRAMP configuration file, a dynamic panel requires two properties: the `text` property, which is what will be displayed on the left side. This can contain markdown and HTML like a regular text panel. The dynamic panel also requires a `children` property. This is an array that contains the configs for the panels that may be displayed on the right side. You must specify an ID for these panels.

The most difficult part of this issue for me was trying to figure out a good way to add the panel-switching links to the text side of the panel. The solution I came up with was to look for a new attribute on anchor tags called `panel`. If the anchor tag contains the `panel` attribute, an `onclick` script is added to the tag that will swap the panel to the ID provided when clicked.

For example, if there is a panel config under `children` called `panel-1`, you can switch to this panel by putting the following on the text side: `<a panel="panel-1">click to swap</a>`.

I'm not sure if this is the best approach for this. If you can think of any better way to do this let me know and I can switch it over.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/95)
<!-- Reviewable:end -->
