### PR TITLE
Add support for basic pie charts

### DIFF
--- a/src/components/panels/chart-panel.vue
+++ b/src/components/panels/chart-panel.vue
@@ -54,54 +54,114 @@ export default class ChartPanelV extends Vue {
 
             // download: true needed for local files which is treated as an URL
             this.$papa.parse(data.url, {
-                header: true,
+                header: dqvOptions?.type === 'pie' ? false : true,
                 dynamicTyping: true,
                 download: true,
                 complete: (res: any) => {
-                    // process parsed CSV data (get fields and xaxis categories first)
-                    const fields = res.meta.fields;
-                    const cato = res.meta.fields.shift();
-                    const xAxis = {
-                        title: {
-                            text: dqvOptions?.xAxisLabel ? dqvOptions?.xAxisLabel : ''
-                        },
-                        categories: res.data.map((row: any[]) => row[cato])
-                    };
-
-                    // get all series data for each field
-                    let series: SeriesData[] = [];
-                    fields.forEach((f: string) => {
-                        const colData = res.data.map((row: any) => row[f]);
-                        // default to line graph (not sure best way to configure this with CSV input)
-                        series.push({
-                            name: f,
-                            data: colData,
-                            type: dqvOptions?.type ? dqvOptions?.type : 'line'
-                        });
-                    });
-
-                    // initializing chartOptions with filtered CSV data + configurable options (TODO)
-                    this.chartOptions = {
-                        series: series,
-                        xAxis: xAxis,
-                        title: {
-                            text: dqvOptions?.title ? dqvOptions?.title : ''
-                        },
-                        subtitle: {
-                            text: dqvOptions?.subtitle ? dqvOptions?.subtitle : ''
-                        },
-                        credits: {
-                            enabled: dqvOptions?.credits ? dqvOptions?.credits : false
-                        },
-                        yAxis: {
-                            title: {
-                                text: dqvOptions?.yAxisLabel ? dqvOptions?.yAxisLabel : ''
-                            }
-                        }
-                    };
+                    // construct highcharts objects based on chart type
+                    if (dqvOptions?.type === 'pie') {
+                        this.makePieChart(res.data);
+                    } else {
+                        this.makeLineChart(res.meta.fields, res.data);
+                    }
                 }
             });
         });
+    }
+
+    /**
+     * Parse chart data content and return a highcharts formatted series object for a pie chart.
+     */
+    makePieChart(data: any): void {
+        const dqvOptions = this.config.options;
+        let series: { data: SeriesData[] } = { data: [] };
+
+        // construct series data
+        data.forEach((slice: any) => {
+            series.data.push({
+                name: slice[0],
+                // in case of strings being passed in such as '10%'
+                y: parseFloat(slice[1])
+            });
+        });
+
+        // plot options for pie charts
+        const plotOptions = {
+            pie: {
+                allowPointSelect: true,
+                cursor: 'pointer',
+                dataLabels: {
+                    enabled: true,
+                    format: '<b>{point.name}</b>: {point.percentage:.1f} %'
+                }
+            }
+        };
+
+        // initializing chartOptions for line/bar charts
+        this.chartOptions = {
+            chart: {
+                type: dqvOptions?.type ? dqvOptions?.type : 'chart'
+            },
+            title: {
+                text: dqvOptions?.title ? dqvOptions?.title : ''
+            },
+            subtitle: {
+                text: dqvOptions?.subtitle ? dqvOptions?.subtitle : ''
+            },
+            plotOptions: plotOptions,
+            series: series,
+            credits: {
+                enabled: dqvOptions?.credits ? dqvOptions?.credits : false
+            }
+        };
+    }
+
+    /**
+     * Parse chart data content and return a highcharts formatted series object for a line/bar chart.
+     */
+    makeLineChart(fields: string[], data: any): void {
+        const dqvOptions = this.config.options;
+        // find xAxis categories for line/bar charts
+        const cato = fields.shift() as string;
+        const xAxis = {
+            title: {
+                text: dqvOptions?.xAxisLabel ? dqvOptions?.xAxisLabel : ''
+            },
+            categories: data.map((row: any) => row[cato])
+        };
+
+        // construct series data
+        let series: SeriesData[] = [];
+        fields.forEach((f: string) => {
+            const colData = data.map((row: any) => row[f]);
+            series.push({
+                name: f,
+                data: colData
+            });
+        });
+
+        // initializing chartOptions for line/bar charts
+        this.chartOptions = {
+            chart: {
+                type: dqvOptions?.type ? dqvOptions?.type : 'line'
+            },
+            series: series,
+            xAxis: xAxis,
+            title: {
+                text: dqvOptions?.title ? dqvOptions?.title : ''
+            },
+            subtitle: {
+                text: dqvOptions?.subtitle ? dqvOptions?.subtitle : ''
+            },
+            credits: {
+                enabled: dqvOptions?.credits ? dqvOptions?.credits : false
+            },
+            yAxis: {
+                title: {
+                    text: dqvOptions?.yAxisLabel ? dqvOptions?.yAxisLabel : ''
+                }
+            }
+        };
     }
 }
 </script>

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -18,12 +18,16 @@ export interface DQVOptions {
 
 export interface SeriesData {
     name: string;
-    data: number[];
-    type: string;
+    y?: number;
+    data?: number[];
+    type?: string;
     color?: string;
 }
 
 export interface DQVChartConfig {
+    chart: {
+        type: string;
+    };
     title: {
         text: string;
     };
@@ -33,18 +37,19 @@ export interface DQVChartConfig {
     subtitle: {
         text: string;
     };
-    yAxis: {
+    yAxis?: {
         title: {
             text: string;
         };
     };
-    xAxis: {
+    xAxis?: {
         title: {
             text: string;
         };
         categories: [];
     };
-    series: SeriesData[];
+    plotOptions?: any;
+    series: SeriesData[] | { data: SeriesData[] };
 }
 
 export interface Intro {


### PR DESCRIPTION
Closes #117

Rewrites parsing functionality in `chart-panel` to add support for pie charts. All the pie charts from the Ethlyene Glycol and Pulp and Paper configs should display properly. It is displayed as follows: 

![image](https://user-images.githubusercontent.com/31557789/150417815-5e7a37a7-e56f-4b88-ad48-d9bde46e8463.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/128)
<!-- Reviewable:end -->
