### PR TITLE
fix Canada.ca template issues

### DIFF
--- a/public/index-ca-en.html
+++ b/public/index-ca-en.html
@@ -33,7 +33,6 @@
         <!-- template footer and no-script fallback -->
         <div id="def-footer"><%= require('html-loader!../src/assets/static/cdts/footer-en.html') %></div>
 
-        <script src="scripts/multi-ramp/rv-main.js"></script>
         <script type="text/javascript">
             var url = new URL(window.location.href);
             var hashParams = url.hash.split('/');
@@ -64,6 +63,8 @@
         <script>
             document.write(wet.builder.refFooter({}));
         </script>
+
+        <script src="scripts/multi-ramp/rv-main.js"></script>
 
         <style>
             html {

--- a/public/index-ca-fr.html
+++ b/public/index-ca-fr.html
@@ -33,7 +33,6 @@
         <!-- template footer and no-script fallback -->
         <div id="def-footer"><%= require('html-loader!../src/assets/static/cdts/footer-fr.html') %></div>
 
-        <script src="scripts/multi-ramp/rv-main.js"></script>
         <script type="text/javascript">
             var url = new URL(window.location.href);
             var hashParams = url.hash.split('/');
@@ -64,6 +63,8 @@
         <script>
             document.write(wet.builder.refFooter({}));
         </script>
+
+        <script src="scripts/multi-ramp/rv-main.js"></script>
 
         <style>
             html {

--- a/src/components/panels/dynamic-panel.vue
+++ b/src/components/panels/dynamic-panel.vue
@@ -33,7 +33,7 @@ export default class DynamicPanelV extends Vue {
     md = new MarkdownIt({ html: true });
 
     mounted(): void {
-        document.querySelectorAll('a:not([target])').forEach((el: any) => (el.target = '_blank'));
+        document.querySelectorAll('.storyramp-app a:not([target])').forEach((el: any) => (el.target = '_blank'));
 
         this.addDynamicURLs();
     }

--- a/src/components/panels/text-panel.vue
+++ b/src/components/panels/text-panel.vue
@@ -26,7 +26,7 @@ export default class TextPanelV extends Vue {
     md = new MarkdownIt({ html: true });
 
     mounted(): void {
-        document.querySelectorAll('a:not([target])').forEach((el: any) => (el.target = '_blank'));
+        document.querySelectorAll('.storyramp-app a:not([target])').forEach((el: any) => (el.target = '_blank'));
     }
 }
 </script>


### PR DESCRIPTION
Closes #130 

Turns out most of the problems were just due to where the RAMP3 script was being loaded in the file. I've moved it to the very bottom and that's fixed all of the problems we were having.

I also made it so only links contained within the app itself open in a new tab. External links (such as any link in the Canada.ca header or footer) will open in the same tab. This way, the language switch link will no longer open the page in a new tab.