### PR TITLE
add extra checks to language switch

### DIFF
--- a/public/index-ca-en.html
+++ b/public/index-ca-en.html
@@ -36,15 +36,33 @@
         <div id="def-footer"><%= require('html-loader!../src/assets/static/cdts/footer-en.html') %></div>
 
         <script type="text/javascript">
+            // URL Parsing for Language Switch
             var url = new URL(window.location.href);
             var hashParams = url.hash.split('/');
+
+            // If there's an empty item at the end of the paramater list (occurs if there's a trailing slash in the URL), clear it.
+            if(hashParams.at(-1).length === 0) {
+                hashParams.pop();
+            }
+
+            // If content after the last slash in the URL is an anchor, clear it.
+            if(hashParams.at(-1).startsWith("#")) {
+                hashParams.pop();
+            }
+
+            // Finally, extract the StoryRAMP ID from the URL. If it has an anchor tag in it, remove it since it's not useful on the new page.
+            var productID = hashParams.pop();
+
+            if(productID.includes("#")) {
+                productID = productID.split('#')[0];
+            }
 
             var defTop = document.getElementById('def-top');
             defTop.outerHTML = wet.builder.top({
                 lngLinks: [
                     {
                         lang: 'fr',
-                        href: 'index-ca-fr.html#/fr/' + hashParams.pop(),
+                        href: 'index-ca-fr.html#/fr/' + productID,
                         text: 'Français'
                     }
                 ],

--- a/public/index-ca-fr.html
+++ b/public/index-ca-fr.html
@@ -36,15 +36,33 @@
         <div id="def-footer"><%= require('html-loader!../src/assets/static/cdts/footer-fr.html') %></div>
 
         <script type="text/javascript">
+            // URL Parsing for Language Switch
             var url = new URL(window.location.href);
             var hashParams = url.hash.split('/');
+
+            // If there's an empty item at the end of the paramater list (occurs if there's a trailing slash in the URL), clear it.
+            if(hashParams.at(-1).length === 0) {
+                hashParams.pop();
+            }
+
+            // If content after the last slash in the URL is an anchor, clear it.
+            if(hashParams.at(-1).startsWith("#")) {
+                hashParams.pop();
+            }
+
+            // Finally, extract the StoryRAMP ID from the URL. If it has an anchor tag in it, remove it since it's not useful on the new page.
+            var productID = hashParams.pop();
+
+            if(productID.includes("#")) {
+                productID = productID.split('#')[0];
+            }
 
             var defTop = document.getElementById('def-top');
             defTop.outerHTML = wet.builder.top({
                 lngLinks: [
                     {
                         lang: 'en',
-                        href: 'index-ca-en.html#/en/' + hashParams.pop(),
+                        href: 'index-ca-en.html#/en/' + productID,
                         text: 'English'
                     }
                 ],


### PR DESCRIPTION
Closes #175 

Adds some extra checks to the language switch logic:

- if the URL ends in a '/', language switch will still work
- if the URL ends in a '/' and contains an anchor after it (i.e., `/<id>/#anchor`), the anchor will be removed when switching languages.
- if the URL does not end in a '/' and still contains an anchor (i.e., `/<id>#anchor`), the anchor will be removed when switching languages.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/176)
<!-- Reviewable:end -->
