### PR TITLE
Add ability to scroll to anchor tags vue router

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,6 +1,6 @@
 import Vue from 'vue';
 import StoryRampV from '@/components/story/story-ramp.vue';
-import Router from 'vue-router';
+import Router, { Route } from 'vue-router';
 
 Vue.use(Router);
 
@@ -20,5 +20,14 @@ const routes = [
 ];
 
 export default new Router({
-    routes: routes
+    routes: routes,
+    // mode: 'history', // TODO: uncomment to change to history mode for nicer URLs (eliminating middle hash) see #100
+    scrollBehavior: function (to: Route) {
+        if (to.hash) {
+            return {
+                selector: to.hash,
+                behavior: 'smooth'
+            };
+        }
+    }
 });


### PR DESCRIPTION
Closes #98

Vue router now checks if any hash anchor tag is attached to the URL and scrolls to that slide. For instance, http://localhost:8080/#/en/00000000-0000-0000-0000-000000000000#oil-sands-deposits should now work properly. Added a new issue #100 for adding the HTML5 history mode as suggested by @spencerwahl in an earlier review as it would seem helpful to eventually eliminate the # in the middle of URLs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/101)
<!-- Reviewable:end -->
