### PR TITLE
fix altText property on slideshow panel

### DIFF
--- a/src/components/panels/slideshow-panel.vue
+++ b/src/components/panels/slideshow-panel.vue
@@ -6,7 +6,7 @@
                     :src="image.src"
                     :height="image.height"
                     :width="image.width"
-                    :alt="image.alt"
+                    :alt="image.altText"
                     class="m-auto story-graphic"
                 />
             </slide>


### PR DESCRIPTION
Closes #105 

The `altText` property was not being added to images correctly in the slideshow panel. There was a small inconsistency in the property name for slideshow images which this PR fixes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/110)
<!-- Reviewable:end -->
