### PR TITLE
Fix for anchor navigation through ToC on UID loaded pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,7 @@
         "vue-property-decorator": "^9.1.2",
         "vue-router": "^3.5.3",
         "vue-scrollama": "^2.0.2",
-        "vue-tippy": "^4.10.0",
-        "vue2-smooth-scroll": "^1.5.0"
+        "vue-tippy": "^4.10.0"
     },
     "devDependencies": {
         "@types/markdown-it": "^12.0.1",

--- a/src/components/story/chapter-menu.vue
+++ b/src/components/story/chapter-menu.vue
@@ -33,7 +33,12 @@
         <ul class="nav-content menu">
             <li>
                 <tippy to="menu-options-tippy" delay="200" placement="right">Return to Top</tippy>
-                <a name="menu-options-tippy" href="#intro" class="flex items-center px-2 py-1 mx-1" v-smooth-scroll>
+                <router-link
+                    name="menu-options-tippy"
+                    :to="{ hash: '#intro' }"
+                    class="flex items-center px-2 py-1 mx-1"
+                    target
+                >
                     <svg
                         class="flex-shrink-0"
                         width="24"
@@ -51,15 +56,15 @@
                     <span class="flex-1 ml-4 overflow-hidden leading-normal overflow-ellipsis whitespace-nowrap"
                         >Return to Top</span
                     >
-                </a>
+                </router-link>
             </li>
             <li v-for="(slide, idx) in slides" :key="idx" :class="{ 'is-active': activeChapterIndex === idx }">
                 <tippy :to="`menu-options-tippy-${idx}`" delay="200" placement="right">{{ slide.title }}</tippy>
-                <a
+                <router-link
                     :name="`menu-options-tippy-${idx}`"
-                    :href="`#${idx}-${slide.title.toLowerCase().replaceAll(' ', '-')}`"
+                    :to="{ hash: `#${idx}-${slide.title.toLowerCase().replaceAll(' ', '-')}` }"
                     class="flex items-center px-2 py-1 mx-1"
-                    v-smooth-scroll
+                    target
                 >
                     <svg
                         class="flex-shrink-0"
@@ -78,7 +83,7 @@
                     <span class="flex-1 ml-4 overflow-hidden leading-normal overflow-ellipsis whitespace-nowrap">{{
                         slide.title
                     }}</span>
-                </a>
+                </router-link>
             </li>
         </ul>
     </div>

--- a/src/components/story/introduction.vue
+++ b/src/components/story/introduction.vue
@@ -9,7 +9,7 @@
             {{ config.subtitle }}
         </p>
 
-        <a href="#story" class="inline-block mt-10 scroll-arrow" title="scroll to story" v-smooth-scroll>
+        <router-link :to="{ hash: '#story' }" class="inline-block mt-10 scroll-arrow" title="scroll to story" target>
             <svg
                 class="w-auto h-24 m-auto"
                 width="90"
@@ -32,7 +32,7 @@
                     stroke-width=".97921"
                 />
             </svg>
-        </a>
+        </router-link>
     </div>
 </template>
 

--- a/src/components/story/story.vue
+++ b/src/components/story/story.vue
@@ -9,6 +9,7 @@
                 :key="idx"
                 :data-chapter-index="idx"
                 :id="`${idx}-${slide.title.toLowerCase().replaceAll(' ', '-')}`"
+                :name="`${idx}-${slide.title.toLowerCase().replaceAll(' ', '-')}`"
             >
                 <slide :config="slide" :slideIdx="idx"></slide>
             </div>

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,11 +4,6 @@ import App from './app.vue';
 import router from './router';
 import './style.css';
 
-import VueSmoothScroll from 'vue2-smooth-scroll';
-Vue.use(VueSmoothScroll, {
-    updateHistory: false
-});
-
 import VueTippy, { TippyComponent } from 'vue-tippy';
 
 Vue.use(VueTippy);


### PR DESCRIPTION
Closes #120 

Fixes the issue of paginator linking to page content by using `router-link` to generate anchors. Also removed `vue2-smooth-scroll` since there is a replacement for that in Vue Router's `scrollBehavior`. One limitation to this new approach is that the the paginator will cause 404 errors on the default test page ([localhost:8080/#/](http://localhost:8080/#/)) but I think this would be fixed when history mode is enabled.