### PR TITLE
add loading spinner while config is fetched

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
         "markdown-it": "^12.0.6",
         "vue": "^2.6.11",
         "vue-class-component": "^7.2.3",
+        "vue-loading-spinner": "^1.0.11",
         "vue-papa-parse": "^3.0.4",
         "vue-progressive-image": "^3.2.0",
         "vue-property-decorator": "^9.1.2",


### PR DESCRIPTION
Closes #108 

Displays a spinner while the config file is being fetched in order to prevent the default text from being displayed briefly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/124)
<!-- Reviewable:end -->
