### PR TITLE
[WCAG] Fix link contrast and header levels

### DIFF
--- a/public/410b88da-0ed1-4749-903f-5e76c24e2e5f/410b88da-0ed1-4749-903f-5e76c24e2e5f_en.ts
+++ b/public/410b88da-0ed1-4749-903f-5e76c24e2e5f/410b88da-0ed1-4749-903f-5e76c24e2e5f_en.ts
@@ -96,7 +96,7 @@ Thermal in-situ facilities have a much smaller physical footprint than surface m
                 {
                     title: 'Where are facilities located?',
                     content: `Oil sands extraction facilities that report to the NPRI are located exclusively in northern Alberta, particularly around the municipality of Fort McMurray. Of the facilities that reported in 2019, 1 of them are in the Peace River deposit, 5 in the Cold Lake deposit and 30 in the Athabasca deposit. Also included in this map is an upgrader facility in Fort Saskatchewan, Alberta, that upgrades oil from the Canadian Natural Resources’ Muskeg River oil sands surface mining facility. Of the facilities that reported to the NPRI, seven of them are surface mining operations, one was an [upgrader facility](https://www.nrcan.gc.ca/energy/energy-sources-distribution/crude-oil/upgrading-oil-sands-and-heavy-oil/5875) and the remaining 30 were in-situ facilities.
-#### Oil sands facilities reporting to the NPRI - 2019
+### Oil sands facilities reporting to the NPRI - 2019
 
 | **Facility location** | **Thermal in-situ** | **Surface mining** | **Upgrader** | **Total** |
 | ----------------------| :-------------------: | :------------------: | :---------: | :---------: |

--- a/public/410b88da-0ed1-4749-903f-5e76c24e2e5f/410b88da-0ed1-4749-903f-5e76c24e2e5f_fr.ts
+++ b/public/410b88da-0ed1-4749-903f-5e76c24e2e5f/410b88da-0ed1-4749-903f-5e76c24e2e5f_fr.ts
@@ -95,7 +95,7 @@ Les installations in situ ont une empreinte physique beaucoup plus petite que le
                 {
                     title: 'Où sont situées les installations?',
                     content: `Les installations d’extraction des sables bitumineux qui produisent des déclarations à l’INRP sont situées exclusivement dans le nord de l’Alberta, surtout autour de la municipalité de Fort McMurray. Parmi les installations déclarantes en 2019, une se trouve dans le gisement Peace River, cinq sont dans le gisement Cold Lake et 30 sont dans le gisement Athabasca. Cette carte comprend également une [installation de valorisation](https://www.rncan.gc.ca/energie/sources-denergie-et-reseau-de-distribution/petrole-brut/valorisation-des-sables-bitumineux-et-du-petrole-lourd/5876?_ga=2.12839347.524335214.1562344489-2057911658.1562344489) à Fort Saskatchewan, en Alberta, qui valorise le pétrole de l’installation d’exploitation minière à ciel ouvert des sables bitumineux de Muskeg River de Canadian Natural Resources. Parmi les installations ayant fait l’objet d’une déclaration à l’INRP, sept sont des exploitations minières à ciel ouvert, une est une installation de valorisation et les 30 autres sont des installations in situ.
-#### Installations de sables bitumineux déclarantes à l'INRP - 2019
+### Installations de sables bitumineux déclarantes à l'INRP - 2019
 | **Emplacement de l’installation** | **Installation in situ** | **Exploitation minière à ciel ouvert** | **Installation de valorisation** | **Total** |
 | ----------------------| :-------------------: | :------------------: | :---------: | :---------: |
 | Athabasca             | 23                  | 7                  | 0         | **30**    |

--- a/public/ea24000c-7dc3-49a9-baac-c55d28dcaeb9/ea24000c-7dc3-49a9-baac-c55d28dcaeb9_en.ts
+++ b/public/ea24000c-7dc3-49a9-baac-c55d28dcaeb9/ea24000c-7dc3-49a9-baac-c55d28dcaeb9_en.ts
@@ -81,7 +81,7 @@ The rapid degradation, low concentrations in terms of toxicity, seasonality of r
                 {
                     title: 'Facilities reporting ethylene glycol to the NPRI',
                     content: `                   
-#### Breakdown of facilities reporting ethylene glycol to the NPRI for 2019 by sectors and province
+### Breakdown of facilities reporting ethylene glycol to the NPRI for 2019 by sectors and province
 | **Sectors**                   | **Airports and Services to Airports** | **All Other Sectors** | **Chemical Manufacturing** | **Oil and Gas (Conventional and Non-Conventional)** | **Waste Treatment and Disposal** | **TOTAL** |
 | ----------------------------- | :-------------------------------------: | :---------------------: | :--------------------------: | :---------------------------------------------------: | :--------------------------------: | :---------: |
 | **Alberta**                   | 10                                    | 4                     | 25                         | 56                                                  | 16                               | **111**   |

--- a/public/ea24000c-7dc3-49a9-baac-c55d28dcaeb9/ea24000c-7dc3-49a9-baac-c55d28dcaeb9_fr.ts
+++ b/public/ea24000c-7dc3-49a9-baac-c55d28dcaeb9/ea24000c-7dc3-49a9-baac-c55d28dcaeb9_fr.ts
@@ -85,7 +85,7 @@ En 2019, la province comptant le plus grand nombre d’installations ayant décl
                 {
                     title: 'Installations déclarant l’éthylène glycol à l’INRP',
                     content: `
-#### Répartition des installations ayant déclaré l’utilisation de l’éthylène glycol à l’INRP en 2019, par secteur et par province
+### Répartition des installations ayant déclaré l’utilisation de l’éthylène glycol à l’INRP en 2019, par secteur et par province
 
 | Secteurs                  | Aéroports et services aux aéroports | Tous les autres secteurs | Fabrication de produits chimiques | Pétrole et gaz (conventionnel et non conventionnel) | Traitement et élimination de déchets | TOTAL |
 | ------------------------- | :-----------------------------------: | :------------------------: | :---------------------------------: | :---------------------------------------------------: | :------------------------------------: | :-----: |

--- a/src/components/story/story.vue
+++ b/src/components/story/story.vue
@@ -26,11 +26,11 @@
 
             <footer class="p-8 pt-2 text-right text-sm">
                 Context:
-                <a class="text-blue-500 font-semibold" :href="config.contextLink" target="_NEW">{{
+                <a class="text-blue-700 font-semibold" :href="config.contextLink" target="_NEW">{{
                     config.contextLabel
                 }}</a>
                 |
-                <a href="https://github.com/ramp4-pcar4/story-ramp" target="_NEW" class="font-semibold text-blue-500"
+                <a href="https://github.com/ramp4-pcar4/story-ramp" target="_NEW" class="font-semibold text-blue-700"
                     >ramp4-pcar4/story-ramp</a
                 >
             </footer>


### PR DESCRIPTION
Closes #165, #167

Adjusted header levels in markdown to not skip `h3`.
Darkened the blue for the `Context:` links in the footer.