### PR TITLE
update page title and add date modified

### DIFF
--- a/StoryRampSchema.json
+++ b/StoryRampSchema.json
@@ -429,6 +429,11 @@
             "type": "string",
             "description": "The language to display in the app",
             "enum": ["en", "fr"]
+        },
+
+        "dateModified": {
+            "type": "string",
+            "description": "The last date that this config file was modified."
         }
     },
 

--- a/public/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000_en.ts
+++ b/public/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000_en.ts
@@ -548,7 +548,8 @@ These easy-to-use files let you dig deeper into the data in a variety of ways
     contextLink:
         'https://www.canada.ca/en/environment-climate-change/services/national-pollutant-release-inventory/tools-resources-data/exploredata.html',
     contextLabel: 'Explore National Pollutant Release Inventory data',
-    lang: 'en'
+    lang: 'en',
+    dateModified: '2022-02-14'
 };
 
 export default config;

--- a/public/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000_fr.ts
+++ b/public/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000_fr.ts
@@ -416,7 +416,8 @@ Les installations d’exploitation minière à ciel ouvert des sables bitumineux
     contextLink:
         'https://www.canada.ca/en/environment-climate-change/services/national-pollutant-release-inventory/tools-resources-data/exploredata.html',
     contextLabel: 'Explore National Pollutant Release Inventory data',
-    lang: 'en'
+    lang: 'en',
+    dateModified: '2022-02-14'
 };
 
 export default config;

--- a/src/components/story/story.vue
+++ b/src/components/story/story.vue
@@ -34,6 +34,11 @@
                     >ramp4-pcar4/story-ramp</a
                 >
             </footer>
+
+            <div class="storyramp-modified" v-if="config.dateModified">
+                {{ lang === 'en' ? 'Date modified:' : 'Date de modification:' }}
+                {{ config.dateModified }}
+            </div>
         </div>
     </div>
 
@@ -95,6 +100,11 @@ export default class StoryV extends Vue {
             .then((res) => {
                 this.config = res.default;
                 this.isLoading = false;
+
+                // set page title
+                if (this.config) {
+                    document.title = this.config.title + ' - Canada.ca';
+                }
             })
             .catch((err) => {
                 console.error(`There exists no config given by the URL params: ${err}`);
@@ -128,6 +138,14 @@ $font-list: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
         font-family: $font-list;
         line-height: 1.5;
         border-bottom: 0px;
+    }
+
+    .storyramp-modified {
+        max-width: 1536px;
+        margin: 0 auto;
+        padding-left: 15px;
+        padding-top: 1em;
+        padding-bottom: 1em;
     }
 }
 

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -5,6 +5,7 @@ export interface StoryRampConfig {
     slides: Slide[];
     contextLink: string;
     contextLabel: string;
+    dateModified: string;
 }
 
 export interface DQVOptions {


### PR DESCRIPTION
Closes #158 
Closes #159 

When the config file is loaded, the page header will be updated to `<product title> - Canada.ca` in order to better match how the rest of Canada.ca works.

This PR also adds the dateModified property to the schema. If it is set, then the provided date will be displayed at the bottom of the Storyline product.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/166)
<!-- Reviewable:end -->
