### PR TITLE
keep image aspect ratio, prevent from breaking layout

### DIFF
--- a/src/components/panels/image-panel.vue
+++ b/src/components/panels/image-panel.vue
@@ -1,6 +1,11 @@
 <template>
     <div class="justify-center flex flex-col h-full align-middle py-5 w-full">
-        <img :src="config.src" :class="config.class" :alt="config.altText" class="px-10 my-6 block max-w-full flex" />
+        <img
+            :src="config.src"
+            :class="config.class"
+            :alt="config.altText"
+            class="px-10 my-6 block w-auto flex object-contain max-h-screen"
+        />
 
         <div v-if="config.caption" class="text-center mt-5 text-sm max-w-full" v-html="md.render(config.caption)"></div>
     </div>


### PR DESCRIPTION
Closes #127 

This PR ensures that images don't appear larger than the screen height, and forces images to keep their aspect ratio so they don't appear blurry if resized.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/137)
<!-- Reviewable:end -->
