### PR TITLE
Set page language based on lang of config

### DIFF
--- a/StoryRampSchema.json
+++ b/StoryRampSchema.json
@@ -328,9 +328,15 @@
                     "description": "The type of chart.",
                     "enum": ["line", "spline", "area", "areaspline", "column", "bar", "pie", "scatter", "gauge", "arearange", "areasplinerange", "columnrange"]
                 },
+                "export": {
+                    "type": "boolean",
+                    "description": "Specify whether export menu options are enabled.",
+                    "default": true
+                },
                 "credits": {
                     "type": "boolean",
-                    "description": "Specify whether credits are enabled."
+                    "description": "Specify whether credits are enabled.",
+                    "default": false
                 },
                 "xAxisLabel": {
                     "type": "string",

--- a/src/components/panels/chart-panel.vue
+++ b/src/components/panels/chart-panel.vue
@@ -119,7 +119,8 @@ export default class ChartPanelV extends Vue {
                 contextButton: {
                     menuItems: this.menuOptions
                 }
-            }
+            },
+            enabled: dqvOptions?.export !== undefined ? dqvOptions?.export : true
         };
 
         // initializing chartOptions for line/bar charts
@@ -137,7 +138,7 @@ export default class ChartPanelV extends Vue {
             series: series,
             exporting: exportOptions,
             credits: {
-                enabled: dqvOptions?.credits ? dqvOptions?.credits : false
+                enabled: dqvOptions?.credits !== undefined ? dqvOptions?.credits : false
             }
         };
     }
@@ -172,7 +173,8 @@ export default class ChartPanelV extends Vue {
                 contextButton: {
                     menuItems: this.menuOptions
                 }
-            }
+            },
+            enabled: dqvOptions?.export !== undefined ? dqvOptions?.export : true
         };
 
         // initializing chartOptions for line/bar charts
@@ -190,7 +192,7 @@ export default class ChartPanelV extends Vue {
             },
             exporting: exportOptions,
             credits: {
-                enabled: dqvOptions?.credits ? dqvOptions?.credits : false
+                enabled: dqvOptions?.credits !== undefined ? dqvOptions?.credits : false
             },
             yAxis: {
                 title: {

--- a/src/components/story/story-ramp.vue
+++ b/src/components/story/story-ramp.vue
@@ -65,6 +65,10 @@ export default class StoryRampV extends Vue {
         if (uid) {
             this.fetchConfig(uid, lang);
         }
+
+        // set page lang
+        const html = document.documentElement; // returns the html tag
+        html.setAttribute('lang', lang);
     }
 
     // react to param changes in URL

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -12,6 +12,7 @@ export interface DQVOptions {
     subtitle: string;
     xAxisLabel: string;
     yAxisLabel: string;
+    export: boolean;
     credits: boolean;
     type: string;
 }
@@ -55,6 +56,7 @@ export interface DQVChartConfig {
                 menuItems: string[];
             };
         };
+        enabled: boolean;
     };
     series: SeriesData[] | { data: SeriesData[] };
 }


### PR DESCRIPTION
Closes #107 

Sets lang property of page every time a new config is loaded so the lang in RAMP will match the config language. Also added a toggle config option for highcharts hamburger menu that I missed in #126.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/131)
<!-- Reviewable:end -->
