### PR TITLE
Add chart context menu options

### DIFF
--- a/src/components/panels/chart-panel.vue
+++ b/src/components/panels/chart-panel.vue
@@ -13,8 +13,12 @@ import { Chart } from 'highcharts-vue';
 import { ChartPanel, DQVChartConfig, SeriesData } from '@/definitions';
 import Highcharts from 'highcharts';
 import dataModule from 'highcharts/modules/data';
+import exporting from 'highcharts/modules/exporting';
+import exportData from 'highcharts/modules/export-data';
 
 dataModule(Highcharts);
+exporting(Highcharts);
+exportData(Highcharts);
 
 @Component({
     components: {
@@ -26,6 +30,18 @@ export default class ChartPanelV extends Vue {
 
     chartOptions: DQVChartConfig = {} as DQVChartConfig;
     title = '';
+    menuOptions = [
+        'viewFullScreen',
+        'printChart',
+        'separator',
+        'downloadPNG',
+        'downloadJPEG',
+        'downloadPDF',
+        'downloadSVG',
+        'separator',
+        'downloadCSV',
+        'downloadXLS'
+    ];
 
     mounted(): void {
         const extension = this.config.src.split('.').pop();
@@ -97,6 +113,15 @@ export default class ChartPanelV extends Vue {
             }
         };
 
+        // export options displayed on hamburger menu
+        const exportOptions = {
+            buttons: {
+                contextButton: {
+                    menuItems: this.menuOptions
+                }
+            }
+        };
+
         // initializing chartOptions for line/bar charts
         this.chartOptions = {
             chart: {
@@ -110,6 +135,7 @@ export default class ChartPanelV extends Vue {
             },
             plotOptions: plotOptions,
             series: series,
+            exporting: exportOptions,
             credits: {
                 enabled: dqvOptions?.credits ? dqvOptions?.credits : false
             }
@@ -140,6 +166,15 @@ export default class ChartPanelV extends Vue {
             });
         });
 
+        // export options displayed on hamburger menu
+        const exportOptions = {
+            buttons: {
+                contextButton: {
+                    menuItems: this.menuOptions
+                }
+            }
+        };
+
         // initializing chartOptions for line/bar charts
         this.chartOptions = {
             chart: {
@@ -153,6 +188,7 @@ export default class ChartPanelV extends Vue {
             subtitle: {
                 text: dqvOptions?.subtitle ? dqvOptions?.subtitle : ''
             },
+            exporting: exportOptions,
             credits: {
                 enabled: dqvOptions?.credits ? dqvOptions?.credits : false
             },

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -49,6 +49,13 @@ export interface DQVChartConfig {
         categories: [];
     };
     plotOptions?: any;
+    exporting: {
+        buttons: {
+            contextButton: {
+                menuItems: string[];
+            };
+        };
+    };
     series: SeriesData[] | { data: SeriesData[] };
 }
 


### PR DESCRIPTION
Closes #126 

Enables the highcharts hamburger menu with all the required options through importing two additional highcharts modules. 

![image](https://user-images.githubusercontent.com/31557789/150538269-8a434434-44de-4051-95f1-bf40f342a3a6.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/129)
<!-- Reviewable:end -->
