### PR TITLE
re-implement scrollguard to work with Firefox

### DIFF
--- a/src/components/panels/helpers/scrollguard.vue
+++ b/src/components/panels/helpers/scrollguard.vue
@@ -1,0 +1,61 @@
+<template>
+    <div class="sg" ref="scrollGuard">
+        <p class="sg-label">
+            {{
+                lang === 'en'
+                    ? 'Use ctrl + scroll to zoom the map'
+                    : 'Utilisez les touches Ctrl et + pour faire un zoom de la carte'
+            }}
+        </p>
+    </div>
+</template>
+
+<script lang="ts">
+import { Vue, Component, Prop } from 'vue-property-decorator';
+
+@Component
+export default class Scrollguard extends Vue {
+    @Prop() lang!: string;
+}
+</script>
+
+<style lang="scss">
+.sg {
+    transition: opacity ease-in-out;
+    background-color: rgba(0, 0, 0, 1);
+    text-align: center;
+
+    position: absolute;
+    padding: 0px;
+    margin: 0px;
+    border-width: 0px;
+    width: 100%;
+    height: 100%;
+    left: 0px;
+    top: 0px;
+
+    transition-duration: 0.8s;
+
+    opacity: 1;
+    pointer-events: none !important;
+    z-index: 1000;
+
+    &.sg-active {
+        opacity: 1;
+        transition-duration: 0.3s;
+    }
+
+    &.sg-scrolling {
+        transition-duration: 0.3s;
+    }
+
+    .sg-label {
+        font-size: 1em * 1.5;
+        color: white;
+        position: relative;
+        margin: 0;
+        top: 50% !important;
+        transform: translateY(-50%);
+    }
+}
+</style>


### PR DESCRIPTION
Closes #161 

The scroll guard wasn't working using the Firefox browser. It seems like the `stopPropagation()` method acts differently in Firefox than it does for other browsers, and after spending a ton of time trying things to get it to work I eventually just gave up and wrote a new implementation for the scroll guard using a RAMP3 custom panel.

An issue still exists in Firefox where the map will sometimes scroll once as the scroll guard pops up, again due to `stopPropagation` not working. I'm not exactly sure how to fix this, and if anyone else has an idea let me know.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/171)
<!-- Reviewable:end -->
