### PR TITLE
Add expandable option to graphics

### DIFF
--- a/StoryRampSchema.json
+++ b/StoryRampSchema.json
@@ -141,10 +141,10 @@
                 }
             ],
             "properties": {
-                "expandable": {
+                "fullscreen": {
                     "type": "boolean",
-                    "description": "Determines whether the panel can be expanded.",
-                    "default": false
+                    "description": "Specifies whether the panel can be expanded to full screen.",
+                    "default": true
                 }
             }
         },
@@ -158,10 +158,10 @@
                     "description": "A relative path to a JSON file containing the map config.",
                     "default": ""
                 },
-                "expandable": {
+                "fullscreen": {
                     "type": "boolean",
-                    "description": "Determines whether the panel can be expanded.",
-                    "default": false
+                    "description": "Specifies whether the panel can be expanded to full screen.",
+                    "default": true
                 },
                 "type": {
                     "type": "string",
@@ -188,10 +188,10 @@
                     "type": "string",
                     "description": "The source containing the dqvchart json config."
                 },
-                "expandable": {
+                "fullscreen": {
                     "type": "boolean",
-                    "description": "Determines whether the panel can be expanded.",
-                    "default": false
+                    "description": "Specifies whether the panel can be expanded to full screen.",
+                    "default": true
                 },
                 "type": {
                     "type": "string",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
         "nouislider": "^15.5.0",
         "vue": "^2.6.11",
         "vue-class-component": "^7.2.3",
+        "vue-fullscreen": "^2.6.1",
         "vue-loading-spinner": "^1.0.11",
         "vue-papa-parse": "^3.0.4",
         "vue-progressive-image": "^3.2.0",

--- a/public/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000_en.ts
+++ b/public/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000_en.ts
@@ -110,7 +110,8 @@ Surface mining involves digging up large areas with large excavators. The result
                 {
                     src:
                         '00000000-0000-0000-0000-000000000000/assets/en/GettyImages-187242601__1554821467033__w1920.jpg',
-                    type: 'image'
+                    type: 'image',
+                    fullscreen: false
                 }
             ]
         },

--- a/src/components/panels/helpers/chart.vue
+++ b/src/components/panels/helpers/chart.vue
@@ -31,7 +31,7 @@ export default class ChartV extends Vue {
     chartOptions: DQVChartConfig = {} as DQVChartConfig;
     title = '';
     menuOptions = [
-        'viewFullScreen',
+        'viewFullscreen',
         'printChart',
         'separator',
         'downloadPNG',

--- a/src/components/panels/helpers/fullscreen.vue
+++ b/src/components/panels/helpers/fullscreen.vue
@@ -1,0 +1,55 @@
+<template>
+    <fullscreen v-model="fullscreen">
+        <div class="relative bg-white">
+            <button
+                v-if="expandable !== undefined ? expandable : true"
+                class="expand-button absolute items-center justify-center p-3 z-10"
+                :class="[fullscreen ? `top-0` : `bottom-0`, type === 'image' ? `right-10` : `right-2`]"
+                @click="toggleFullscreen"
+            >
+                <svg
+                    v-show="fullscreen"
+                    xmlns="http://www.w3.org/2000/svg"
+                    height="24px"
+                    viewBox="0 0 24 24"
+                    width="24px"
+                    fill="#595959"
+                >
+                    <path
+                        d="M19,6.41L17.59,5L12,10.59L6.41,5L5,6.41L10.59,12L5,17.59L6.41,19L12,13.41L17.59,19L19,17.59L13.41,12L19,6.41Z"
+                        fill="#666666"
+                    />
+                </svg>
+                <svg
+                    v-show="!fullscreen"
+                    xmlns="http://www.w3.org/2000/svg"
+                    height="24px"
+                    viewBox="0 0 24 24"
+                    width="24px"
+                    fill="#595959"
+                >
+                    <path
+                        d="M10,21V19H6.41L10.91,14.5L9.5,13.09L5,17.59V14H3V21H10M14.5,10.91L19,6.41V10H21V3H14V5H17.59L13.09,9.5L14.5,10.91Z"
+                    />
+                </svg>
+            </button>
+            <slot></slot>
+        </div>
+    </fullscreen>
+</template>
+
+<script lang="ts">
+import { Vue, Component, Prop } from 'vue-property-decorator';
+
+@Component
+export default class FullscreenV extends Vue {
+    @Prop() expandable!: boolean;
+    @Prop() type!: string;
+
+    fullscreen = false;
+
+    toggleFullscreen(): void {
+        this.fullscreen = !this.fullscreen;
+    }
+}
+</script>

--- a/src/components/panels/image-panel.vue
+++ b/src/components/panels/image-panel.vue
@@ -1,11 +1,13 @@
 <template>
     <div class="graphic self-start justify-center flex flex-col h-full align-middle py-5 w-full">
-        <img
-            :src="config.src"
-            :class="config.class"
-            :alt="config.altText"
-            class="graphic px-10 my-6 block flex object-contain sm:max-h-screen"
-        />
+        <full-screen :expandable="config.fullscreen" :type="config.type">
+            <img
+                :src="config.src"
+                :class="config.class"
+                :alt="config.altText"
+                class="graphic px-10 mx-auto my-6 block flex object-contain sm:max-w-screen sm:max-h-screen"
+            />
+        </full-screen>
 
         <div v-if="config.caption" class="text-center mt-5 text-sm max-w-full" v-html="md.render(config.caption)"></div>
     </div>
@@ -16,8 +18,13 @@ import { ImagePanel } from '@/definitions';
 import { Component, Vue, Prop } from 'vue-property-decorator';
 
 import MarkdownIt from 'markdown-it';
+import FullscreenV from '@/components/panels/helpers/fullscreen.vue';
 
-@Component({})
+@Component({
+    components: {
+        'full-screen': FullscreenV
+    }
+})
 export default class ImagePanelV extends Vue {
     @Prop() config!: ImagePanel;
 

--- a/src/components/panels/slideshow-panel.vue
+++ b/src/components/panels/slideshow-panel.vue
@@ -1,19 +1,21 @@
 <template>
     <div class="carousel self-start px-10 my-8 bg-gray-200_ h-28_" :style="{ width: `${width}px` }">
-        <hooper ref="carousel" v-if="width !== -1" class="h-full" :infiniteScroll="config.loop">
-            <slide v-for="(image, index) in config.images" :key="index" :index="index" class="self-center">
-                <img
-                    :src="image.src"
-                    :height="image.height"
-                    :width="image.width"
-                    :alt="image.altText"
-                    class="m-auto story-graphic"
-                />
-            </slide>
+        <full-screen :expandable="config.fullscreen" :type="config.type">
+            <hooper ref="carousel" v-if="width !== -1" class="h-full" :infiniteScroll="config.loop">
+                <slide v-for="(image, index) in config.images" :key="index" :index="index" class="self-center">
+                    <img
+                        :src="image.src"
+                        :height="image.height"
+                        :width="image.width"
+                        :alt="image.altText"
+                        class="m-auto story-graphic"
+                    />
+                </slide>
 
-            <hooper-navigation slot="hooper-addons"></hooper-navigation>
-            <hooper-pagination slot="hooper-addons"></hooper-pagination>
-        </hooper>
+                <hooper-navigation slot="hooper-addons"></hooper-navigation>
+                <hooper-pagination slot="hooper-addons"></hooper-pagination>
+            </hooper>
+        </full-screen>
 
         <div v-if="config.caption" class="text-center mt-5 text-sm" v-html="md.render(config.caption)"></div>
     </div>
@@ -26,12 +28,14 @@ import 'hooper/dist/hooper.css';
 import MarkdownIt from 'markdown-it';
 
 import { SlideshowPanel } from '@/definitions';
+import FullscreenV from '@/components/panels/helpers/fullscreen.vue';
 import { Component, Vue, Prop } from 'vue-property-decorator';
 
 @Component({
     components: {
         Hooper,
         Slide,
+        'full-screen': FullscreenV,
         HooperNavigation,
         HooperPagination
     }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -104,7 +104,7 @@ export interface TextPanel extends BasePanel {
 export interface MapPanel extends BasePanel {
     type: PanelType.Map;
     config: string;
-    expandable?: boolean;
+    fullscreen?: boolean;
     timeSlider?: TimeSliderConfig;
     title: string;
     scrollguard: boolean;
@@ -133,6 +133,7 @@ export interface ImagePanel extends BasePanel {
     width?: number;
     height?: number;
     class?: string;
+    fullscreen?: boolean;
     altText?: string;
     caption?: string;
     tooltip?: string;
@@ -155,6 +156,7 @@ export interface AudioPanel extends BasePanel {
 export interface SlideshowPanel extends BasePanel {
     type: PanelType.Slideshow;
     images: ImagePanel[];
+    fullscreen?: boolean;
     loop?: boolean;
     caption?: string;
 }
@@ -162,7 +164,7 @@ export interface SlideshowPanel extends BasePanel {
 export interface ChartPanel extends BasePanel {
     type: PanelType.Chart;
     charts: ChartConfig[];
-    expandable?: boolean;
+    fullscreen?: boolean;
 }
 
 export interface ChartConfig {

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,6 +18,9 @@ Vue.use(VuePapaParse);
 import VueProgressiveImage from 'vue-progressive-image';
 Vue.use(VueProgressiveImage);
 
+import VueFullScreen from 'vue-fullscreen';
+Vue.use(VueFullScreen);
+
 Vue.config.productionTip = false;
 
 new Vue({

--- a/src/shims-vue.d.ts
+++ b/src/shims-vue.d.ts
@@ -6,5 +6,6 @@ declare module '*.vue' {
 declare module 'vue-scrollama';
 declare module 'vue-tippy';
 declare module 'vue-progressive-image';
+declare module 'vue-fullscreen';
 declare module 'hooper';
 declare module 'vue-papa-parse';


### PR DESCRIPTION
Closes #153 

Adds a full screen expandable option for all graphic panels. For image and slideshow panels, a toggle button is added while for chart panels, a full screen option was added to the hamburger context menu. The option is also configurable and defaults to true (enabled).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/168)
<!-- Reviewable:end -->
