### PR TITLE
Add navigation for direct links through URL on initial load

### DIFF
--- a/src/components/story/story-content.vue
+++ b/src/components/story/story-content.vue
@@ -44,6 +44,16 @@ export default class StoryContentV extends Vue {
 
     activeChapterIndex = -1;
 
+    mounted(): void {
+        const hash = this.$route.hash.substring(1);
+        if (hash) {
+            // decode in case there are special french characters that are encoded in hash
+            const decodedHash = decodeURIComponent(hash);
+            const el = document.getElementById(decodedHash);
+            el?.scrollIntoView({ behavior: 'smooth' });
+        }
+    }
+
     stepEnter({ element }: { element: HTMLElement }): void {
         this.activeChapterIndex = parseInt(element.dataset.chapterIndex || '-1');
         this.$emit('step', this.activeChapterIndex);


### PR DESCRIPTION
Closes #138 

On initial app load, added a manual scroll to element if there is a hash attached to the end of the URL in `mounted`. Adding a small delay could also work but would delay navigation through the side menu. The hash needed to be decoded in the case of special French characters being used.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/157)
<!-- Reviewable:end -->
