### PR TITLE
add caption property to image slide

### DIFF
--- a/StoryRampSchema.json
+++ b/StoryRampSchema.json
@@ -215,6 +215,10 @@
                     "type": "string",
                     "description": "The supporting text for the image."
                 },
+                "caption": {
+                    "type": "string",
+                    "description": "Supporting text content for the image."
+                },
                 "class": {
                     "type": "string",
                     "description": "Styling class properties for the image."

--- a/public/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000_en.ts
+++ b/public/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000_en.ts
@@ -22,7 +22,8 @@ Businesses, institutions and other facilities across Canada must report their re
                 {
                     src:
                         '00000000-0000-0000-0000-000000000000/assets/en/NPRIpictogramme-2016data-EN__1553797637582__w1430.jpg',
-                    type: 'image'
+                    type: 'image',
+                    caption: 'This is a caption for the image.'
                 }
             ]
         },

--- a/src/components/panels/image-panel.vue
+++ b/src/components/panels/image-panel.vue
@@ -1,6 +1,8 @@
 <template>
-    <div class="justify-center flex h-full align-middle py-5">
-        <img :src="config.src" :class="config.class" :alt="config.altText" class="px-10 my-8 block max-w-full" />
+    <div class="justify-center flex flex-col h-full align-middle py-5 w-full">
+        <img :src="config.src" :class="config.class" :alt="config.altText" class="px-10 my-6 block max-w-full flex" />
+
+        <div v-if="config.caption" class="text-center mt-5 text-sm max-w-full" v-html="md.render(config.caption)"></div>
     </div>
 </template>
 
@@ -8,9 +10,13 @@
 import { ImagePanel } from '@/definitions';
 import { Component, Vue, Prop } from 'vue-property-decorator';
 
+import MarkdownIt from 'markdown-it';
+
 @Component({})
 export default class ImagePanelV extends Vue {
     @Prop() config!: ImagePanel;
+
+    md = new MarkdownIt({ html: true });
 }
 </script>
 

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -111,6 +111,7 @@ export interface ImagePanel extends BasePanel {
     height?: number;
     class?: string;
     altText?: string;
+    caption?: string;
     tooltip?: string;
 }
 


### PR DESCRIPTION
Closes #121 

This PR adds a `config` property to the config for image panels. The caption appears below the image and supports both HTML and markdown.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/122)
<!-- Reviewable:end -->
