### PR TITLE
Make chart colours configurable

### DIFF
--- a/StoryRampSchema.json
+++ b/StoryRampSchema.json
@@ -328,6 +328,13 @@
                     "description": "The type of chart.",
                     "enum": ["line", "spline", "area", "areaspline", "column", "bar", "pie", "scatter", "gauge", "arearange", "areasplinerange", "columnrange"]
                 },
+                "colours": {
+                    "type": "array",
+                    "description": "A list of colors to display chart data that corresponds to the order of columns in CSV file.",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "export": {
                     "type": "boolean",
                     "description": "Specify whether export menu options are enabled.",

--- a/public/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000_en.ts
+++ b/public/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000_en.ts
@@ -514,6 +514,27 @@ These easy-to-use files let you dig deeper into the data in a variety of ways
                     }
                 }
             ]
+        },
+        {
+            title: 'Pie chart with custom colours',
+            panel: [
+                {
+                    title: 'Pie chart with custom colours',
+                    content: '(╯°□°)╯︵ ┻━┻',
+                    type: 'text'
+                },
+                {
+                    src: 'f6f7baf4-cccb-4521-a037-b4691b0f0d49/charts/en/CAC_en.csv',
+                    type: 'chart',
+                    options: {
+                        title:
+                            'Proportion of criteria air contaminants released by pulp and paper facilities that reported to the NPRI in 2019',
+                        subtitle: '',
+                        type: 'pie',
+                        colours: ['green', '#FAEBD7', 'indigo', '#FFD700', '#B22222', '#FF00FF']
+                    }
+                }
+            ]
         }
     ],
     contextLink:

--- a/src/components/panels/chart-panel.vue
+++ b/src/components/panels/chart-panel.vue
@@ -43,7 +43,7 @@ export default class ChartPanelV extends Vue {
         'downloadXLS'
     ];
 
-    mounted(): void {
+    created(): void {
         const extension = this.config.src.split('.').pop();
 
         // get input given by src path
@@ -136,6 +136,7 @@ export default class ChartPanelV extends Vue {
             },
             plotOptions: plotOptions,
             series: series,
+            ...(dqvOptions?.colours && { colors: dqvOptions?.colours }),
             exporting: exportOptions,
             credits: {
                 enabled: dqvOptions?.credits !== undefined ? dqvOptions?.credits : false
@@ -191,6 +192,7 @@ export default class ChartPanelV extends Vue {
                 text: dqvOptions?.subtitle ? dqvOptions?.subtitle : ''
             },
             exporting: exportOptions,
+            ...(dqvOptions?.colours && { colors: dqvOptions?.colours }),
             credits: {
                 enabled: dqvOptions?.credits !== undefined ? dqvOptions?.credits : false
             },

--- a/src/components/panels/panel.vue
+++ b/src/components/panels/panel.vue
@@ -1,5 +1,5 @@
 <template>
-    <div :class="ratio && config.type !== 'text' ? 'flex-2' : 'flex'" class="flex-col">
+    <div :class="ratio && config.type !== 'text' ? 'sticky self-start flex-2 top-16' : 'flex'" class="flex-col">
         <component :is="getTemplate()" :config="config" :slideIdx="slideIdx"></component>
     </div>
 </template>

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -13,6 +13,7 @@ export interface DQVOptions {
     xAxisLabel: string;
     yAxisLabel: string;
     export: boolean;
+    colours?: string[];
     credits: boolean;
     type: string;
 }
@@ -22,7 +23,6 @@ export interface SeriesData {
     y?: number;
     data?: number[];
     type?: string;
-    color?: string;
 }
 
 export interface DQVChartConfig {


### PR DESCRIPTION
Closes #103 

Adds config option for specifying an array of colours to be used in charts. These correspond to the order of columns given in the CSV data. Also adds back the behavior of text panels scrolling while graphic panels are sticky.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/136)
<!-- Reviewable:end -->
