### PR TITLE
fix starting extents for existing projects

### DIFF
--- a/public/410b88da-0ed1-4749-903f-5e76c24e2e5f/ramp-config/en/OilSandsFacilityLocations2019.json
+++ b/public/410b88da-0ed1-4749-903f-5e76c24e2e5f/ramp-config/en/OilSandsFacilityLocations2019.json
@@ -1,7 +1,7 @@
 {
     "ui": {
         "title": "Oil Sands Facility Locations - 2019",
-        "logoUrl": "https://raw.githubusercontent.com/ramp4-pcar4/ramp4-pcar4/master/assets/logo.svg",        
+        "logoUrl": "https://raw.githubusercontent.com/ramp4-pcar4/ramp4-pcar4/master/assets/logo.svg",
         "appBar": {
             "geosearch": false,
             "basemap": false
@@ -87,19 +87,19 @@
                 "name": "Oil Sands Facility Locations - 2019",
                 "layerType": "esriFeature",
                 "singleEntryCollapse": true,
-                "symbologyExpanded": true,                
+                "symbologyExpanded": true,
                 "url": "https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/StoryRAMP/410b88da_0ed1_4749_903f_5e76c24e2e5f/MapServer/1",
                 "state": {
-                  "opacity": 0.75
-                }         
+                    "opacity": 0.75
+                }
             }
         ],
         "extentSets": [
             {
                 "id": "EXT_ESRI_World_AuxMerc_3857",
                 "default": {
-                    "xmax": -10875269.150822684,
-                    "xmin": -16442330.794887159,
+                    "xmax": -11375269.150822684,
+                    "xmin": -16942330.794887159,
                     "ymax": 9124722.042838877,
                     "ymin": 5700343.175663892
                 },

--- a/public/410b88da-0ed1-4749-903f-5e76c24e2e5f/ramp-config/en/ReleasesandDisposalsbyMiningFacilitiesin2019(satellite).json
+++ b/public/410b88da-0ed1-4749-903f-5e76c24e2e5f/ramp-config/en/ReleasesandDisposalsbyMiningFacilitiesin2019(satellite).json
@@ -75,7 +75,7 @@
                 "children": [
                     {
                         "symbologyExpanded": true,
-                        "description": "Releases and Disposals by Mining Facilities in 2019 (tonnes)",                        
+                        "description": "Releases and Disposals by Mining Facilities in 2019 (tonnes)",
                         "layerId": "ReleasesandDisposalsbyMiningFacilitiesin2019(satellite)"
                     }
                 ]
@@ -91,16 +91,16 @@
                 "symbologyExpanded": true,
                 "url": "https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/StoryRAMP/410b88da_0ed1_4749_903f_5e76c24e2e5f/MapServer/2",
                 "state": {
-                  "opacity": 0.75
-                }         
+                    "opacity": 0.75
+                }
             }
         ],
         "extentSets": [
             {
                 "id": "EXT_ESRI_World_AuxMerc_3857",
                 "default": {
-                    "xmax": -12272079.405705657,
-                    "xmin": -12620020.758459613,
+                    "xmax": -12279079.405705657,
+                    "xmin": -12627020.758459613,
                     "ymax": 7916959.668162176,
                     "ymin": 7702935.9889637865
                 },

--- a/public/410b88da-0ed1-4749-903f-5e76c24e2e5f/ramp-config/en/ReleasestoAirbyInSituFacilitiesforAllSubstances2010to2019(timeslider).json
+++ b/public/410b88da-0ed1-4749-903f-5e76c24e2e5f/ramp-config/en/ReleasestoAirbyInSituFacilitiesforAllSubstances2010to2019(timeslider).json
@@ -87,20 +87,20 @@
                 "name": "Releases to Air",
                 "layerType": "esriFeature",
                 "singleEntryCollapse": true,
-                "symbologyExpanded": true,  
-                "tolerance": 20,                
+                "symbologyExpanded": true,
+                "tolerance": 20,
                 "url": "https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/StoryRAMP/410b88da_0ed1_4749_903f_5e76c24e2e5f/MapServer/6",
                 "state": {
-                  "opacity": 0.75
-                } 
+                    "opacity": 0.75
+                }
             }
         ],
         "extentSets": [
             {
                 "id": "EXT_ESRI_World_AuxMerc_3857",
                 "default": {
-                    "xmax": -11484319.392198805,
-                    "xmin": -14267850.214231044,
+                    "xmax": -11574319.392198805,
+                    "xmin": -14357850.214231044,
                     "ymax": 8349344.827914256,
                     "ymin": 6637155.394326762
                 },

--- a/public/410b88da-0ed1-4749-903f-5e76c24e2e5f/ramp-config/en/ReleasestoAirbyInSituFacilitiesforAllSubstancesin2019.json
+++ b/public/410b88da-0ed1-4749-903f-5e76c24e2e5f/ramp-config/en/ReleasestoAirbyInSituFacilitiesforAllSubstancesin2019.json
@@ -87,20 +87,20 @@
                 "name": "Releases to Air",
                 "layerType": "esriFeature",
                 "singleEntryCollapse": true,
-                "symbologyExpanded": true,  
+                "symbologyExpanded": true,
                 "tolerance": 20,
                 "url": "https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/StoryRAMP/410b88da_0ed1_4749_903f_5e76c24e2e5f/MapServer/5",
                 "state": {
-                  "opacity": 0.75
-                } 
+                    "opacity": 0.75
+                }
             }
         ],
         "extentSets": [
             {
                 "id": "EXT_ESRI_World_AuxMerc_3857",
                 "default": {
-                    "xmax": -11484319.392198805,
-                    "xmin": -14267850.214231044,
+                    "xmax": -11554319.392198805,
+                    "xmin": -14337850.214231044,
                     "ymax": 8349344.827914256,
                     "ymin": 6637155.394326762
                 },

--- a/public/410b88da-0ed1-4749-903f-5e76c24e2e5f/ramp-config/fr/OilSandsFacilityLocations2019.json
+++ b/public/410b88da-0ed1-4749-903f-5e76c24e2e5f/ramp-config/fr/OilSandsFacilityLocations2019.json
@@ -25,7 +25,7 @@
             }
         }
     },
-    "language": "fr",      
+    "language": "fr",
     "services": {
         "proxyUrl": "http://167.40.64.74/wmsproxy/ws/wmsproxy/executeFromProxy",
         "exportMapUrl": "http://section917.cloudapp.net/arcgis/rest/services/Utilities/PrintingTools/GPServer/Export%20Web%20Map%20Task",
@@ -86,19 +86,19 @@
                 "name": "Installations de sables bitumineux - 2019",
                 "layerType": "esriFeature",
                 "singleEntryCollapse": true,
-                "symbologyExpanded": true,                  
+                "symbologyExpanded": true,
                 "url": "https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/StoryRAMP/410b88da_0ed1_4749_903f_5e76c24e2e5f/MapServer/8",
                 "state": {
-                  "opacity": 0.75
-                } 
+                    "opacity": 0.75
+                }
             }
         ],
         "extentSets": [
             {
                 "id": "EXT_ESRI_World_AuxMerc_3857",
                 "default": {
-                    "xmax": -10875269.150822684,
-                    "xmin": -16442330.794887159,
+                    "xmax": -11375269.150822684,
+                    "xmin": -16942330.794887159,
                     "ymax": 9124722.042838877,
                     "ymin": 5700343.175663892
                 },
@@ -230,17 +230,16 @@
         ],
         "baseMaps": [
             {
-
                 "id": "baseEsriTopo",
                 "name": "Monde topographique",
                 "description": "La carte du monde topographique est conçue pour être utilisé comme une carte de base par les professionnels du SIG et comme une carte de référence par quiconque.",
                 "altText": "altText - La carte du monde topographique",
                 "layers": [
-                  {
-                    "id": "World_Topo_Map",
-                    "layerType": "esriFeature",
-                    "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer"
-                  }
+                    {
+                        "id": "World_Topo_Map",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer"
+                    }
                 ],
                 "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
             }

--- a/public/410b88da-0ed1-4749-903f-5e76c24e2e5f/ramp-config/fr/ReleasesandDisposalsbyMiningFacilitiesin2019(satellite).json
+++ b/public/410b88da-0ed1-4749-903f-5e76c24e2e5f/ramp-config/fr/ReleasesandDisposalsbyMiningFacilitiesin2019(satellite).json
@@ -88,19 +88,19 @@
                 "layerType": "esriFeature",
                 "tolerance": 20,
                 "singleEntryCollapse": true,
-                "symbologyExpanded": true,                
+                "symbologyExpanded": true,
                 "url": "https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/StoryRAMP/410b88da_0ed1_4749_903f_5e76c24e2e5f/MapServer/9",
                 "state": {
-                  "opacity": 0.75
-                } 
+                    "opacity": 0.75
+                }
             }
         ],
         "extentSets": [
             {
                 "id": "EXT_ESRI_World_AuxMerc_3857",
                 "default": {
-                    "xmax": -12272079.405705657,
-                    "xmin": -12620020.758459613,
+                    "xmax": -12279079.405705657,
+                    "xmin": -12627020.758459613,
                     "ymax": 7916959.668162176,
                     "ymin": 7702935.9889637865
                 },

--- a/public/410b88da-0ed1-4749-903f-5e76c24e2e5f/ramp-config/fr/ReleasestoAirbyInSituFacilitiesforAllSubstances2010to2019(timeslider).json
+++ b/public/410b88da-0ed1-4749-903f-5e76c24e2e5f/ramp-config/fr/ReleasestoAirbyInSituFacilitiesforAllSubstances2010to2019(timeslider).json
@@ -75,7 +75,7 @@
                 "children": [
                     {
                         "symbologyExpanded": true,
-                        "description": "Rejets à l'air par des installations in situ pour toutes les substances, de 2010 à 2019 (tonnes)",                        
+                        "description": "Rejets à l'air par des installations in situ pour toutes les substances, de 2010 à 2019 (tonnes)",
                         "layerId": "ReleasestoAirbyInSituFacilitiesforAllSubstances2010to2019(timeslider)"
                     }
                 ]
@@ -87,20 +87,20 @@
                 "name": "Rejets à l'air",
                 "layerType": "esriFeature",
                 "singleEntryCollapse": true,
-                "symbologyExpanded": true,  
-                "tolerance": 20,                   
+                "symbologyExpanded": true,
+                "tolerance": 20,
                 "url": "https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/StoryRAMP/410b88da_0ed1_4749_903f_5e76c24e2e5f/MapServer/13",
                 "state": {
-                  "opacity": 0.75
-                } 
+                    "opacity": 0.75
+                }
             }
         ],
         "extentSets": [
             {
                 "id": "EXT_ESRI_World_AuxMerc_3857",
                 "default": {
-                    "xmax": -11484319.392198805,
-                    "xmin": -14267850.214231044,
+                    "xmax": -11574319.392198805,
+                    "xmin": -14357850.214231044,
                     "ymax": 8349344.827914256,
                     "ymin": 6637155.394326762
                 },
@@ -237,11 +237,11 @@
                 "description": "La carte du monde topographique est conçue pour être utilisé comme une carte de base par les professionnels du SIG et comme une carte de référence par quiconque.",
                 "altText": "altText - La carte du monde topographique",
                 "layers": [
-                  {
-                    "id": "World_Topo_Map",
-                    "layerType": "esriFeature",
-                    "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer"
-                  }
+                    {
+                        "id": "World_Topo_Map",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer"
+                    }
                 ],
                 "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
             }

--- a/public/410b88da-0ed1-4749-903f-5e76c24e2e5f/ramp-config/fr/ReleasestoAirbyInSituFacilitiesforAllSubstancesin2019.json
+++ b/public/410b88da-0ed1-4749-903f-5e76c24e2e5f/ramp-config/fr/ReleasestoAirbyInSituFacilitiesforAllSubstancesin2019.json
@@ -75,7 +75,7 @@
                 "children": [
                     {
                         "symbologyExpanded": true,
-                        "description": "Rejets à l'air par des installations in situ pour toutes les substances en 2019 (tonnes)",                        
+                        "description": "Rejets à l'air par des installations in situ pour toutes les substances en 2019 (tonnes)",
                         "layerId": "ReleasestoAirbyInSituFacilitiesforAllSubstancesin2019"
                     }
                 ]
@@ -87,20 +87,20 @@
                 "name": "Rejets à l'air",
                 "layerType": "esriFeature",
                 "singleEntryCollapse": true,
-                "symbologyExpanded": true,  
-                "tolerance": 20,                
+                "symbologyExpanded": true,
+                "tolerance": 20,
                 "url": "https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/StoryRAMP/410b88da_0ed1_4749_903f_5e76c24e2e5f/MapServer/12",
                 "state": {
-                  "opacity": 0.75
-                } 
+                    "opacity": 0.75
+                }
             }
         ],
         "extentSets": [
             {
                 "id": "EXT_ESRI_World_AuxMerc_3857",
                 "default": {
-                    "xmax": -11484319.392198805,
-                    "xmin": -14267850.214231044,
+                    "xmax": -11554319.392198805,
+                    "xmin": -14337850.214231044,
                     "ymax": 8349344.827914256,
                     "ymin": 6637155.394326762
                 },
@@ -237,11 +237,11 @@
                 "description": "La carte du monde topographique est conçue pour être utilisé comme une carte de base par les professionnels du SIG et comme une carte de référence par quiconque.",
                 "altText": "altText - La carte du monde topographique",
                 "layers": [
-                  {
-                    "id": "World_Topo_Map",
-                    "layerType": "esriFeature",
-                    "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer"
-                  }
+                    {
+                        "id": "World_Topo_Map",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer"
+                    }
                 ],
                 "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
             }

--- a/public/ea24000c-7dc3-49a9-baac-c55d28dcaeb9/ramp-config/en/total_quantities2019.json
+++ b/public/ea24000c-7dc3-49a9-baac-c55d28dcaeb9/ramp-config/en/total_quantities2019.json
@@ -1,548 +1,535 @@
 {
-  "version": "2.0",
-  "language": "en",
-  "ui": {
-    "title": "Interactive map",
-    "fullscreen": true,
-    "navBar": {
-      "zoom": "buttons",
-      "extra": [
-        "fullscreen",
-        "geoLocator",
-        "home",
-        "help"
-      ]
-    },
-    "appBar": {
-      "basemap": true
-    },
-    "help": {
-      "folderName": "default"
-    },
-    "sideMenu": {
-      "items": [
-        [
-          "fullscreen",
-          "export",
-          "touch",
-          "help",
-          "about"
-        ]
-      ],
-      "logo": false
-    },
-    "legend": {
-      "allowImport": true,
-      "isOpen": {
-        "large": true,
-        "medium": false,
-        "small": false
-      }
-    }
-  },
-  "services": {
-    "proxyUrl": "http://167.40.64.74/wmsproxy/ws/wmsproxy/executeFromProxy",
-    "exportMapUrl": "https://maps-cartes.dev.ec.gc.ca/arcgis/rest/services/Utilities/PrintingTools/GPServer/Export%20Web%20Map%20Task",
-    "export": {
-      "title": {
-        "value": "Total quantities of ethylene glycol disposed and recycled by facilities in 2019"
-      },
-      "map": {},
-      "mapElements": {},
-      "legend": {},
-      "footnote": {
-        "value": "Total quantities of ethylene glycol disposed and recycled by facilities in 2019"
-      }
-    },
-    "search": {
-      "settings": {
-        "categories": [
-          "CITY",
-          "HAM",
-          "IR",
-          "LTM",
-          "MUN1",
-          "MUN2",
-          "PROV",
-          "STM",
-          "TERR",
-          "TOWN",
-          "UTM",
-          "VILG",
-          "UNP"
-        ],
-        "sortOrder": [
-          "CITY",
-          "HAM",
-          "IR",
-          "LTM",
-          "MUN1",
-          "MUN2",
-          "PROV",
-          "STM",
-          "TERR",
-          "TOWN",
-          "UTM",
-          "VILG",
-          "UNP"
-        ],
-        "maxResults": 1000,
-        "officialOnly": true
-      },
-      "serviceUrls": {
-        "geoNames": "https://geogratis.gc.ca/services/geoname/en/geonames.json",
-        "geoLocation": "https://geogratis.gc.ca/services/geolocation/en/locate?q=",
-        "geoSuggest": "https://geogratis.gc.ca/services/geolocation/en/suggest?q=",
-        "provinces": "https://geogratis.gc.ca/services/geoname/en/codes/province.json",
-        "types": "https://geogratis.gc.ca/services/geoname/en/codes/concise.json"
-      }
-    }
-  },
-  "map": {
-    "initialBasemapId": "baseNrCan",
-    "components": {
-      "geoSearch": {
-        "enabled": true,
-        "showGraphic": true,
-        "showInfo": true
-      },
-      "mouseInfo": {
-        "enabled": true,
-        "spatialReference": {
-          "wkid": 4326
-        }
-      },
-      "northArrow": {
-        "enabled": false
-      },
-      "basemap": {
-        "enabled": true
-      },
-      "overviewMap": {
-        "enabled": true,
-        "layerType": "imagery"
-      },
-      "scaleBar": {
-        "enabled": true
-      }
-    },
-    "extentSets": [
-      {
-        "id": "EXT_NRCAN_Lambert_3978",
-        "default": {
-          "xmax": 2849492,
-          "xmin": -5281457,
-          "ymax": 4482193,
-          "ymin": -983440
+    "version": "2.0",
+    "language": "en",
+    "ui": {
+        "title": "Interactive map",
+        "fullscreen": true,
+        "navBar": {
+            "zoom": "buttons",
+            "extra": ["fullscreen", "geoLocator", "home", "help"]
         },
-        "spatialReference": {
-          "wkid": 3978
-        }
-      },
-      {
-        "id": "EXT_ESRI_World_AuxMerc_3857",
-        "default": {
-          "xmax": -5007771.626060756,
-          "xmin": -16632697.354854,
-          "ymax": 10015875.184845109,
-          "ymin": 5022907.964742964
+        "appBar": {
+            "basemap": true
         },
-        "spatialReference": {
-          "wkid": 102100,
-          "latestWkid": 3857
+        "help": {
+            "folderName": "default"
+        },
+        "sideMenu": {
+            "items": [["fullscreen", "export", "touch", "help", "about"]],
+            "logo": false
+        },
+        "legend": {
+            "allowImport": true,
+            "isOpen": {
+                "large": true,
+                "medium": false,
+                "small": false
+            }
         }
-      }
-    ],
-    "lodSets": [
-      {
-        "id": "LOD_NRCAN_Lambert_3978",
-        "lods": [
-          {
-            "level": 0,
-            "resolution": 38364.660062653464,
-            "scale": 145000000
-          },
-          {
-            "level": 1,
-            "resolution": 22489.628312589961,
-            "scale": 85000000
-          },
-          {
-            "level": 2,
-            "resolution": 13229.193125052918,
-            "scale": 50000000
-          },
-          {
-            "level": 3,
-            "resolution": 7937.5158750317505,
-            "scale": 30000000
-          },
-          {
-            "level": 4,
-            "resolution": 4630.2175937685215,
-            "scale": 17500000
-          },
-          {
-            "level": 5,
-            "resolution": 2645.8386250105837,
-            "scale": 10000000
-          },
-          {
-            "level": 6,
-            "resolution": 1587.5031750063501,
-            "scale": 6000000
-          },
-          {
-            "level": 7,
-            "resolution": 926.04351875370423,
-            "scale": 3500000
-          },
-          {
-            "level": 8,
-            "resolution": 529.16772500211675,
-            "scale": 2000000
-          },
-          {
-            "level": 9,
-            "resolution": 317.50063500127004,
-            "scale": 1200000
-          },
-          {
-            "level": 10,
-            "resolution": 185.20870375074085,
-            "scale": 700000
-          },
-          {
-            "level": 11,
-            "resolution": 111.12522225044451,
-            "scale": 420000
-          },
-          {
-            "level": 12,
-            "resolution": 66.1459656252646,
-            "scale": 250000
-          },
-          {
-            "level": 13,
-            "resolution": 38.364660062653464,
-            "scale": 145000
-          },
-          {
-            "level": 14,
-            "resolution": 22.489628312589961,
-            "scale": 85000
-          },
-          {
-            "level": 15,
-            "resolution": 13.229193125052918,
-            "scale": 50000
-          },
-          {
-            "level": 16,
-            "resolution": 7.9375158750317505,
-            "scale": 30000
-          },
-          {
-            "level": 17,
-            "resolution": 4.6302175937685215,
-            "scale": 17500
-          }
-        ]
-      },
-      {
-        "id": "LOD_ESRI_World_AuxMerc_3857",
-        "lods": [
-          {
-            "level": 0,
-            "resolution": 19567.879240999919,
-            "scale": 73957190.948944
-          },
-          {
-            "level": 1,
-            "resolution": 9783.93962049996,
-            "scale": 36978595.474472
-          },
-          {
-            "level": 2,
-            "resolution": 4891.96981024998,
-            "scale": 18489297.737236
-          },
-          {
-            "level": 3,
-            "resolution": 2445.98490512499,
-            "scale": 9244648.868618
-          },
-          {
-            "level": 4,
-            "resolution": 1222.9924525624949,
-            "scale": 4622324.434309
-          },
-          {
-            "level": 5,
-            "resolution": 611.49622628137968,
-            "scale": 2311162.217155
-          },
-          {
-            "level": 6,
-            "resolution": 305.74811314055756,
-            "scale": 1155581.108577
-          },
-          {
-            "level": 7,
-            "resolution": 152.87405657041106,
-            "scale": 577790.554289
-          },
-          {
-            "level": 8,
-            "resolution": 76.437028285073239,
-            "scale": 288895.277144
-          },
-          {
-            "level": 9,
-            "resolution": 38.21851414253662,
-            "scale": 144447.638572
-          },
-          {
-            "level": 10,
-            "resolution": 19.10925707126831,
-            "scale": 72223.819286
-          },
-          {
-            "level": 11,
-            "resolution": 9.5546285356341549,
-            "scale": 36111.909643
-          },
-          {
-            "level": 12,
-            "resolution": 4.77731426794937,
-            "scale": 18055.954822
-          },
-          {
-            "level": 13,
-            "resolution": 2.3886571339746849,
-            "scale": 9027.977411
-          },
-          {
-            "level": 14,
-            "resolution": 1.1943285668550503,
-            "scale": 4513.988705
-          },
-          {
-            "level": 15,
-            "resolution": 0.59716428355981721,
-            "scale": 2256.994353
-          },
-          {
-            "level": 16,
-            "resolution": 0.29858214164761665,
-            "scale": 1128.497176
-          },
-          {
-            "level": 17,
-            "resolution": 0.14929107082380833,
-            "scale": 564.248588
-          },
-          {
-            "level": 18,
-            "resolution": 0.074645535411904163,
-            "scale": 282.124294
-          },
-          {
-            "level": 19,
-            "resolution": 0.037322767705952081,
-            "scale": 141.062147
-          },
-          {
-            "level": 20,
-            "resolution": 0.018661383852976041,
-            "scale": 70.5310735
-          }
-        ]
-      }
-    ],
-    "legend": {
-      "type": "structured",
-      "root": {
-        "name": "root",
-        "children": [
-          {
-            "layerId": "Total_Quantities2019",
-            "description": "Total quantities of ethylene glycol disposed and recycled by facilities in 2019 (tonnes)",
-            "symbologyExpanded": true
-          }
-        ]
-      }
     },
-    "layers": [
-      {
-        "id": "Total_Quantities2019",
-        "name": "Total quantities of ethylene glycol",
-        "layerType": "esriFeature",
-        "singleEntryCollapse": true,
-        "symbologyExpanded": true,
-        "tolerance": 20,
-        "url": "https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/StoryRAMP/ea24000c_7dc3_49a9_baac_c55d28dcaeb9/MapServer/2",
-        "state": {
-          "opacity": 0.75
-        } 
-      }
-    ],
-    "tileSchemas": [
-      {
-        "id": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978",
-        "name": "Lambert Maps",
-        "extentSetId": "EXT_NRCAN_Lambert_3978",
-        "lodSetId": "LOD_NRCAN_Lambert_3978",
-        "hasNorthPole": true
-      },
-      {
-        "id": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857",
-        "name": "Web Mercator Maps",
-        "extentSetId": "EXT_ESRI_World_AuxMerc_3857",
-        "lodSetId": "LOD_ESRI_World_AuxMerc_3857"
-      }
-    ],
-    "baseMaps": [
-      {
-        "id": "baseNrCan",
-        "name": "Canada Base Map - Transportation (CBMT)",
-        "description": "The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.",
-        "altText": "altText - The Canada Base Map - Transportation (CBMT)",
-        "layers": [
-          {
-            "id": "CBMT",
-            "layerType": "esriFeature",
-            "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer"
-          }
+    "services": {
+        "proxyUrl": "http://167.40.64.74/wmsproxy/ws/wmsproxy/executeFromProxy",
+        "exportMapUrl": "https://maps-cartes.dev.ec.gc.ca/arcgis/rest/services/Utilities/PrintingTools/GPServer/Export%20Web%20Map%20Task",
+        "export": {
+            "title": {
+                "value": "Total quantities of ethylene glycol disposed and recycled by facilities in 2019"
+            },
+            "map": {},
+            "mapElements": {},
+            "legend": {},
+            "footnote": {
+                "value": "Total quantities of ethylene glycol disposed and recycled by facilities in 2019"
+            }
+        },
+        "search": {
+            "settings": {
+                "categories": [
+                    "CITY",
+                    "HAM",
+                    "IR",
+                    "LTM",
+                    "MUN1",
+                    "MUN2",
+                    "PROV",
+                    "STM",
+                    "TERR",
+                    "TOWN",
+                    "UTM",
+                    "VILG",
+                    "UNP"
+                ],
+                "sortOrder": [
+                    "CITY",
+                    "HAM",
+                    "IR",
+                    "LTM",
+                    "MUN1",
+                    "MUN2",
+                    "PROV",
+                    "STM",
+                    "TERR",
+                    "TOWN",
+                    "UTM",
+                    "VILG",
+                    "UNP"
+                ],
+                "maxResults": 1000,
+                "officialOnly": true
+            },
+            "serviceUrls": {
+                "geoNames": "https://geogratis.gc.ca/services/geoname/en/geonames.json",
+                "geoLocation": "https://geogratis.gc.ca/services/geolocation/en/locate?q=",
+                "geoSuggest": "https://geogratis.gc.ca/services/geolocation/en/suggest?q=",
+                "provinces": "https://geogratis.gc.ca/services/geoname/en/codes/province.json",
+                "types": "https://geogratis.gc.ca/services/geoname/en/codes/concise.json"
+            }
+        }
+    },
+    "map": {
+        "initialBasemapId": "baseNrCan",
+        "components": {
+            "geoSearch": {
+                "enabled": true,
+                "showGraphic": true,
+                "showInfo": true
+            },
+            "mouseInfo": {
+                "enabled": true,
+                "spatialReference": {
+                    "wkid": 4326
+                }
+            },
+            "northArrow": {
+                "enabled": false
+            },
+            "basemap": {
+                "enabled": true
+            },
+            "overviewMap": {
+                "enabled": true,
+                "layerType": "imagery"
+            },
+            "scaleBar": {
+                "enabled": true
+            }
+        },
+        "extentSets": [
+            {
+                "id": "EXT_NRCAN_Lambert_3978",
+                "default": {
+                    "xmax": 2349492,
+                    "xmin": -5781457,
+                    "ymax": 4482193,
+                    "ymin": -983440
+                },
+                "spatialReference": {
+                    "wkid": 3978
+                }
+            },
+            {
+                "id": "EXT_ESRI_World_AuxMerc_3857",
+                "default": {
+                    "xmax": -5007771.626060756,
+                    "xmin": -16632697.354854,
+                    "ymax": 10015875.184845109,
+                    "ymin": 5022907.964742964
+                },
+                "spatialReference": {
+                    "wkid": 102100,
+                    "latestWkid": 3857
+                }
+            }
         ],
-        "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
-      },
-      {
-        "id": "baseSimple",
-        "name": "Canada Base Map - Simple",
-        "description": "Canada Base Map - Simple",
-        "altText": "altText - Canada base map - Simple",
-        "layers": [
-          {
-            "id": "SMR",
-            "layerType": "esriFeature",
-            "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer"
-          }
+        "lodSets": [
+            {
+                "id": "LOD_NRCAN_Lambert_3978",
+                "lods": [
+                    {
+                        "level": 0,
+                        "resolution": 38364.660062653464,
+                        "scale": 145000000
+                    },
+                    {
+                        "level": 1,
+                        "resolution": 22489.628312589961,
+                        "scale": 85000000
+                    },
+                    {
+                        "level": 2,
+                        "resolution": 13229.193125052918,
+                        "scale": 50000000
+                    },
+                    {
+                        "level": 3,
+                        "resolution": 7937.5158750317505,
+                        "scale": 30000000
+                    },
+                    {
+                        "level": 4,
+                        "resolution": 4630.2175937685215,
+                        "scale": 17500000
+                    },
+                    {
+                        "level": 5,
+                        "resolution": 2645.8386250105837,
+                        "scale": 10000000
+                    },
+                    {
+                        "level": 6,
+                        "resolution": 1587.5031750063501,
+                        "scale": 6000000
+                    },
+                    {
+                        "level": 7,
+                        "resolution": 926.04351875370423,
+                        "scale": 3500000
+                    },
+                    {
+                        "level": 8,
+                        "resolution": 529.16772500211675,
+                        "scale": 2000000
+                    },
+                    {
+                        "level": 9,
+                        "resolution": 317.50063500127004,
+                        "scale": 1200000
+                    },
+                    {
+                        "level": 10,
+                        "resolution": 185.20870375074085,
+                        "scale": 700000
+                    },
+                    {
+                        "level": 11,
+                        "resolution": 111.12522225044451,
+                        "scale": 420000
+                    },
+                    {
+                        "level": 12,
+                        "resolution": 66.1459656252646,
+                        "scale": 250000
+                    },
+                    {
+                        "level": 13,
+                        "resolution": 38.364660062653464,
+                        "scale": 145000
+                    },
+                    {
+                        "level": 14,
+                        "resolution": 22.489628312589961,
+                        "scale": 85000
+                    },
+                    {
+                        "level": 15,
+                        "resolution": 13.229193125052918,
+                        "scale": 50000
+                    },
+                    {
+                        "level": 16,
+                        "resolution": 7.9375158750317505,
+                        "scale": 30000
+                    },
+                    {
+                        "level": 17,
+                        "resolution": 4.6302175937685215,
+                        "scale": 17500
+                    }
+                ]
+            },
+            {
+                "id": "LOD_ESRI_World_AuxMerc_3857",
+                "lods": [
+                    {
+                        "level": 0,
+                        "resolution": 19567.879240999919,
+                        "scale": 73957190.948944
+                    },
+                    {
+                        "level": 1,
+                        "resolution": 9783.93962049996,
+                        "scale": 36978595.474472
+                    },
+                    {
+                        "level": 2,
+                        "resolution": 4891.96981024998,
+                        "scale": 18489297.737236
+                    },
+                    {
+                        "level": 3,
+                        "resolution": 2445.98490512499,
+                        "scale": 9244648.868618
+                    },
+                    {
+                        "level": 4,
+                        "resolution": 1222.9924525624949,
+                        "scale": 4622324.434309
+                    },
+                    {
+                        "level": 5,
+                        "resolution": 611.49622628137968,
+                        "scale": 2311162.217155
+                    },
+                    {
+                        "level": 6,
+                        "resolution": 305.74811314055756,
+                        "scale": 1155581.108577
+                    },
+                    {
+                        "level": 7,
+                        "resolution": 152.87405657041106,
+                        "scale": 577790.554289
+                    },
+                    {
+                        "level": 8,
+                        "resolution": 76.437028285073239,
+                        "scale": 288895.277144
+                    },
+                    {
+                        "level": 9,
+                        "resolution": 38.21851414253662,
+                        "scale": 144447.638572
+                    },
+                    {
+                        "level": 10,
+                        "resolution": 19.10925707126831,
+                        "scale": 72223.819286
+                    },
+                    {
+                        "level": 11,
+                        "resolution": 9.5546285356341549,
+                        "scale": 36111.909643
+                    },
+                    {
+                        "level": 12,
+                        "resolution": 4.77731426794937,
+                        "scale": 18055.954822
+                    },
+                    {
+                        "level": 13,
+                        "resolution": 2.3886571339746849,
+                        "scale": 9027.977411
+                    },
+                    {
+                        "level": 14,
+                        "resolution": 1.1943285668550503,
+                        "scale": 4513.988705
+                    },
+                    {
+                        "level": 15,
+                        "resolution": 0.59716428355981721,
+                        "scale": 2256.994353
+                    },
+                    {
+                        "level": 16,
+                        "resolution": 0.29858214164761665,
+                        "scale": 1128.497176
+                    },
+                    {
+                        "level": 17,
+                        "resolution": 0.14929107082380833,
+                        "scale": 564.248588
+                    },
+                    {
+                        "level": 18,
+                        "resolution": 0.074645535411904163,
+                        "scale": 282.124294
+                    },
+                    {
+                        "level": 19,
+                        "resolution": 0.037322767705952081,
+                        "scale": 141.062147
+                    },
+                    {
+                        "level": 20,
+                        "resolution": 0.018661383852976041,
+                        "scale": 70.5310735
+                    }
+                ]
+            }
         ],
-        "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
-      },
-      {
-        "id": "baseCBME_CBCE_HS_RO_3978",
-        "name": "Canada Base Map - Elevation (CBME)",
-        "description": "The Canada Base Map - Elevation (CBME) web mapping services of the Earth Sciences Sector at Natural Resources Canada, is intended primarily for online mapping application users and developers.",
-        "altText": "altText - Canada Base Map - Elevation (CBME)",
+        "legend": {
+            "type": "structured",
+            "root": {
+                "name": "root",
+                "children": [
+                    {
+                        "layerId": "Total_Quantities2019",
+                        "description": "Total quantities of ethylene glycol disposed and recycled by facilities in 2019 (tonnes)",
+                        "symbologyExpanded": true
+                    }
+                ]
+            }
+        },
         "layers": [
-          {
-            "id": "CBME_CBCE_HS_RO_3978",
-            "layerType": "esriFeature",
-            "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer"
-          }
+            {
+                "id": "Total_Quantities2019",
+                "name": "Total quantities of ethylene glycol",
+                "layerType": "esriFeature",
+                "singleEntryCollapse": true,
+                "symbologyExpanded": true,
+                "tolerance": 20,
+                "url": "https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/StoryRAMP/ea24000c_7dc3_49a9_baac_c55d28dcaeb9/MapServer/2",
+                "state": {
+                    "opacity": 0.75
+                }
+            }
         ],
-        "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
-      },
-      {
-        "id": "baseCBMT_CBCT_GEOM_3978",
-        "name": "Canada Base Map - Transportation (CBMT)",
-        "description": " The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.",
-        "altText": "altText - Canada Base Map - Transportation (CBMT)",
-        "layers": [
-          {
-            "id": "CBMT_CBCT_GEOM_3978",
-            "layerType": "esriFeature",
-            "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer"
-          }
+        "tileSchemas": [
+            {
+                "id": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978",
+                "name": "Lambert Maps",
+                "extentSetId": "EXT_NRCAN_Lambert_3978",
+                "lodSetId": "LOD_NRCAN_Lambert_3978",
+                "hasNorthPole": true
+            },
+            {
+                "id": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857",
+                "name": "Web Mercator Maps",
+                "extentSetId": "EXT_ESRI_World_AuxMerc_3857",
+                "lodSetId": "LOD_ESRI_World_AuxMerc_3857"
+            }
         ],
-        "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
-      },
-      {
-        "id": "baseEsriWorld",
-        "name": "World Imagery",
-        "description": "World Imagery provides one meter or better satellite and aerial imagery in many parts of the world and lower resolution satellite imagery worldwide.",
-        "altText": "altText - World Imagery",
-        "layers": [
-          {
-            "id": "World_Imagery",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      },
-      {
-        "id": "baseEsriPhysical",
-        "name": "World Physical Map",
-        "description": "This map presents the Natural Earth physical map at 1.24km per pixel for the world and 500m for the coterminous United States.",
-        "altText": "altText - World Physical Map",
-        "layers": [
-          {
-            "id": "World_Physical_Map",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Physical_Map/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      },
-      {
-        "id": "baseEsriRelief",
-        "name": "World Shaded Relief",
-        "description": "This map portrays surface elevation as shaded relief. This map is used as a basemap layer to add shaded relief to other GIS maps, such as the ArcGIS Online World Street Map.",
-        "altText": "altText - World Shaded Relief",
-        "layers": [
-          {
-            "id": "World_Shaded_Relief",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Shaded_Relief/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      },
-      {
-        "id": "baseEsriStreet",
-        "name": "World Street Map",
-        "description": "This worldwide street map presents highway-level data for the world.",
-        "altText": "altText - ESWorld Street Map",
-        "layers": [
-          {
-            "id": "World_Street_Map",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Street_Map/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      },
-      {
-        "id": "baseEsriTerrain",
-        "name": "World Terrain Base",
-        "description": "This map is designed to be used as a base map by GIS professionals to overlay other thematic layers such as demographics or land cover.",
-        "altText": "altText - World Terrain Base",
-        "layers": [
-          {
-            "id": "World_Terrain_Base",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Terrain_Base/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      },
-      {
-        "id": "baseEsriTopo",
-        "name": "World Topographic Map",
-        "description": "This map is designed to be used as a basemap by GIS professionals and as a reference map by anyone.",
-        "altText": "altText - World Topographic Map",
-        "layers": [
-          {
-            "id": "World_Topo_Map",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      }
-    ]
-  }
+        "baseMaps": [
+            {
+                "id": "baseNrCan",
+                "name": "Canada Base Map - Transportation (CBMT)",
+                "description": "The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.",
+                "altText": "altText - The Canada Base Map - Transportation (CBMT)",
+                "layers": [
+                    {
+                        "id": "CBMT",
+                        "layerType": "esriFeature",
+                        "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+            },
+            {
+                "id": "baseSimple",
+                "name": "Canada Base Map - Simple",
+                "description": "Canada Base Map - Simple",
+                "altText": "altText - Canada base map - Simple",
+                "layers": [
+                    {
+                        "id": "SMR",
+                        "layerType": "esriFeature",
+                        "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+            },
+            {
+                "id": "baseCBME_CBCE_HS_RO_3978",
+                "name": "Canada Base Map - Elevation (CBME)",
+                "description": "The Canada Base Map - Elevation (CBME) web mapping services of the Earth Sciences Sector at Natural Resources Canada, is intended primarily for online mapping application users and developers.",
+                "altText": "altText - Canada Base Map - Elevation (CBME)",
+                "layers": [
+                    {
+                        "id": "CBME_CBCE_HS_RO_3978",
+                        "layerType": "esriFeature",
+                        "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+            },
+            {
+                "id": "baseCBMT_CBCT_GEOM_3978",
+                "name": "Canada Base Map - Transportation (CBMT)",
+                "description": " The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.",
+                "altText": "altText - Canada Base Map - Transportation (CBMT)",
+                "layers": [
+                    {
+                        "id": "CBMT_CBCT_GEOM_3978",
+                        "layerType": "esriFeature",
+                        "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+            },
+            {
+                "id": "baseEsriWorld",
+                "name": "World Imagery",
+                "description": "World Imagery provides one meter or better satellite and aerial imagery in many parts of the world and lower resolution satellite imagery worldwide.",
+                "altText": "altText - World Imagery",
+                "layers": [
+                    {
+                        "id": "World_Imagery",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriPhysical",
+                "name": "World Physical Map",
+                "description": "This map presents the Natural Earth physical map at 1.24km per pixel for the world and 500m for the coterminous United States.",
+                "altText": "altText - World Physical Map",
+                "layers": [
+                    {
+                        "id": "World_Physical_Map",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Physical_Map/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriRelief",
+                "name": "World Shaded Relief",
+                "description": "This map portrays surface elevation as shaded relief. This map is used as a basemap layer to add shaded relief to other GIS maps, such as the ArcGIS Online World Street Map.",
+                "altText": "altText - World Shaded Relief",
+                "layers": [
+                    {
+                        "id": "World_Shaded_Relief",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Shaded_Relief/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriStreet",
+                "name": "World Street Map",
+                "description": "This worldwide street map presents highway-level data for the world.",
+                "altText": "altText - ESWorld Street Map",
+                "layers": [
+                    {
+                        "id": "World_Street_Map",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Street_Map/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriTerrain",
+                "name": "World Terrain Base",
+                "description": "This map is designed to be used as a base map by GIS professionals to overlay other thematic layers such as demographics or land cover.",
+                "altText": "altText - World Terrain Base",
+                "layers": [
+                    {
+                        "id": "World_Terrain_Base",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Terrain_Base/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriTopo",
+                "name": "World Topographic Map",
+                "description": "This map is designed to be used as a basemap by GIS professionals and as a reference map by anyone.",
+                "altText": "altText - World Topographic Map",
+                "layers": [
+                    {
+                        "id": "World_Topo_Map",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            }
+        ]
+    }
 }

--- a/public/ea24000c-7dc3-49a9-baac-c55d28dcaeb9/ramp-config/en/total_releases2019.json
+++ b/public/ea24000c-7dc3-49a9-baac-c55d28dcaeb9/ramp-config/en/total_releases2019.json
@@ -1,548 +1,535 @@
 {
-  "version": "2.0",
-  "language": "en",
-  "ui": {
-    "title": "Interactive map",
-    "fullscreen": true,
-    "navBar": {
-      "zoom": "buttons",
-      "extra": [
-        "fullscreen",
-        "geoLocator",
-        "home",
-        "help"
-      ]
-    },
-    "appBar": {
-      "basemap": true
-    },
-    "help": {
-      "folderName": "default"
-    },
-    "sideMenu": {
-      "items": [
-        [
-          "fullscreen",
-          "export",
-          "touch",
-          "help",
-          "about"
-        ]
-      ],
-      "logo": false
-    },
-    "legend": {
-      "allowImport": false,
-      "isOpen": {
-        "large": true,
-        "medium": false,
-        "small": false
-      }
-    }
-  },
-  "services": {
-    "proxyUrl": "http://167.40.64.74/wmsproxy/ws/wmsproxy/executeFromProxy",
-    "exportMapUrl": "https://maps-cartes.dev.ec.gc.ca/arcgis/rest/services/Utilities/PrintingTools/GPServer/Export%20Web%20Map%20Task",
-    "export": {
-      "title": {
-        "value": "Total releases of ethylene glycol per facility for 2019"
-      },
-      "map": {},
-      "mapElements": {},
-      "legend": {},
-      "footnote": {
-        "value": "Total releases of ethylene glycol per facility for 2019"
-      }
-    },
-    "search": {
-      "settings": {
-        "categories": [
-          "CITY",
-          "HAM",
-          "IR",
-          "LTM",
-          "MUN1",
-          "MUN2",
-          "PROV",
-          "STM",
-          "TERR",
-          "TOWN",
-          "UTM",
-          "VILG",
-          "UNP"
-        ],
-        "sortOrder": [
-          "CITY",
-          "HAM",
-          "IR",
-          "LTM",
-          "MUN1",
-          "MUN2",
-          "PROV",
-          "STM",
-          "TERR",
-          "TOWN",
-          "UTM",
-          "VILG",
-          "UNP"
-        ],
-        "maxResults": 1000,
-        "officialOnly": true
-      },
-      "serviceUrls": {
-        "geoNames": "https://geogratis.gc.ca/services/geoname/en/geonames.json",
-        "geoLocation": "https://geogratis.gc.ca/services/geolocation/en/locate?q=",
-        "geoSuggest": "https://geogratis.gc.ca/services/geolocation/en/suggest?q=",
-        "provinces": "https://geogratis.gc.ca/services/geoname/en/codes/province.json",
-        "types": "https://geogratis.gc.ca/services/geoname/en/codes/concise.json"
-      }
-    }
-  },
-  "map": {
-    "initialBasemapId": "baseNrCan",
-    "components": {
-      "geoSearch": {
-        "enabled": true,
-        "showGraphic": true,
-        "showInfo": true
-      },
-      "mouseInfo": {
-        "enabled": true,
-        "spatialReference": {
-          "wkid": 4326
-        }
-      },
-      "northArrow": {
-        "enabled": false
-      },
-      "basemap": {
-        "enabled": true
-      },
-      "overviewMap": {
-        "enabled": true,
-        "layerType": "imagery"
-      },
-      "scaleBar": {
-        "enabled": true
-      }
-    },
-    "extentSets": [
-      {
-        "id": "EXT_NRCAN_Lambert_3978",
-        "default": {
-          "xmax": 2849492,
-          "xmin": -5281457,
-          "ymax": 4482193,
-          "ymin": -983440
+    "version": "2.0",
+    "language": "en",
+    "ui": {
+        "title": "Interactive map",
+        "fullscreen": true,
+        "navBar": {
+            "zoom": "buttons",
+            "extra": ["fullscreen", "geoLocator", "home", "help"]
         },
-        "spatialReference": {
-          "wkid": 3978
-        }
-      },
-      {
-        "id": "EXT_ESRI_World_AuxMerc_3857",
-        "default": {
-          "xmax": -5007771.626060756,
-          "xmin": -16632697.354854,
-          "ymax": 10015875.184845109,
-          "ymin": 5022907.964742964
+        "appBar": {
+            "basemap": true
         },
-        "spatialReference": {
-          "wkid": 102100,
-          "latestWkid": 3857
+        "help": {
+            "folderName": "default"
+        },
+        "sideMenu": {
+            "items": [["fullscreen", "export", "touch", "help", "about"]],
+            "logo": false
+        },
+        "legend": {
+            "allowImport": false,
+            "isOpen": {
+                "large": true,
+                "medium": false,
+                "small": false
+            }
         }
-      }
-    ],
-    "lodSets": [
-      {
-        "id": "LOD_NRCAN_Lambert_3978",
-        "lods": [
-          {
-            "level": 0,
-            "resolution": 38364.660062653464,
-            "scale": 145000000
-          },
-          {
-            "level": 1,
-            "resolution": 22489.628312589961,
-            "scale": 85000000
-          },
-          {
-            "level": 2,
-            "resolution": 13229.193125052918,
-            "scale": 50000000
-          },
-          {
-            "level": 3,
-            "resolution": 7937.5158750317505,
-            "scale": 30000000
-          },
-          {
-            "level": 4,
-            "resolution": 4630.2175937685215,
-            "scale": 17500000
-          },
-          {
-            "level": 5,
-            "resolution": 2645.8386250105837,
-            "scale": 10000000
-          },
-          {
-            "level": 6,
-            "resolution": 1587.5031750063501,
-            "scale": 6000000
-          },
-          {
-            "level": 7,
-            "resolution": 926.04351875370423,
-            "scale": 3500000
-          },
-          {
-            "level": 8,
-            "resolution": 529.16772500211675,
-            "scale": 2000000
-          },
-          {
-            "level": 9,
-            "resolution": 317.50063500127004,
-            "scale": 1200000
-          },
-          {
-            "level": 10,
-            "resolution": 185.20870375074085,
-            "scale": 700000
-          },
-          {
-            "level": 11,
-            "resolution": 111.12522225044451,
-            "scale": 420000
-          },
-          {
-            "level": 12,
-            "resolution": 66.1459656252646,
-            "scale": 250000
-          },
-          {
-            "level": 13,
-            "resolution": 38.364660062653464,
-            "scale": 145000
-          },
-          {
-            "level": 14,
-            "resolution": 22.489628312589961,
-            "scale": 85000
-          },
-          {
-            "level": 15,
-            "resolution": 13.229193125052918,
-            "scale": 50000
-          },
-          {
-            "level": 16,
-            "resolution": 7.9375158750317505,
-            "scale": 30000
-          },
-          {
-            "level": 17,
-            "resolution": 4.6302175937685215,
-            "scale": 17500
-          }
-        ]
-      },
-      {
-        "id": "LOD_ESRI_World_AuxMerc_3857",
-        "lods": [
-          {
-            "level": 0,
-            "resolution": 19567.879240999919,
-            "scale": 73957190.948944
-          },
-          {
-            "level": 1,
-            "resolution": 9783.93962049996,
-            "scale": 36978595.474472
-          },
-          {
-            "level": 2,
-            "resolution": 4891.96981024998,
-            "scale": 18489297.737236
-          },
-          {
-            "level": 3,
-            "resolution": 2445.98490512499,
-            "scale": 9244648.868618
-          },
-          {
-            "level": 4,
-            "resolution": 1222.9924525624949,
-            "scale": 4622324.434309
-          },
-          {
-            "level": 5,
-            "resolution": 611.49622628137968,
-            "scale": 2311162.217155
-          },
-          {
-            "level": 6,
-            "resolution": 305.74811314055756,
-            "scale": 1155581.108577
-          },
-          {
-            "level": 7,
-            "resolution": 152.87405657041106,
-            "scale": 577790.554289
-          },
-          {
-            "level": 8,
-            "resolution": 76.437028285073239,
-            "scale": 288895.277144
-          },
-          {
-            "level": 9,
-            "resolution": 38.21851414253662,
-            "scale": 144447.638572
-          },
-          {
-            "level": 10,
-            "resolution": 19.10925707126831,
-            "scale": 72223.819286
-          },
-          {
-            "level": 11,
-            "resolution": 9.5546285356341549,
-            "scale": 36111.909643
-          },
-          {
-            "level": 12,
-            "resolution": 4.77731426794937,
-            "scale": 18055.954822
-          },
-          {
-            "level": 13,
-            "resolution": 2.3886571339746849,
-            "scale": 9027.977411
-          },
-          {
-            "level": 14,
-            "resolution": 1.1943285668550503,
-            "scale": 4513.988705
-          },
-          {
-            "level": 15,
-            "resolution": 0.59716428355981721,
-            "scale": 2256.994353
-          },
-          {
-            "level": 16,
-            "resolution": 0.29858214164761665,
-            "scale": 1128.497176
-          },
-          {
-            "level": 17,
-            "resolution": 0.14929107082380833,
-            "scale": 564.248588
-          },
-          {
-            "level": 18,
-            "resolution": 0.074645535411904163,
-            "scale": 282.124294
-          },
-          {
-            "level": 19,
-            "resolution": 0.037322767705952081,
-            "scale": 141.062147
-          },
-          {
-            "level": 20,
-            "resolution": 0.018661383852976041,
-            "scale": 70.5310735
-          }
-        ]
-      }
-    ],
-    "legend": {
-      "type": "structured",
-      "root": {
-        "name": "root",
-        "children": [
-          {
-            "layerId": "Total_Releases2019",
-            "description": "Total releases of ethylene glycol per facility for 2019 (tonnes)",
-            "symbologyExpanded": true
-          }
-        ]
-      }
     },
-    "layers": [
-      {
-        "id": "Total_Releases2019",
-        "name": "Total releases of ethylene glycol",
-        "layerType": "esriFeature",
-        "singleEntryCollapse": true,
-        "symbologyExpanded": true,
-        "tolerance": 20,
-        "url": "https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/StoryRAMP/ea24000c_7dc3_49a9_baac_c55d28dcaeb9/MapServer/1",
-        "state": {
-          "opacity": 0.75
-        } 
-      }
-    ],
-    "tileSchemas": [
-      {
-        "id": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978",
-        "name": "Lambert Maps",
-        "extentSetId": "EXT_NRCAN_Lambert_3978",
-        "lodSetId": "LOD_NRCAN_Lambert_3978",
-        "hasNorthPole": true
-      },
-      {
-        "id": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857",
-        "name": "Web Mercator Maps",
-        "extentSetId": "EXT_ESRI_World_AuxMerc_3857",
-        "lodSetId": "LOD_ESRI_World_AuxMerc_3857"
-      }
-    ],
-    "baseMaps": [
-      {
-        "id": "baseNrCan",
-        "name": "Canada Base Map - Transportation (CBMT)",
-        "description": "The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.",
-        "altText": "altText - The Canada Base Map - Transportation (CBMT)",
-        "layers": [
-          {
-            "id": "CBMT",
-            "layerType": "esriFeature",
-            "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer"
-          }
+    "services": {
+        "proxyUrl": "http://167.40.64.74/wmsproxy/ws/wmsproxy/executeFromProxy",
+        "exportMapUrl": "https://maps-cartes.dev.ec.gc.ca/arcgis/rest/services/Utilities/PrintingTools/GPServer/Export%20Web%20Map%20Task",
+        "export": {
+            "title": {
+                "value": "Total releases of ethylene glycol per facility for 2019"
+            },
+            "map": {},
+            "mapElements": {},
+            "legend": {},
+            "footnote": {
+                "value": "Total releases of ethylene glycol per facility for 2019"
+            }
+        },
+        "search": {
+            "settings": {
+                "categories": [
+                    "CITY",
+                    "HAM",
+                    "IR",
+                    "LTM",
+                    "MUN1",
+                    "MUN2",
+                    "PROV",
+                    "STM",
+                    "TERR",
+                    "TOWN",
+                    "UTM",
+                    "VILG",
+                    "UNP"
+                ],
+                "sortOrder": [
+                    "CITY",
+                    "HAM",
+                    "IR",
+                    "LTM",
+                    "MUN1",
+                    "MUN2",
+                    "PROV",
+                    "STM",
+                    "TERR",
+                    "TOWN",
+                    "UTM",
+                    "VILG",
+                    "UNP"
+                ],
+                "maxResults": 1000,
+                "officialOnly": true
+            },
+            "serviceUrls": {
+                "geoNames": "https://geogratis.gc.ca/services/geoname/en/geonames.json",
+                "geoLocation": "https://geogratis.gc.ca/services/geolocation/en/locate?q=",
+                "geoSuggest": "https://geogratis.gc.ca/services/geolocation/en/suggest?q=",
+                "provinces": "https://geogratis.gc.ca/services/geoname/en/codes/province.json",
+                "types": "https://geogratis.gc.ca/services/geoname/en/codes/concise.json"
+            }
+        }
+    },
+    "map": {
+        "initialBasemapId": "baseNrCan",
+        "components": {
+            "geoSearch": {
+                "enabled": true,
+                "showGraphic": true,
+                "showInfo": true
+            },
+            "mouseInfo": {
+                "enabled": true,
+                "spatialReference": {
+                    "wkid": 4326
+                }
+            },
+            "northArrow": {
+                "enabled": false
+            },
+            "basemap": {
+                "enabled": true
+            },
+            "overviewMap": {
+                "enabled": true,
+                "layerType": "imagery"
+            },
+            "scaleBar": {
+                "enabled": true
+            }
+        },
+        "extentSets": [
+            {
+                "id": "EXT_NRCAN_Lambert_3978",
+                "default": {
+                    "xmax": 2349492,
+                    "xmin": -5781457,
+                    "ymax": 4482193,
+                    "ymin": -983440
+                },
+                "spatialReference": {
+                    "wkid": 3978
+                }
+            },
+            {
+                "id": "EXT_ESRI_World_AuxMerc_3857",
+                "default": {
+                    "xmax": -5507771.626060756,
+                    "xmin": -17332697.354854,
+                    "ymax": 10015875.184845109,
+                    "ymin": 5022907.964742964
+                },
+                "spatialReference": {
+                    "wkid": 102100,
+                    "latestWkid": 3857
+                }
+            }
         ],
-        "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
-      },
-      {
-        "id": "baseSimple",
-        "name": "Canada Base Map - Simple",
-        "description": "Canada Base Map - Simple",
-        "altText": "altText - Canada base map - Simple",
-        "layers": [
-          {
-            "id": "SMR",
-            "layerType": "esriFeature",
-            "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer"
-          }
+        "lodSets": [
+            {
+                "id": "LOD_NRCAN_Lambert_3978",
+                "lods": [
+                    {
+                        "level": 0,
+                        "resolution": 38364.660062653464,
+                        "scale": 145000000
+                    },
+                    {
+                        "level": 1,
+                        "resolution": 22489.628312589961,
+                        "scale": 85000000
+                    },
+                    {
+                        "level": 2,
+                        "resolution": 13229.193125052918,
+                        "scale": 50000000
+                    },
+                    {
+                        "level": 3,
+                        "resolution": 7937.5158750317505,
+                        "scale": 30000000
+                    },
+                    {
+                        "level": 4,
+                        "resolution": 4630.2175937685215,
+                        "scale": 17500000
+                    },
+                    {
+                        "level": 5,
+                        "resolution": 2645.8386250105837,
+                        "scale": 10000000
+                    },
+                    {
+                        "level": 6,
+                        "resolution": 1587.5031750063501,
+                        "scale": 6000000
+                    },
+                    {
+                        "level": 7,
+                        "resolution": 926.04351875370423,
+                        "scale": 3500000
+                    },
+                    {
+                        "level": 8,
+                        "resolution": 529.16772500211675,
+                        "scale": 2000000
+                    },
+                    {
+                        "level": 9,
+                        "resolution": 317.50063500127004,
+                        "scale": 1200000
+                    },
+                    {
+                        "level": 10,
+                        "resolution": 185.20870375074085,
+                        "scale": 700000
+                    },
+                    {
+                        "level": 11,
+                        "resolution": 111.12522225044451,
+                        "scale": 420000
+                    },
+                    {
+                        "level": 12,
+                        "resolution": 66.1459656252646,
+                        "scale": 250000
+                    },
+                    {
+                        "level": 13,
+                        "resolution": 38.364660062653464,
+                        "scale": 145000
+                    },
+                    {
+                        "level": 14,
+                        "resolution": 22.489628312589961,
+                        "scale": 85000
+                    },
+                    {
+                        "level": 15,
+                        "resolution": 13.229193125052918,
+                        "scale": 50000
+                    },
+                    {
+                        "level": 16,
+                        "resolution": 7.9375158750317505,
+                        "scale": 30000
+                    },
+                    {
+                        "level": 17,
+                        "resolution": 4.6302175937685215,
+                        "scale": 17500
+                    }
+                ]
+            },
+            {
+                "id": "LOD_ESRI_World_AuxMerc_3857",
+                "lods": [
+                    {
+                        "level": 0,
+                        "resolution": 19567.879240999919,
+                        "scale": 73957190.948944
+                    },
+                    {
+                        "level": 1,
+                        "resolution": 9783.93962049996,
+                        "scale": 36978595.474472
+                    },
+                    {
+                        "level": 2,
+                        "resolution": 4891.96981024998,
+                        "scale": 18489297.737236
+                    },
+                    {
+                        "level": 3,
+                        "resolution": 2445.98490512499,
+                        "scale": 9244648.868618
+                    },
+                    {
+                        "level": 4,
+                        "resolution": 1222.9924525624949,
+                        "scale": 4622324.434309
+                    },
+                    {
+                        "level": 5,
+                        "resolution": 611.49622628137968,
+                        "scale": 2311162.217155
+                    },
+                    {
+                        "level": 6,
+                        "resolution": 305.74811314055756,
+                        "scale": 1155581.108577
+                    },
+                    {
+                        "level": 7,
+                        "resolution": 152.87405657041106,
+                        "scale": 577790.554289
+                    },
+                    {
+                        "level": 8,
+                        "resolution": 76.437028285073239,
+                        "scale": 288895.277144
+                    },
+                    {
+                        "level": 9,
+                        "resolution": 38.21851414253662,
+                        "scale": 144447.638572
+                    },
+                    {
+                        "level": 10,
+                        "resolution": 19.10925707126831,
+                        "scale": 72223.819286
+                    },
+                    {
+                        "level": 11,
+                        "resolution": 9.5546285356341549,
+                        "scale": 36111.909643
+                    },
+                    {
+                        "level": 12,
+                        "resolution": 4.77731426794937,
+                        "scale": 18055.954822
+                    },
+                    {
+                        "level": 13,
+                        "resolution": 2.3886571339746849,
+                        "scale": 9027.977411
+                    },
+                    {
+                        "level": 14,
+                        "resolution": 1.1943285668550503,
+                        "scale": 4513.988705
+                    },
+                    {
+                        "level": 15,
+                        "resolution": 0.59716428355981721,
+                        "scale": 2256.994353
+                    },
+                    {
+                        "level": 16,
+                        "resolution": 0.29858214164761665,
+                        "scale": 1128.497176
+                    },
+                    {
+                        "level": 17,
+                        "resolution": 0.14929107082380833,
+                        "scale": 564.248588
+                    },
+                    {
+                        "level": 18,
+                        "resolution": 0.074645535411904163,
+                        "scale": 282.124294
+                    },
+                    {
+                        "level": 19,
+                        "resolution": 0.037322767705952081,
+                        "scale": 141.062147
+                    },
+                    {
+                        "level": 20,
+                        "resolution": 0.018661383852976041,
+                        "scale": 70.5310735
+                    }
+                ]
+            }
         ],
-        "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
-      },
-      {
-        "id": "baseCBME_CBCE_HS_RO_3978",
-        "name": "Canada Base Map - Elevation (CBME)",
-        "description": "The Canada Base Map - Elevation (CBME) web mapping services of the Earth Sciences Sector at Natural Resources Canada, is intended primarily for online mapping application users and developers.",
-        "altText": "altText - Canada Base Map - Elevation (CBME)",
+        "legend": {
+            "type": "structured",
+            "root": {
+                "name": "root",
+                "children": [
+                    {
+                        "layerId": "Total_Releases2019",
+                        "description": "Total releases of ethylene glycol per facility for 2019 (tonnes)",
+                        "symbologyExpanded": true
+                    }
+                ]
+            }
+        },
         "layers": [
-          {
-            "id": "CBME_CBCE_HS_RO_3978",
-            "layerType": "esriFeature",
-            "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer"
-          }
+            {
+                "id": "Total_Releases2019",
+                "name": "Total releases of ethylene glycol",
+                "layerType": "esriFeature",
+                "singleEntryCollapse": true,
+                "symbologyExpanded": true,
+                "tolerance": 20,
+                "url": "https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/StoryRAMP/ea24000c_7dc3_49a9_baac_c55d28dcaeb9/MapServer/1",
+                "state": {
+                    "opacity": 0.75
+                }
+            }
         ],
-        "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
-      },
-      {
-        "id": "baseCBMT_CBCT_GEOM_3978",
-        "name": "Canada Base Map - Transportation (CBMT)",
-        "description": " The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.",
-        "altText": "altText - Canada Base Map - Transportation (CBMT)",
-        "layers": [
-          {
-            "id": "CBMT_CBCT_GEOM_3978",
-            "layerType": "esriFeature",
-            "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer"
-          }
+        "tileSchemas": [
+            {
+                "id": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978",
+                "name": "Lambert Maps",
+                "extentSetId": "EXT_NRCAN_Lambert_3978",
+                "lodSetId": "LOD_NRCAN_Lambert_3978",
+                "hasNorthPole": true
+            },
+            {
+                "id": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857",
+                "name": "Web Mercator Maps",
+                "extentSetId": "EXT_ESRI_World_AuxMerc_3857",
+                "lodSetId": "LOD_ESRI_World_AuxMerc_3857"
+            }
         ],
-        "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
-      },
-      {
-        "id": "baseEsriWorld",
-        "name": "World Imagery",
-        "description": "World Imagery provides one meter or better satellite and aerial imagery in many parts of the world and lower resolution satellite imagery worldwide.",
-        "altText": "altText - World Imagery",
-        "layers": [
-          {
-            "id": "World_Imagery",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      },
-      {
-        "id": "baseEsriPhysical",
-        "name": "World Physical Map",
-        "description": "This map presents the Natural Earth physical map at 1.24km per pixel for the world and 500m for the coterminous United States.",
-        "altText": "altText - World Physical Map",
-        "layers": [
-          {
-            "id": "World_Physical_Map",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Physical_Map/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      },
-      {
-        "id": "baseEsriRelief",
-        "name": "World Shaded Relief",
-        "description": "This map portrays surface elevation as shaded relief. This map is used as a basemap layer to add shaded relief to other GIS maps, such as the ArcGIS Online World Street Map.",
-        "altText": "altText - World Shaded Relief",
-        "layers": [
-          {
-            "id": "World_Shaded_Relief",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Shaded_Relief/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      },
-      {
-        "id": "baseEsriStreet",
-        "name": "World Street Map",
-        "description": "This worldwide street map presents highway-level data for the world.",
-        "altText": "altText - ESWorld Street Map",
-        "layers": [
-          {
-            "id": "World_Street_Map",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Street_Map/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      },
-      {
-        "id": "baseEsriTerrain",
-        "name": "World Terrain Base",
-        "description": "This map is designed to be used as a base map by GIS professionals to overlay other thematic layers such as demographics or land cover.",
-        "altText": "altText - World Terrain Base",
-        "layers": [
-          {
-            "id": "World_Terrain_Base",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Terrain_Base/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      },
-      {
-        "id": "baseEsriTopo",
-        "name": "World Topographic Map",
-        "description": "This map is designed to be used as a basemap by GIS professionals and as a reference map by anyone.",
-        "altText": "altText - World Topographic Map",
-        "layers": [
-          {
-            "id": "World_Topo_Map",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      }
-    ]
-  }
+        "baseMaps": [
+            {
+                "id": "baseNrCan",
+                "name": "Canada Base Map - Transportation (CBMT)",
+                "description": "The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.",
+                "altText": "altText - The Canada Base Map - Transportation (CBMT)",
+                "layers": [
+                    {
+                        "id": "CBMT",
+                        "layerType": "esriFeature",
+                        "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+            },
+            {
+                "id": "baseSimple",
+                "name": "Canada Base Map - Simple",
+                "description": "Canada Base Map - Simple",
+                "altText": "altText - Canada base map - Simple",
+                "layers": [
+                    {
+                        "id": "SMR",
+                        "layerType": "esriFeature",
+                        "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+            },
+            {
+                "id": "baseCBME_CBCE_HS_RO_3978",
+                "name": "Canada Base Map - Elevation (CBME)",
+                "description": "The Canada Base Map - Elevation (CBME) web mapping services of the Earth Sciences Sector at Natural Resources Canada, is intended primarily for online mapping application users and developers.",
+                "altText": "altText - Canada Base Map - Elevation (CBME)",
+                "layers": [
+                    {
+                        "id": "CBME_CBCE_HS_RO_3978",
+                        "layerType": "esriFeature",
+                        "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+            },
+            {
+                "id": "baseCBMT_CBCT_GEOM_3978",
+                "name": "Canada Base Map - Transportation (CBMT)",
+                "description": " The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.",
+                "altText": "altText - Canada Base Map - Transportation (CBMT)",
+                "layers": [
+                    {
+                        "id": "CBMT_CBCT_GEOM_3978",
+                        "layerType": "esriFeature",
+                        "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+            },
+            {
+                "id": "baseEsriWorld",
+                "name": "World Imagery",
+                "description": "World Imagery provides one meter or better satellite and aerial imagery in many parts of the world and lower resolution satellite imagery worldwide.",
+                "altText": "altText - World Imagery",
+                "layers": [
+                    {
+                        "id": "World_Imagery",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriPhysical",
+                "name": "World Physical Map",
+                "description": "This map presents the Natural Earth physical map at 1.24km per pixel for the world and 500m for the coterminous United States.",
+                "altText": "altText - World Physical Map",
+                "layers": [
+                    {
+                        "id": "World_Physical_Map",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Physical_Map/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriRelief",
+                "name": "World Shaded Relief",
+                "description": "This map portrays surface elevation as shaded relief. This map is used as a basemap layer to add shaded relief to other GIS maps, such as the ArcGIS Online World Street Map.",
+                "altText": "altText - World Shaded Relief",
+                "layers": [
+                    {
+                        "id": "World_Shaded_Relief",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Shaded_Relief/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriStreet",
+                "name": "World Street Map",
+                "description": "This worldwide street map presents highway-level data for the world.",
+                "altText": "altText - ESWorld Street Map",
+                "layers": [
+                    {
+                        "id": "World_Street_Map",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Street_Map/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriTerrain",
+                "name": "World Terrain Base",
+                "description": "This map is designed to be used as a base map by GIS professionals to overlay other thematic layers such as demographics or land cover.",
+                "altText": "altText - World Terrain Base",
+                "layers": [
+                    {
+                        "id": "World_Terrain_Base",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Terrain_Base/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriTopo",
+                "name": "World Topographic Map",
+                "description": "This map is designed to be used as a basemap by GIS professionals and as a reference map by anyone.",
+                "altText": "altText - World Topographic Map",
+                "layers": [
+                    {
+                        "id": "World_Topo_Map",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            }
+        ]
+    }
 }

--- a/public/ea24000c-7dc3-49a9-baac-c55d28dcaeb9/ramp-config/fr/total_quantities2019.json
+++ b/public/ea24000c-7dc3-49a9-baac-c55d28dcaeb9/ramp-config/fr/total_quantities2019.json
@@ -1,553 +1,540 @@
 {
-  "version": "2.0",
-  "language": "fr",
-  "ui": {
-    "title": "Carte interactive",
-    "fullscreen": true,
-    "navBar": {
-      "zoom": "buttons",
-      "extra": [
-        "fullscreen",
-        "geoLocator",
-        "home",
-        "help"
-      ]
-    },
-    "appBar": {
-      "basemap": true
-    },
-    "help": {
-      "folderName": "default"
-    },
-    "sideMenu": {
-      "items": [
-        [
-          "fullscreen",
-          "export",
-          "touch",
-          "help",
-          "about"
-        ]
-      ],
-      "logo": false
-    },
-    "legend": {
-      "allowImport": true,
-      "isOpen": {
-        "large": true,
-        "medium": false,
-        "small": false
-      }
-    }
-  },
-  "services": {
-    "proxyUrl": "http://167.40.64.74/wmsproxy/ws/wmsproxy/executeFromProxy",
-    "exportMapUrl": "https://maps-cartes.dev.ec.gc.ca/arcgis/rest/services/Utilities/PrintingTools/GPServer/Export%20Web%20Map%20Task",
-    "export": {
-      "title": {
-        "value": "Quantités totales d’éthylène glycol éliminées et recyclées par des installations en 2019"
-      },
-      "map": {},
-      "mapElements": {},
-      "legend": {},
-      "footnote": {
-        "value": "Quantités totales d’éthylène glycol éliminées et recyclées par des installations en 2019"
-      }
-    },
-    "search": {
-      "settings": {
-        "categories": [
-          "CITY",
-          "HAM",
-          "IR",
-          "LTM",
-          "MUN1",
-          "MUN2",
-          "PROV",
-          "STM",
-          "TERR",
-          "TOWN",
-          "UTM",
-          "VILG",
-          "UNP"
-        ],
-        "sortOrder": [
-          "CITY",
-          "HAM",
-          "IR",
-          "LTM",
-          "MUN1",
-          "MUN2",
-          "PROV",
-          "STM",
-          "TERR",
-          "TOWN",
-          "UTM",
-          "VILG",
-          "UNP"
-        ],
-        "maxResults": 1000,
-        "officialOnly": true
-      },
-      "serviceUrls": {
-        "geoNames": "https://geogratis.gc.ca/services/geoname/en/geonames.json",
-        "geoLocation": "https://geogratis.gc.ca/services/geolocation/en/locate?q=",
-        "geoSuggest": "https://geogratis.gc.ca/services/geolocation/en/suggest?q=",
-        "provinces": "https://geogratis.gc.ca/services/geoname/en/codes/province.json",
-        "types": "https://geogratis.gc.ca/services/geoname/en/codes/concise.json"
-      }
-    }
-  },
-  "map": {
-    "initialBasemapId": "baseNrCan",
-    "components": {
-      "geoSearch": {
-        "enabled": true,
-        "showGraphic": true,
-        "showInfo": true
-      },
-      "mouseInfo": {
-        "enabled": true,
-        "spatialReference": {
-          "wkid": 4326
-        }
-      },
-      "northArrow": {
-        "enabled": false
-      },
-      "basemap": {
-        "enabled": true
-      },
-      "overviewMap": {
-        "enabled": true,
-        "layerType": "imagery"
-      },
-      "scaleBar": {
-        "enabled": true
-      }
-    },
-    "extentSets": [
-      {
-        "id": "EXT_NRCAN_Lambert_3978",
-        "default": {
-          "xmax": 2849492,
-          "xmin": -5281457,
-          "ymax": 4482193,
-          "ymin": -983440
+    "version": "2.0",
+    "language": "fr",
+    "ui": {
+        "title": "Carte interactive",
+        "fullscreen": true,
+        "navBar": {
+            "zoom": "buttons",
+            "extra": ["fullscreen", "geoLocator", "home", "help"]
         },
-        "spatialReference": {
-          "wkid": 3978
-        }
-      },
-      {
-        "id": "EXT_ESRI_World_AuxMerc_3857",
-        "default": {
-          "xmax": -5007771.626060756,
-          "xmin": -16632697.354854,
-          "ymax": 10015875.184845109,
-          "ymin": 5022907.964742964
+        "appBar": {
+            "basemap": true
         },
-        "spatialReference": {
-          "wkid": 102100,
-          "latestWkid": 3857
+        "help": {
+            "folderName": "default"
+        },
+        "sideMenu": {
+            "items": [["fullscreen", "export", "touch", "help", "about"]],
+            "logo": false
+        },
+        "legend": {
+            "allowImport": true,
+            "isOpen": {
+                "large": true,
+                "medium": false,
+                "small": false
+            }
         }
-      }
-    ],
-    "lodSets": [
-      {
-        "id": "LOD_NRCAN_Lambert_3978",
-        "lods": [
-          {
-            "level": 0,
-            "resolution": 38364.660062653464,
-            "scale": 145000000
-          },
-          {
-            "level": 1,
-            "resolution": 22489.628312589961,
-            "scale": 85000000
-          },
-          {
-            "level": 2,
-            "resolution": 13229.193125052918,
-            "scale": 50000000
-          },
-          {
-            "level": 3,
-            "resolution": 7937.5158750317505,
-            "scale": 30000000
-          },
-          {
-            "level": 4,
-            "resolution": 4630.2175937685215,
-            "scale": 17500000
-          },
-          {
-            "level": 5,
-            "resolution": 2645.8386250105837,
-            "scale": 10000000
-          },
-          {
-            "level": 6,
-            "resolution": 1587.5031750063501,
-            "scale": 6000000
-          },
-          {
-            "level": 7,
-            "resolution": 926.04351875370423,
-            "scale": 3500000
-          },
-          {
-            "level": 8,
-            "resolution": 529.16772500211675,
-            "scale": 2000000
-          },
-          {
-            "level": 9,
-            "resolution": 317.50063500127004,
-            "scale": 1200000
-          },
-          {
-            "level": 10,
-            "resolution": 185.20870375074085,
-            "scale": 700000
-          },
-          {
-            "level": 11,
-            "resolution": 111.12522225044451,
-            "scale": 420000
-          },
-          {
-            "level": 12,
-            "resolution": 66.1459656252646,
-            "scale": 250000
-          },
-          {
-            "level": 13,
-            "resolution": 38.364660062653464,
-            "scale": 145000
-          },
-          {
-            "level": 14,
-            "resolution": 22.489628312589961,
-            "scale": 85000
-          },
-          {
-            "level": 15,
-            "resolution": 13.229193125052918,
-            "scale": 50000
-          },
-          {
-            "level": 16,
-            "resolution": 7.9375158750317505,
-            "scale": 30000
-          },
-          {
-            "level": 17,
-            "resolution": 4.6302175937685215,
-            "scale": 17500
-          }
-        ]
-      },
-      {
-        "id": "LOD_ESRI_World_AuxMerc_3857",
-        "lods": [
-          {
-            "level": 0,
-            "resolution": 19567.879240999919,
-            "scale": 73957190.948944
-          },
-          {
-            "level": 1,
-            "resolution": 9783.93962049996,
-            "scale": 36978595.474472
-          },
-          {
-            "level": 2,
-            "resolution": 4891.96981024998,
-            "scale": 18489297.737236
-          },
-          {
-            "level": 3,
-            "resolution": 2445.98490512499,
-            "scale": 9244648.868618
-          },
-          {
-            "level": 4,
-            "resolution": 1222.9924525624949,
-            "scale": 4622324.434309
-          },
-          {
-            "level": 5,
-            "resolution": 611.49622628137968,
-            "scale": 2311162.217155
-          },
-          {
-            "level": 6,
-            "resolution": 305.74811314055756,
-            "scale": 1155581.108577
-          },
-          {
-            "level": 7,
-            "resolution": 152.87405657041106,
-            "scale": 577790.554289
-          },
-          {
-            "level": 8,
-            "resolution": 76.437028285073239,
-            "scale": 288895.277144
-          },
-          {
-            "level": 9,
-            "resolution": 38.21851414253662,
-            "scale": 144447.638572
-          },
-          {
-            "level": 10,
-            "resolution": 19.10925707126831,
-            "scale": 72223.819286
-          },
-          {
-            "level": 11,
-            "resolution": 9.5546285356341549,
-            "scale": 36111.909643
-          },
-          {
-            "level": 12,
-            "resolution": 4.77731426794937,
-            "scale": 18055.954822
-          },
-          {
-            "level": 13,
-            "resolution": 2.3886571339746849,
-            "scale": 9027.977411
-          },
-          {
-            "level": 14,
-            "resolution": 1.1943285668550503,
-            "scale": 4513.988705
-          },
-          {
-            "level": 15,
-            "resolution": 0.59716428355981721,
-            "scale": 2256.994353
-          },
-          {
-            "level": 16,
-            "resolution": 0.29858214164761665,
-            "scale": 1128.497176
-          },
-          {
-            "level": 17,
-            "resolution": 0.14929107082380833,
-            "scale": 564.248588
-          },
-          {
-            "level": 18,
-            "resolution": 0.074645535411904163,
-            "scale": 282.124294
-          },
-          {
-            "level": 19,
-            "resolution": 0.037322767705952081,
-            "scale": 141.062147
-          },
-          {
-            "level": 20,
-            "resolution": 0.018661383852976041,
-            "scale": 70.5310735
-          }
-        ]
-      }
-    ],
-    "legend": {
-      "type": "structured",
-      "root": {
-        "name": "root",
-        "children": [
-          {
-            "layerId": "Total_Quantities2019",
-            "description": "Quantités totales d’éthylène glycol éliminées et recyclées par des installations en 2019 (tonnes)",
-            "symbologyExpanded": true
-          }
-        ]
-      }
     },
-    "layers": [
-      {
-        "id": "Total_Quantities2019",
-        "name": "Quantités totales d’éthylène glycol",
-        "layerType": "esriFeature",
-        "singleEntryCollapse": true,
-        "symbologyExpanded": true,
-        "tolerance": 20,
-        "url": "https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/StoryRAMP/ea24000c_7dc3_49a9_baac_c55d28dcaeb9/MapServer/6",
-        "state": {
-          "opacity": 0.75
-        } 
-      }
-    ],
-    "tileSchemas": [
-      {
-        "id": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978",
-        "name": "Lambert Maps",
-        "extentSetId": "EXT_NRCAN_Lambert_3978",
-        "lodSetId": "LOD_NRCAN_Lambert_3978",
-        "hasNorthPole": true
-      },
-      {
-        "id": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857",
-        "name": "Web Mercator Maps",
-        "extentSetId": "EXT_ESRI_World_AuxMerc_3857",
-        "lodSetId": "LOD_ESRI_World_AuxMerc_3857"
-      }
-    ],
-    "baseMaps": [
-      {
-        "id": "baseNrCan",
-        "name": "Carte de base du Canada – transport (CBCT) avec étiquettes",
-        "description": "La carte de base du Canada – transport (CBCT) du Secteur des sciences de la Terre de Ressources naturelles Canada est un service Internet qui s'adresse principalement aux utilisateurs et développeurs d'applications cartographiques en ligne.",
-        "altText": "altText - La carte de base du Canada – transport (CBCT)",
-        "layers": [
-          {
-            "id": "CBCT",
-            "layerType": "esriFeature",
-            "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBCT3978/MapServer"
-          }
+    "services": {
+        "proxyUrl": "http://167.40.64.74/wmsproxy/ws/wmsproxy/executeFromProxy",
+        "exportMapUrl": "https://maps-cartes.dev.ec.gc.ca/arcgis/rest/services/Utilities/PrintingTools/GPServer/Export%20Web%20Map%20Task",
+        "export": {
+            "title": {
+                "value": "Quantités totales d’éthylène glycol éliminées et recyclées par des installations en 2019"
+            },
+            "map": {},
+            "mapElements": {},
+            "legend": {},
+            "footnote": {
+                "value": "Quantités totales d’éthylène glycol éliminées et recyclées par des installations en 2019"
+            }
+        },
+        "search": {
+            "settings": {
+                "categories": [
+                    "CITY",
+                    "HAM",
+                    "IR",
+                    "LTM",
+                    "MUN1",
+                    "MUN2",
+                    "PROV",
+                    "STM",
+                    "TERR",
+                    "TOWN",
+                    "UTM",
+                    "VILG",
+                    "UNP"
+                ],
+                "sortOrder": [
+                    "CITY",
+                    "HAM",
+                    "IR",
+                    "LTM",
+                    "MUN1",
+                    "MUN2",
+                    "PROV",
+                    "STM",
+                    "TERR",
+                    "TOWN",
+                    "UTM",
+                    "VILG",
+                    "UNP"
+                ],
+                "maxResults": 1000,
+                "officialOnly": true
+            },
+            "serviceUrls": {
+                "geoNames": "https://geogratis.gc.ca/services/geoname/en/geonames.json",
+                "geoLocation": "https://geogratis.gc.ca/services/geolocation/en/locate?q=",
+                "geoSuggest": "https://geogratis.gc.ca/services/geolocation/en/suggest?q=",
+                "provinces": "https://geogratis.gc.ca/services/geoname/en/codes/province.json",
+                "types": "https://geogratis.gc.ca/services/geoname/en/codes/concise.json"
+            }
+        }
+    },
+    "map": {
+        "initialBasemapId": "baseNrCan",
+        "components": {
+            "geoSearch": {
+                "enabled": true,
+                "showGraphic": true,
+                "showInfo": true
+            },
+            "mouseInfo": {
+                "enabled": true,
+                "spatialReference": {
+                    "wkid": 4326
+                }
+            },
+            "northArrow": {
+                "enabled": false
+            },
+            "basemap": {
+                "enabled": true
+            },
+            "overviewMap": {
+                "enabled": true,
+                "layerType": "imagery"
+            },
+            "scaleBar": {
+                "enabled": true
+            }
+        },
+        "extentSets": [
+            {
+                "id": "EXT_NRCAN_Lambert_3978",
+                "default": {
+                    "xmax": 2349492,
+                    "xmin": -5781457,
+                    "ymax": 4482193,
+                    "ymin": -983440
+                },
+                "spatialReference": {
+                    "wkid": 3978
+                }
+            },
+            {
+                "id": "EXT_ESRI_World_AuxMerc_3857",
+                "default": {
+                    "xmax": -5007771.626060756,
+                    "xmin": -16632697.354854,
+                    "ymax": 10015875.184845109,
+                    "ymin": 5022907.964742964
+                },
+                "spatialReference": {
+                    "wkid": 102100,
+                    "latestWkid": 3857
+                }
+            }
         ],
-        "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
-      },
-      {
-        "id": "baseSimple",
-        "name": "Carte de base du Canada - simple",
-        "description": "La carte de base du Canada - simple",
-        "altText": "altText - La carte de base du Canada - simple",
-        "layers": [
-          {
-            "id": "SMR",
-            "layerType": "esriFeature",
-            "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer"
-          },
-          {
-            "id": "SMW",
-            "layerType": "esriFeature",
-            "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_TXT_3978/MapServer"
-          }
+        "lodSets": [
+            {
+                "id": "LOD_NRCAN_Lambert_3978",
+                "lods": [
+                    {
+                        "level": 0,
+                        "resolution": 38364.660062653464,
+                        "scale": 145000000
+                    },
+                    {
+                        "level": 1,
+                        "resolution": 22489.628312589961,
+                        "scale": 85000000
+                    },
+                    {
+                        "level": 2,
+                        "resolution": 13229.193125052918,
+                        "scale": 50000000
+                    },
+                    {
+                        "level": 3,
+                        "resolution": 7937.5158750317505,
+                        "scale": 30000000
+                    },
+                    {
+                        "level": 4,
+                        "resolution": 4630.2175937685215,
+                        "scale": 17500000
+                    },
+                    {
+                        "level": 5,
+                        "resolution": 2645.8386250105837,
+                        "scale": 10000000
+                    },
+                    {
+                        "level": 6,
+                        "resolution": 1587.5031750063501,
+                        "scale": 6000000
+                    },
+                    {
+                        "level": 7,
+                        "resolution": 926.04351875370423,
+                        "scale": 3500000
+                    },
+                    {
+                        "level": 8,
+                        "resolution": 529.16772500211675,
+                        "scale": 2000000
+                    },
+                    {
+                        "level": 9,
+                        "resolution": 317.50063500127004,
+                        "scale": 1200000
+                    },
+                    {
+                        "level": 10,
+                        "resolution": 185.20870375074085,
+                        "scale": 700000
+                    },
+                    {
+                        "level": 11,
+                        "resolution": 111.12522225044451,
+                        "scale": 420000
+                    },
+                    {
+                        "level": 12,
+                        "resolution": 66.1459656252646,
+                        "scale": 250000
+                    },
+                    {
+                        "level": 13,
+                        "resolution": 38.364660062653464,
+                        "scale": 145000
+                    },
+                    {
+                        "level": 14,
+                        "resolution": 22.489628312589961,
+                        "scale": 85000
+                    },
+                    {
+                        "level": 15,
+                        "resolution": 13.229193125052918,
+                        "scale": 50000
+                    },
+                    {
+                        "level": 16,
+                        "resolution": 7.9375158750317505,
+                        "scale": 30000
+                    },
+                    {
+                        "level": 17,
+                        "resolution": 4.6302175937685215,
+                        "scale": 17500
+                    }
+                ]
+            },
+            {
+                "id": "LOD_ESRI_World_AuxMerc_3857",
+                "lods": [
+                    {
+                        "level": 0,
+                        "resolution": 19567.879240999919,
+                        "scale": 73957190.948944
+                    },
+                    {
+                        "level": 1,
+                        "resolution": 9783.93962049996,
+                        "scale": 36978595.474472
+                    },
+                    {
+                        "level": 2,
+                        "resolution": 4891.96981024998,
+                        "scale": 18489297.737236
+                    },
+                    {
+                        "level": 3,
+                        "resolution": 2445.98490512499,
+                        "scale": 9244648.868618
+                    },
+                    {
+                        "level": 4,
+                        "resolution": 1222.9924525624949,
+                        "scale": 4622324.434309
+                    },
+                    {
+                        "level": 5,
+                        "resolution": 611.49622628137968,
+                        "scale": 2311162.217155
+                    },
+                    {
+                        "level": 6,
+                        "resolution": 305.74811314055756,
+                        "scale": 1155581.108577
+                    },
+                    {
+                        "level": 7,
+                        "resolution": 152.87405657041106,
+                        "scale": 577790.554289
+                    },
+                    {
+                        "level": 8,
+                        "resolution": 76.437028285073239,
+                        "scale": 288895.277144
+                    },
+                    {
+                        "level": 9,
+                        "resolution": 38.21851414253662,
+                        "scale": 144447.638572
+                    },
+                    {
+                        "level": 10,
+                        "resolution": 19.10925707126831,
+                        "scale": 72223.819286
+                    },
+                    {
+                        "level": 11,
+                        "resolution": 9.5546285356341549,
+                        "scale": 36111.909643
+                    },
+                    {
+                        "level": 12,
+                        "resolution": 4.77731426794937,
+                        "scale": 18055.954822
+                    },
+                    {
+                        "level": 13,
+                        "resolution": 2.3886571339746849,
+                        "scale": 9027.977411
+                    },
+                    {
+                        "level": 14,
+                        "resolution": 1.1943285668550503,
+                        "scale": 4513.988705
+                    },
+                    {
+                        "level": 15,
+                        "resolution": 0.59716428355981721,
+                        "scale": 2256.994353
+                    },
+                    {
+                        "level": 16,
+                        "resolution": 0.29858214164761665,
+                        "scale": 1128.497176
+                    },
+                    {
+                        "level": 17,
+                        "resolution": 0.14929107082380833,
+                        "scale": 564.248588
+                    },
+                    {
+                        "level": 18,
+                        "resolution": 0.074645535411904163,
+                        "scale": 282.124294
+                    },
+                    {
+                        "level": 19,
+                        "resolution": 0.037322767705952081,
+                        "scale": 141.062147
+                    },
+                    {
+                        "level": 20,
+                        "resolution": 0.018661383852976041,
+                        "scale": 70.5310735
+                    }
+                ]
+            }
         ],
-        "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
-      },
-      {
-        "id": "baseCBME_CBCE_HS_RO_3978",
-        "name": "Carte de base du Canada - élevation (CBCE)",
-        "description": "La carte de base du Canada - élevation (CBCE) du Secteur des sciences de la Terre de Ressources naturelles Canada est un service Internet qui s'adresse principalement aux utilisateurs et développeurs d'applications cartographiques en ligne.",
-        "altText": "altText - La carte de base du Canada - élevation (CBCE)",
+        "legend": {
+            "type": "structured",
+            "root": {
+                "name": "root",
+                "children": [
+                    {
+                        "layerId": "Total_Quantities2019",
+                        "description": "Quantités totales d’éthylène glycol éliminées et recyclées par des installations en 2019 (tonnes)",
+                        "symbologyExpanded": true
+                    }
+                ]
+            }
+        },
         "layers": [
-          {
-            "id": "CBME_CBCE_HS_RO_3978",
-            "layerType": "esriFeature",
-            "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer"
-          }
+            {
+                "id": "Total_Quantities2019",
+                "name": "Quantités totales d’éthylène glycol",
+                "layerType": "esriFeature",
+                "singleEntryCollapse": true,
+                "symbologyExpanded": true,
+                "tolerance": 20,
+                "url": "https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/StoryRAMP/ea24000c_7dc3_49a9_baac_c55d28dcaeb9/MapServer/6",
+                "state": {
+                    "opacity": 0.75
+                }
+            }
         ],
-        "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
-      },
-      {
-        "id": "baseCBMT_CBCT_GEOM_3978",
-        "name": "Carte de base du Canada - transport (CBCT)",
-        "description": "La carte de base du Canada - transport (CBCT) du Secteur des sciences de la Terre de Ressources naturelles Canada est un service Internet qui s'adresse principalement aux utilisateurs et développeurs d'applications cartographiques en ligne.",
-        "altText": "altText - La carte de base du Canada - transport (CBCT)",
-        "layers": [
-          {
-            "id": "CBMT_CBCT_GEOM_3978",
-            "layerType": "esriFeature",
-            "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer"
-          }
+        "tileSchemas": [
+            {
+                "id": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978",
+                "name": "Lambert Maps",
+                "extentSetId": "EXT_NRCAN_Lambert_3978",
+                "lodSetId": "LOD_NRCAN_Lambert_3978",
+                "hasNorthPole": true
+            },
+            {
+                "id": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857",
+                "name": "Web Mercator Maps",
+                "extentSetId": "EXT_ESRI_World_AuxMerc_3857",
+                "lodSetId": "LOD_ESRI_World_AuxMerc_3857"
+            }
         ],
-        "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
-      },
-      {
-        "id": "baseEsriWorld",
-        "name": "Imagerie mondiale",
-        "description": "L'imagerie mondiale fournit une imagerie satellitaire et aérienne dans de nombreuses régions du monde avec une résolution de 1 mètres et moins et des images satellitaires de résolution inférieure dans le monde entier.",
-        "altText": "altText - L'imagerie mondiale",
-        "layers": [
-          {
-            "id": "World_Imagery",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      },
-      {
-        "id": "baseEsriPhysical",
-        "name": "Monde physique",
-        "description": "La carte du monde physique représente l'aspect physique naturel de la Terre à 1.24 kilomètres par pixel pour le monde et à 500 mètres pour les États-Unis.",
-        "altText": "altText - La carte du monde physique",
-        "layers": [
-          {
-            "id": "World_Physical_Map",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Physical_Map/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      },
-      {
-        "id": "baseEsriRelief",
-        "name": "Monde en relief ombragé",
-        "description": "La carte du monde en relief ombragé représente l'élévation de la surface de la terre comme un relief ombragé. Cette carte est utilisée comme couche de fond afin d'ajouter un relief ombragé à d'autres cartes SIG, comme la carte ArcGIS Online World Street Map.",
-        "altText": "altText - La carte du monde en relief ombragé",
-        "layers": [
-          {
-            "id": "World_Shaded_Relief",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Shaded_Relief/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      },
-      {
-        "id": "baseEsriStreet",
-        "name": "Monde routier",
-        "description": "La carte du monde routier présente des données au niveau des autoroutes pour le monde.",
-        "altText": "altText - La carte du monde routier",
-        "layers": [
-          {
-            "id": "World_Street_Map",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Street_Map/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      },
-      {
-        "id": "baseEsriTerrain",
-        "name": "Monde terrain",
-        "description": "La carte du monde terrain est conçue pour être utilisée comme une carte de base par les professionnels du SIG pour superposer d'autres couches thématiques comme la démographie ou la couverture terrestre.",
-        "altText": "altText - La carte du monde terrain",
-        "layers": [
-          {
-            "id": "World_Terrain_Base",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Terrain_Base/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      },
-      {
-        "id": "baseEsriTopo",
-        "name": "Monde topographique",
-        "description": "La carte du monde topographique est conçue pour être utilisé comme une carte de base par les professionnels du SIG et comme une carte de référence par quiconque.",
-        "altText": "altText - La carte du monde topographique",
-        "layers": [
-          {
-            "id": "World_Topo_Map",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      }
-    ]
-  }
+        "baseMaps": [
+            {
+                "id": "baseNrCan",
+                "name": "Carte de base du Canada – transport (CBCT) avec étiquettes",
+                "description": "La carte de base du Canada – transport (CBCT) du Secteur des sciences de la Terre de Ressources naturelles Canada est un service Internet qui s'adresse principalement aux utilisateurs et développeurs d'applications cartographiques en ligne.",
+                "altText": "altText - La carte de base du Canada – transport (CBCT)",
+                "layers": [
+                    {
+                        "id": "CBCT",
+                        "layerType": "esriFeature",
+                        "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBCT3978/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+            },
+            {
+                "id": "baseSimple",
+                "name": "Carte de base du Canada - simple",
+                "description": "La carte de base du Canada - simple",
+                "altText": "altText - La carte de base du Canada - simple",
+                "layers": [
+                    {
+                        "id": "SMR",
+                        "layerType": "esriFeature",
+                        "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer"
+                    },
+                    {
+                        "id": "SMW",
+                        "layerType": "esriFeature",
+                        "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_TXT_3978/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+            },
+            {
+                "id": "baseCBME_CBCE_HS_RO_3978",
+                "name": "Carte de base du Canada - élevation (CBCE)",
+                "description": "La carte de base du Canada - élevation (CBCE) du Secteur des sciences de la Terre de Ressources naturelles Canada est un service Internet qui s'adresse principalement aux utilisateurs et développeurs d'applications cartographiques en ligne.",
+                "altText": "altText - La carte de base du Canada - élevation (CBCE)",
+                "layers": [
+                    {
+                        "id": "CBME_CBCE_HS_RO_3978",
+                        "layerType": "esriFeature",
+                        "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+            },
+            {
+                "id": "baseCBMT_CBCT_GEOM_3978",
+                "name": "Carte de base du Canada - transport (CBCT)",
+                "description": "La carte de base du Canada - transport (CBCT) du Secteur des sciences de la Terre de Ressources naturelles Canada est un service Internet qui s'adresse principalement aux utilisateurs et développeurs d'applications cartographiques en ligne.",
+                "altText": "altText - La carte de base du Canada - transport (CBCT)",
+                "layers": [
+                    {
+                        "id": "CBMT_CBCT_GEOM_3978",
+                        "layerType": "esriFeature",
+                        "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+            },
+            {
+                "id": "baseEsriWorld",
+                "name": "Imagerie mondiale",
+                "description": "L'imagerie mondiale fournit une imagerie satellitaire et aérienne dans de nombreuses régions du monde avec une résolution de 1 mètres et moins et des images satellitaires de résolution inférieure dans le monde entier.",
+                "altText": "altText - L'imagerie mondiale",
+                "layers": [
+                    {
+                        "id": "World_Imagery",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriPhysical",
+                "name": "Monde physique",
+                "description": "La carte du monde physique représente l'aspect physique naturel de la Terre à 1.24 kilomètres par pixel pour le monde et à 500 mètres pour les États-Unis.",
+                "altText": "altText - La carte du monde physique",
+                "layers": [
+                    {
+                        "id": "World_Physical_Map",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Physical_Map/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriRelief",
+                "name": "Monde en relief ombragé",
+                "description": "La carte du monde en relief ombragé représente l'élévation de la surface de la terre comme un relief ombragé. Cette carte est utilisée comme couche de fond afin d'ajouter un relief ombragé à d'autres cartes SIG, comme la carte ArcGIS Online World Street Map.",
+                "altText": "altText - La carte du monde en relief ombragé",
+                "layers": [
+                    {
+                        "id": "World_Shaded_Relief",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Shaded_Relief/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriStreet",
+                "name": "Monde routier",
+                "description": "La carte du monde routier présente des données au niveau des autoroutes pour le monde.",
+                "altText": "altText - La carte du monde routier",
+                "layers": [
+                    {
+                        "id": "World_Street_Map",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Street_Map/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriTerrain",
+                "name": "Monde terrain",
+                "description": "La carte du monde terrain est conçue pour être utilisée comme une carte de base par les professionnels du SIG pour superposer d'autres couches thématiques comme la démographie ou la couverture terrestre.",
+                "altText": "altText - La carte du monde terrain",
+                "layers": [
+                    {
+                        "id": "World_Terrain_Base",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Terrain_Base/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriTopo",
+                "name": "Monde topographique",
+                "description": "La carte du monde topographique est conçue pour être utilisé comme une carte de base par les professionnels du SIG et comme une carte de référence par quiconque.",
+                "altText": "altText - La carte du monde topographique",
+                "layers": [
+                    {
+                        "id": "World_Topo_Map",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            }
+        ]
+    }
 }

--- a/public/ea24000c-7dc3-49a9-baac-c55d28dcaeb9/ramp-config/fr/total_releases2019.json
+++ b/public/ea24000c-7dc3-49a9-baac-c55d28dcaeb9/ramp-config/fr/total_releases2019.json
@@ -1,553 +1,540 @@
 {
-  "version": "2.0",
-  "language": "fr",
-  "ui": {
-    "title": "Carte interactive",
-    "fullscreen": true,
-    "navBar": {
-      "zoom": "buttons",
-      "extra": [
-        "fullscreen",
-        "geoLocator",
-        "home",
-        "help"
-      ]
-    },
-    "appBar": {
-      "basemap": true
-    },
-    "help": {
-      "folderName": "default"
-    },
-    "sideMenu": {
-      "items": [
-        [
-          "fullscreen",
-          "export",
-          "touch",
-          "help",
-          "about"
-        ]
-      ],
-      "logo": false
-    },
-    "legend": {
-      "allowImport": false,
-      "isOpen": {
-        "large": true,
-        "medium": false,
-        "small": false
-      }
-    }
-  },
-  "services": {
-    "proxyUrl": "http://167.40.64.74/wmsproxy/ws/wmsproxy/executeFromProxy",
-    "exportMapUrl": "https://maps-cartes.dev.ec.gc.ca/arcgis/rest/services/Utilities/PrintingTools/GPServer/Export%20Web%20Map%20Task",
-    "export": {
-      "title": {
-        "value": "Rejets d’éthylène glycol déclarés par les installations de l’INRP dans tous les milieux en 2019"
-      },
-      "map": {},
-      "mapElements": {},
-      "legend": {},
-      "footnote": {
-        "value": "Rejets d’éthylène glycol déclarés par les installations de l’INRP dans tous les milieux en 2019"
-      }
-    },
-    "search": {
-      "settings": {
-        "categories": [
-          "CITY",
-          "HAM",
-          "IR",
-          "LTM",
-          "MUN1",
-          "MUN2",
-          "PROV",
-          "STM",
-          "TERR",
-          "TOWN",
-          "UTM",
-          "VILG",
-          "UNP"
-        ],
-        "sortOrder": [
-          "CITY",
-          "HAM",
-          "IR",
-          "LTM",
-          "MUN1",
-          "MUN2",
-          "PROV",
-          "STM",
-          "TERR",
-          "TOWN",
-          "UTM",
-          "VILG",
-          "UNP"
-        ],
-        "maxResults": 1000,
-        "officialOnly": true
-      },
-      "serviceUrls": {
-        "geoNames": "https://geogratis.gc.ca/services/geoname/fr/geonames.json",
-        "geoLocation": "https://geogratis.gc.ca/services/geolocation/fr/locate?q=",
-        "geoSuggest": "https://geogratis.gc.ca/services/geolocation/fr/suggest?q=",
-        "provinces": "https://geogratis.gc.ca/services/geoname/fr/codes/province.json",
-        "types": "https://geogratis.gc.ca/services/geoname/fr/codes/concise.json"
-      }
-    }
-  },
-  "map": {
-    "initialBasemapId": "baseNrCan",
-    "components": {
-      "geoSearch": {
-        "enabled": true,
-        "showGraphic": true,
-        "showInfo": true
-      },
-      "mouseInfo": {
-        "enabled": true,
-        "spatialReference": {
-          "wkid": 4326
-        }
-      },
-      "northArrow": {
-        "enabled": false
-      },
-      "basemap": {
-        "enabled": true
-      },
-      "overviewMap": {
-        "enabled": true,
-        "layerType": "imagery"
-      },
-      "scaleBar": {
-        "enabled": true
-      }
-    },
-    "extentSets": [
-      {
-        "id": "EXT_NRCAN_Lambert_3978",
-        "default": {
-          "xmax": 2849492,
-          "xmin": -5281457,
-          "ymax": 4482193,
-          "ymin": -983440
+    "version": "2.0",
+    "language": "fr",
+    "ui": {
+        "title": "Carte interactive",
+        "fullscreen": true,
+        "navBar": {
+            "zoom": "buttons",
+            "extra": ["fullscreen", "geoLocator", "home", "help"]
         },
-        "spatialReference": {
-          "wkid": 3978
-        }
-      },
-      {
-        "id": "EXT_ESRI_World_AuxMerc_3857",
-        "default": {
-          "xmax": -5007771.626060756,
-          "xmin": -16632697.354854,
-          "ymax": 10015875.184845109,
-          "ymin": 5022907.964742964
+        "appBar": {
+            "basemap": true
         },
-        "spatialReference": {
-          "wkid": 102100,
-          "latestWkid": 3857
+        "help": {
+            "folderName": "default"
+        },
+        "sideMenu": {
+            "items": [["fullscreen", "export", "touch", "help", "about"]],
+            "logo": false
+        },
+        "legend": {
+            "allowImport": false,
+            "isOpen": {
+                "large": true,
+                "medium": false,
+                "small": false
+            }
         }
-      }
-    ],
-    "lodSets": [
-      {
-        "id": "LOD_NRCAN_Lambert_3978",
-        "lods": [
-          {
-            "level": 0,
-            "resolution": 38364.660062653464,
-            "scale": 145000000
-          },
-          {
-            "level": 1,
-            "resolution": 22489.628312589961,
-            "scale": 85000000
-          },
-          {
-            "level": 2,
-            "resolution": 13229.193125052918,
-            "scale": 50000000
-          },
-          {
-            "level": 3,
-            "resolution": 7937.5158750317505,
-            "scale": 30000000
-          },
-          {
-            "level": 4,
-            "resolution": 4630.2175937685215,
-            "scale": 17500000
-          },
-          {
-            "level": 5,
-            "resolution": 2645.8386250105837,
-            "scale": 10000000
-          },
-          {
-            "level": 6,
-            "resolution": 1587.5031750063501,
-            "scale": 6000000
-          },
-          {
-            "level": 7,
-            "resolution": 926.04351875370423,
-            "scale": 3500000
-          },
-          {
-            "level": 8,
-            "resolution": 529.16772500211675,
-            "scale": 2000000
-          },
-          {
-            "level": 9,
-            "resolution": 317.50063500127004,
-            "scale": 1200000
-          },
-          {
-            "level": 10,
-            "resolution": 185.20870375074085,
-            "scale": 700000
-          },
-          {
-            "level": 11,
-            "resolution": 111.12522225044451,
-            "scale": 420000
-          },
-          {
-            "level": 12,
-            "resolution": 66.1459656252646,
-            "scale": 250000
-          },
-          {
-            "level": 13,
-            "resolution": 38.364660062653464,
-            "scale": 145000
-          },
-          {
-            "level": 14,
-            "resolution": 22.489628312589961,
-            "scale": 85000
-          },
-          {
-            "level": 15,
-            "resolution": 13.229193125052918,
-            "scale": 50000
-          },
-          {
-            "level": 16,
-            "resolution": 7.9375158750317505,
-            "scale": 30000
-          },
-          {
-            "level": 17,
-            "resolution": 4.6302175937685215,
-            "scale": 17500
-          }
-        ]
-      },
-      {
-        "id": "LOD_ESRI_World_AuxMerc_3857",
-        "lods": [
-          {
-            "level": 0,
-            "resolution": 19567.879240999919,
-            "scale": 73957190.948944
-          },
-          {
-            "level": 1,
-            "resolution": 9783.93962049996,
-            "scale": 36978595.474472
-          },
-          {
-            "level": 2,
-            "resolution": 4891.96981024998,
-            "scale": 18489297.737236
-          },
-          {
-            "level": 3,
-            "resolution": 2445.98490512499,
-            "scale": 9244648.868618
-          },
-          {
-            "level": 4,
-            "resolution": 1222.9924525624949,
-            "scale": 4622324.434309
-          },
-          {
-            "level": 5,
-            "resolution": 611.49622628137968,
-            "scale": 2311162.217155
-          },
-          {
-            "level": 6,
-            "resolution": 305.74811314055756,
-            "scale": 1155581.108577
-          },
-          {
-            "level": 7,
-            "resolution": 152.87405657041106,
-            "scale": 577790.554289
-          },
-          {
-            "level": 8,
-            "resolution": 76.437028285073239,
-            "scale": 288895.277144
-          },
-          {
-            "level": 9,
-            "resolution": 38.21851414253662,
-            "scale": 144447.638572
-          },
-          {
-            "level": 10,
-            "resolution": 19.10925707126831,
-            "scale": 72223.819286
-          },
-          {
-            "level": 11,
-            "resolution": 9.5546285356341549,
-            "scale": 36111.909643
-          },
-          {
-            "level": 12,
-            "resolution": 4.77731426794937,
-            "scale": 18055.954822
-          },
-          {
-            "level": 13,
-            "resolution": 2.3886571339746849,
-            "scale": 9027.977411
-          },
-          {
-            "level": 14,
-            "resolution": 1.1943285668550503,
-            "scale": 4513.988705
-          },
-          {
-            "level": 15,
-            "resolution": 0.59716428355981721,
-            "scale": 2256.994353
-          },
-          {
-            "level": 16,
-            "resolution": 0.29858214164761665,
-            "scale": 1128.497176
-          },
-          {
-            "level": 17,
-            "resolution": 0.14929107082380833,
-            "scale": 564.248588
-          },
-          {
-            "level": 18,
-            "resolution": 0.074645535411904163,
-            "scale": 282.124294
-          },
-          {
-            "level": 19,
-            "resolution": 0.037322767705952081,
-            "scale": 141.062147
-          },
-          {
-            "level": 20,
-            "resolution": 0.018661383852976041,
-            "scale": 70.5310735
-          }
-        ]
-      }
-    ],
-    "legend": {
-      "type": "structured",
-      "root": {
-        "name": "root",
-        "children": [
-          {
-            "layerId": "Total_Releases2019",
-            "description": "Rejets d’éthylène glycol déclarés par les installations de l’INRP dans tous les milieux en 2019 (tonnes)",
-            "symbologyExpanded": true
-          }
-        ]
-      }
     },
-    "layers": [
-      {
-        "id": "Total_Releases2019",
-        "name": "Rejets d’éthylène glycol",
-        "layerType": "esriFeature",
-        "singleEntryCollapse": true,
-        "symbologyExpanded": true,
-        "tolerance": 20,
-        "url": "https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/StoryRAMP/ea24000c_7dc3_49a9_baac_c55d28dcaeb9/MapServer/5",
-        "state": {
-          "opacity": 0.75
-        } 
-      }
-    ],
-    "tileSchemas": [
-      {
-        "id": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978",
-        "name": "Lambert Maps",
-        "extentSetId": "EXT_NRCAN_Lambert_3978",
-        "lodSetId": "LOD_NRCAN_Lambert_3978",
-        "hasNorthPole": true
-      },
-      {
-        "id": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857",
-        "name": "Web Mercator Maps",
-        "extentSetId": "EXT_ESRI_World_AuxMerc_3857",
-        "lodSetId": "LOD_ESRI_World_AuxMerc_3857"
-      }
-    ],
-    "baseMaps": [
-      {
-        "id": "baseNrCan",
-        "name": "Carte de base du Canada – transport (CBCT) avec étiquettes",
-        "description": "La carte de base du Canada – transport (CBCT) du Secteur des sciences de la Terre de Ressources naturelles Canada est un service Internet qui s'adresse principalement aux utilisateurs et développeurs d'applications cartographiques en ligne.",
-        "altText": "altText - La carte de base du Canada – transport (CBCT)",
-        "layers": [
-          {
-            "id": "CBCT",
-            "layerType": "esriFeature",
-            "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBCT3978/MapServer"
-          }
+    "services": {
+        "proxyUrl": "http://167.40.64.74/wmsproxy/ws/wmsproxy/executeFromProxy",
+        "exportMapUrl": "https://maps-cartes.dev.ec.gc.ca/arcgis/rest/services/Utilities/PrintingTools/GPServer/Export%20Web%20Map%20Task",
+        "export": {
+            "title": {
+                "value": "Rejets d’éthylène glycol déclarés par les installations de l’INRP dans tous les milieux en 2019"
+            },
+            "map": {},
+            "mapElements": {},
+            "legend": {},
+            "footnote": {
+                "value": "Rejets d’éthylène glycol déclarés par les installations de l’INRP dans tous les milieux en 2019"
+            }
+        },
+        "search": {
+            "settings": {
+                "categories": [
+                    "CITY",
+                    "HAM",
+                    "IR",
+                    "LTM",
+                    "MUN1",
+                    "MUN2",
+                    "PROV",
+                    "STM",
+                    "TERR",
+                    "TOWN",
+                    "UTM",
+                    "VILG",
+                    "UNP"
+                ],
+                "sortOrder": [
+                    "CITY",
+                    "HAM",
+                    "IR",
+                    "LTM",
+                    "MUN1",
+                    "MUN2",
+                    "PROV",
+                    "STM",
+                    "TERR",
+                    "TOWN",
+                    "UTM",
+                    "VILG",
+                    "UNP"
+                ],
+                "maxResults": 1000,
+                "officialOnly": true
+            },
+            "serviceUrls": {
+                "geoNames": "https://geogratis.gc.ca/services/geoname/fr/geonames.json",
+                "geoLocation": "https://geogratis.gc.ca/services/geolocation/fr/locate?q=",
+                "geoSuggest": "https://geogratis.gc.ca/services/geolocation/fr/suggest?q=",
+                "provinces": "https://geogratis.gc.ca/services/geoname/fr/codes/province.json",
+                "types": "https://geogratis.gc.ca/services/geoname/fr/codes/concise.json"
+            }
+        }
+    },
+    "map": {
+        "initialBasemapId": "baseNrCan",
+        "components": {
+            "geoSearch": {
+                "enabled": true,
+                "showGraphic": true,
+                "showInfo": true
+            },
+            "mouseInfo": {
+                "enabled": true,
+                "spatialReference": {
+                    "wkid": 4326
+                }
+            },
+            "northArrow": {
+                "enabled": false
+            },
+            "basemap": {
+                "enabled": true
+            },
+            "overviewMap": {
+                "enabled": true,
+                "layerType": "imagery"
+            },
+            "scaleBar": {
+                "enabled": true
+            }
+        },
+        "extentSets": [
+            {
+                "id": "EXT_NRCAN_Lambert_3978",
+                "default": {
+                    "xmax": 2349492,
+                    "xmin": -5781457,
+                    "ymax": 4482193,
+                    "ymin": -983440
+                },
+                "spatialReference": {
+                    "wkid": 3978
+                }
+            },
+            {
+                "id": "EXT_ESRI_World_AuxMerc_3857",
+                "default": {
+                    "xmax": -5007771.626060756,
+                    "xmin": -16632697.354854,
+                    "ymax": 10015875.184845109,
+                    "ymin": 5022907.964742964
+                },
+                "spatialReference": {
+                    "wkid": 102100,
+                    "latestWkid": 3857
+                }
+            }
         ],
-        "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
-      },
-      {
-        "id": "baseSimple",
-        "name": "Carte de base du Canada - simple",
-        "description": "La carte de base du Canada - simple",
-        "altText": "altText - La carte de base du Canada - simple",
-        "layers": [
-          {
-            "id": "SMR",
-            "layerType": "esriFeature",
-            "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer"
-          },
-          {
-            "id": "SMW",
-            "layerType": "esriFeature",
-            "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_TXT_3978/MapServer"
-          }
+        "lodSets": [
+            {
+                "id": "LOD_NRCAN_Lambert_3978",
+                "lods": [
+                    {
+                        "level": 0,
+                        "resolution": 38364.660062653464,
+                        "scale": 145000000
+                    },
+                    {
+                        "level": 1,
+                        "resolution": 22489.628312589961,
+                        "scale": 85000000
+                    },
+                    {
+                        "level": 2,
+                        "resolution": 13229.193125052918,
+                        "scale": 50000000
+                    },
+                    {
+                        "level": 3,
+                        "resolution": 7937.5158750317505,
+                        "scale": 30000000
+                    },
+                    {
+                        "level": 4,
+                        "resolution": 4630.2175937685215,
+                        "scale": 17500000
+                    },
+                    {
+                        "level": 5,
+                        "resolution": 2645.8386250105837,
+                        "scale": 10000000
+                    },
+                    {
+                        "level": 6,
+                        "resolution": 1587.5031750063501,
+                        "scale": 6000000
+                    },
+                    {
+                        "level": 7,
+                        "resolution": 926.04351875370423,
+                        "scale": 3500000
+                    },
+                    {
+                        "level": 8,
+                        "resolution": 529.16772500211675,
+                        "scale": 2000000
+                    },
+                    {
+                        "level": 9,
+                        "resolution": 317.50063500127004,
+                        "scale": 1200000
+                    },
+                    {
+                        "level": 10,
+                        "resolution": 185.20870375074085,
+                        "scale": 700000
+                    },
+                    {
+                        "level": 11,
+                        "resolution": 111.12522225044451,
+                        "scale": 420000
+                    },
+                    {
+                        "level": 12,
+                        "resolution": 66.1459656252646,
+                        "scale": 250000
+                    },
+                    {
+                        "level": 13,
+                        "resolution": 38.364660062653464,
+                        "scale": 145000
+                    },
+                    {
+                        "level": 14,
+                        "resolution": 22.489628312589961,
+                        "scale": 85000
+                    },
+                    {
+                        "level": 15,
+                        "resolution": 13.229193125052918,
+                        "scale": 50000
+                    },
+                    {
+                        "level": 16,
+                        "resolution": 7.9375158750317505,
+                        "scale": 30000
+                    },
+                    {
+                        "level": 17,
+                        "resolution": 4.6302175937685215,
+                        "scale": 17500
+                    }
+                ]
+            },
+            {
+                "id": "LOD_ESRI_World_AuxMerc_3857",
+                "lods": [
+                    {
+                        "level": 0,
+                        "resolution": 19567.879240999919,
+                        "scale": 73957190.948944
+                    },
+                    {
+                        "level": 1,
+                        "resolution": 9783.93962049996,
+                        "scale": 36978595.474472
+                    },
+                    {
+                        "level": 2,
+                        "resolution": 4891.96981024998,
+                        "scale": 18489297.737236
+                    },
+                    {
+                        "level": 3,
+                        "resolution": 2445.98490512499,
+                        "scale": 9244648.868618
+                    },
+                    {
+                        "level": 4,
+                        "resolution": 1222.9924525624949,
+                        "scale": 4622324.434309
+                    },
+                    {
+                        "level": 5,
+                        "resolution": 611.49622628137968,
+                        "scale": 2311162.217155
+                    },
+                    {
+                        "level": 6,
+                        "resolution": 305.74811314055756,
+                        "scale": 1155581.108577
+                    },
+                    {
+                        "level": 7,
+                        "resolution": 152.87405657041106,
+                        "scale": 577790.554289
+                    },
+                    {
+                        "level": 8,
+                        "resolution": 76.437028285073239,
+                        "scale": 288895.277144
+                    },
+                    {
+                        "level": 9,
+                        "resolution": 38.21851414253662,
+                        "scale": 144447.638572
+                    },
+                    {
+                        "level": 10,
+                        "resolution": 19.10925707126831,
+                        "scale": 72223.819286
+                    },
+                    {
+                        "level": 11,
+                        "resolution": 9.5546285356341549,
+                        "scale": 36111.909643
+                    },
+                    {
+                        "level": 12,
+                        "resolution": 4.77731426794937,
+                        "scale": 18055.954822
+                    },
+                    {
+                        "level": 13,
+                        "resolution": 2.3886571339746849,
+                        "scale": 9027.977411
+                    },
+                    {
+                        "level": 14,
+                        "resolution": 1.1943285668550503,
+                        "scale": 4513.988705
+                    },
+                    {
+                        "level": 15,
+                        "resolution": 0.59716428355981721,
+                        "scale": 2256.994353
+                    },
+                    {
+                        "level": 16,
+                        "resolution": 0.29858214164761665,
+                        "scale": 1128.497176
+                    },
+                    {
+                        "level": 17,
+                        "resolution": 0.14929107082380833,
+                        "scale": 564.248588
+                    },
+                    {
+                        "level": 18,
+                        "resolution": 0.074645535411904163,
+                        "scale": 282.124294
+                    },
+                    {
+                        "level": 19,
+                        "resolution": 0.037322767705952081,
+                        "scale": 141.062147
+                    },
+                    {
+                        "level": 20,
+                        "resolution": 0.018661383852976041,
+                        "scale": 70.5310735
+                    }
+                ]
+            }
         ],
-        "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
-      },
-      {
-        "id": "baseCBME_CBCE_HS_RO_3978",
-        "name": "Carte de base du Canada - élevation (CBCE)",
-        "description": "La carte de base du Canada - élevation (CBCE) du Secteur des sciences de la Terre de Ressources naturelles Canada est un service Internet qui s'adresse principalement aux utilisateurs et développeurs d'applications cartographiques en ligne.",
-        "altText": "altText - La carte de base du Canada - élevation (CBCE)",
+        "legend": {
+            "type": "structured",
+            "root": {
+                "name": "root",
+                "children": [
+                    {
+                        "layerId": "Total_Releases2019",
+                        "description": "Rejets d’éthylène glycol déclarés par les installations de l’INRP dans tous les milieux en 2019 (tonnes)",
+                        "symbologyExpanded": true
+                    }
+                ]
+            }
+        },
         "layers": [
-          {
-            "id": "CBME_CBCE_HS_RO_3978",
-            "layerType": "esriFeature",
-            "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer"
-          }
+            {
+                "id": "Total_Releases2019",
+                "name": "Rejets d’éthylène glycol",
+                "layerType": "esriFeature",
+                "singleEntryCollapse": true,
+                "symbologyExpanded": true,
+                "tolerance": 20,
+                "url": "https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/StoryRAMP/ea24000c_7dc3_49a9_baac_c55d28dcaeb9/MapServer/5",
+                "state": {
+                    "opacity": 0.75
+                }
+            }
         ],
-        "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
-      },
-      {
-        "id": "baseCBMT_CBCT_GEOM_3978",
-        "name": "Carte de base du Canada - transport (CBCT)",
-        "description": "La carte de base du Canada - transport (CBCT) du Secteur des sciences de la Terre de Ressources naturelles Canada est un service Internet qui s'adresse principalement aux utilisateurs et développeurs d'applications cartographiques en ligne.",
-        "altText": "altText - La carte de base du Canada - transport (CBCT)",
-        "layers": [
-          {
-            "id": "CBMT_CBCT_GEOM_3978",
-            "layerType": "esriFeature",
-            "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer"
-          }
+        "tileSchemas": [
+            {
+                "id": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978",
+                "name": "Lambert Maps",
+                "extentSetId": "EXT_NRCAN_Lambert_3978",
+                "lodSetId": "LOD_NRCAN_Lambert_3978",
+                "hasNorthPole": true
+            },
+            {
+                "id": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857",
+                "name": "Web Mercator Maps",
+                "extentSetId": "EXT_ESRI_World_AuxMerc_3857",
+                "lodSetId": "LOD_ESRI_World_AuxMerc_3857"
+            }
         ],
-        "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
-      },
-      {
-        "id": "baseEsriWorld",
-        "name": "Imagerie mondiale",
-        "description": "L'imagerie mondiale fournit une imagerie satellitaire et aérienne dans de nombreuses régions du monde avec une résolution de 1 mètres et moins et des images satellitaires de résolution inférieure dans le monde entier.",
-        "altText": "altText - L'imagerie mondiale",
-        "layers": [
-          {
-            "id": "World_Imagery",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      },
-      {
-        "id": "baseEsriPhysical",
-        "name": "Monde physique",
-        "description": "La carte du monde physique représente l'aspect physique naturel de la Terre à 1.24 kilomètres par pixel pour le monde et à 500 mètres pour les États-Unis.",
-        "altText": "altText - La carte du monde physique",
-        "layers": [
-          {
-            "id": "World_Physical_Map",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Physical_Map/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      },
-      {
-        "id": "baseEsriRelief",
-        "name": "Monde en relief ombragé",
-        "description": "La carte du monde en relief ombragé représente l'élévation de la surface de la terre comme un relief ombragé. Cette carte est utilisée comme couche de fond afin d'ajouter un relief ombragé à d'autres cartes SIG, comme la carte ArcGIS Online World Street Map.",
-        "altText": "altText - La carte du monde en relief ombragé",
-        "layers": [
-          {
-            "id": "World_Shaded_Relief",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Shaded_Relief/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      },
-      {
-        "id": "baseEsriStreet",
-        "name": "Monde routier",
-        "description": "La carte du monde routier présente des données au niveau des autoroutes pour le monde.",
-        "altText": "altText - La carte du monde routier",
-        "layers": [
-          {
-            "id": "World_Street_Map",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Street_Map/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      },
-      {
-        "id": "baseEsriTerrain",
-        "name": "Monde terrain",
-        "description": "La carte du monde terrain est conçue pour être utilisée comme une carte de base par les professionnels du SIG pour superposer d'autres couches thématiques comme la démographie ou la couverture terrestre.",
-        "altText": "altText - La carte du monde terrain",
-        "layers": [
-          {
-            "id": "World_Terrain_Base",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Terrain_Base/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      },
-      {
-        "id": "baseEsriTopo",
-        "name": "Monde topographique",
-        "description": "La carte du monde topographique est conçue pour être utilisé comme une carte de base par les professionnels du SIG et comme une carte de référence par quiconque.",
-        "altText": "altText - La carte du monde topographique",
-        "layers": [
-          {
-            "id": "World_Topo_Map",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      }
-    ]
-  }
+        "baseMaps": [
+            {
+                "id": "baseNrCan",
+                "name": "Carte de base du Canada – transport (CBCT) avec étiquettes",
+                "description": "La carte de base du Canada – transport (CBCT) du Secteur des sciences de la Terre de Ressources naturelles Canada est un service Internet qui s'adresse principalement aux utilisateurs et développeurs d'applications cartographiques en ligne.",
+                "altText": "altText - La carte de base du Canada – transport (CBCT)",
+                "layers": [
+                    {
+                        "id": "CBCT",
+                        "layerType": "esriFeature",
+                        "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBCT3978/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+            },
+            {
+                "id": "baseSimple",
+                "name": "Carte de base du Canada - simple",
+                "description": "La carte de base du Canada - simple",
+                "altText": "altText - La carte de base du Canada - simple",
+                "layers": [
+                    {
+                        "id": "SMR",
+                        "layerType": "esriFeature",
+                        "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer"
+                    },
+                    {
+                        "id": "SMW",
+                        "layerType": "esriFeature",
+                        "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_TXT_3978/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+            },
+            {
+                "id": "baseCBME_CBCE_HS_RO_3978",
+                "name": "Carte de base du Canada - élevation (CBCE)",
+                "description": "La carte de base du Canada - élevation (CBCE) du Secteur des sciences de la Terre de Ressources naturelles Canada est un service Internet qui s'adresse principalement aux utilisateurs et développeurs d'applications cartographiques en ligne.",
+                "altText": "altText - La carte de base du Canada - élevation (CBCE)",
+                "layers": [
+                    {
+                        "id": "CBME_CBCE_HS_RO_3978",
+                        "layerType": "esriFeature",
+                        "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+            },
+            {
+                "id": "baseCBMT_CBCT_GEOM_3978",
+                "name": "Carte de base du Canada - transport (CBCT)",
+                "description": "La carte de base du Canada - transport (CBCT) du Secteur des sciences de la Terre de Ressources naturelles Canada est un service Internet qui s'adresse principalement aux utilisateurs et développeurs d'applications cartographiques en ligne.",
+                "altText": "altText - La carte de base du Canada - transport (CBCT)",
+                "layers": [
+                    {
+                        "id": "CBMT_CBCT_GEOM_3978",
+                        "layerType": "esriFeature",
+                        "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+            },
+            {
+                "id": "baseEsriWorld",
+                "name": "Imagerie mondiale",
+                "description": "L'imagerie mondiale fournit une imagerie satellitaire et aérienne dans de nombreuses régions du monde avec une résolution de 1 mètres et moins et des images satellitaires de résolution inférieure dans le monde entier.",
+                "altText": "altText - L'imagerie mondiale",
+                "layers": [
+                    {
+                        "id": "World_Imagery",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriPhysical",
+                "name": "Monde physique",
+                "description": "La carte du monde physique représente l'aspect physique naturel de la Terre à 1.24 kilomètres par pixel pour le monde et à 500 mètres pour les États-Unis.",
+                "altText": "altText - La carte du monde physique",
+                "layers": [
+                    {
+                        "id": "World_Physical_Map",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Physical_Map/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriRelief",
+                "name": "Monde en relief ombragé",
+                "description": "La carte du monde en relief ombragé représente l'élévation de la surface de la terre comme un relief ombragé. Cette carte est utilisée comme couche de fond afin d'ajouter un relief ombragé à d'autres cartes SIG, comme la carte ArcGIS Online World Street Map.",
+                "altText": "altText - La carte du monde en relief ombragé",
+                "layers": [
+                    {
+                        "id": "World_Shaded_Relief",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Shaded_Relief/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriStreet",
+                "name": "Monde routier",
+                "description": "La carte du monde routier présente des données au niveau des autoroutes pour le monde.",
+                "altText": "altText - La carte du monde routier",
+                "layers": [
+                    {
+                        "id": "World_Street_Map",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Street_Map/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriTerrain",
+                "name": "Monde terrain",
+                "description": "La carte du monde terrain est conçue pour être utilisée comme une carte de base par les professionnels du SIG pour superposer d'autres couches thématiques comme la démographie ou la couverture terrestre.",
+                "altText": "altText - La carte du monde terrain",
+                "layers": [
+                    {
+                        "id": "World_Terrain_Base",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Terrain_Base/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriTopo",
+                "name": "Monde topographique",
+                "description": "La carte du monde topographique est conçue pour être utilisé comme une carte de base par les professionnels du SIG et comme une carte de référence par quiconque.",
+                "altText": "altText - La carte du monde topographique",
+                "layers": [
+                    {
+                        "id": "World_Topo_Map",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            }
+        ]
+    }
 }

--- a/public/f6f7baf4-cccb-4521-a037-b4691b0f0d49/ramp-config/en/phosphorus_and_nitrates_of_pnp_2010-2019.json
+++ b/public/f6f7baf4-cccb-4521-a037-b4691b0f0d49/ramp-config/en/phosphorus_and_nitrates_of_pnp_2010-2019.json
@@ -1,525 +1,552 @@
 {
-  "version": "2.0",
-  "language": "en",
-  "ui": {
-    "title": "Interactive map",
-    "fullscreen": true,
-    "navBar": {
-      "zoom": "buttons",
-      "extra": [ "fullscreen", "geoLocator", "home", "help" ]
-    },
-    "appBar": {
-      "basemap": true
-
-    },
-    "help": {
-      "folderName": "default"
-    },
-    "sideMenu": {
-      "items": [ [ "fullscreen", "export", "touch", "help", "about" ] ],
-      "logo": false
-    },
-    "legend": {
-      "allowImport": true,
-      "isOpen": {
-        "large": true,
-        "medium": false,
-        "small": false
-      }
-    }
-  },
-  "services": {
-    "proxyUrl": "http://167.40.64.74/wmsproxy/ws/wmsproxy/executeFromProxy",
-    "exportMapUrl": "https://maps-cartes.dev.ec.gc.ca/arcgis/rest/services/Utilities/PrintingTools/GPServer/Export%20Web%20Map%20Task",
-    "export": {
-      "title": {
-        "value": "Phosphorus and nitrates released by pulp and paper facilities that reported to the NPRI from 2010 to 2019"
-      },
-      "map": {},
-      "mapElements": {},
-      "legend": {},
-      "footnote": {
-        "value": "Phosphorus and nitrates released by pulp and paper facilities that reported to the NPRI from 2010 to 2019"
-      }
-    },
-    "search": {
-      "settings": {
-        "categories": [ "CITY", "HAM", "IR", "LTM", "MUN1", "MUN2", "PROV", "STM", "TERR", "TOWN", "UTM", "VILG", "UNP" ],
-        "sortOrder": [ "CITY", "HAM", "IR", "LTM", "MUN1", "MUN2", "PROV", "STM", "TERR", "TOWN", "UTM", "VILG", "UNP" ],
-        "maxResults": 1000,
-        "officialOnly": true
-      },	
-      "serviceUrls": {
-        "geoNames": "https://geogratis.gc.ca/services/geoname/en/geonames.json",
-        "geoLocation": "https://geogratis.gc.ca/services/geolocation/en/locate?q=",
-        "geoSuggest": "https://geogratis.gc.ca/services/geolocation/en/suggest?q=",
-        "provinces": "https://geogratis.gc.ca/services/geoname/en/codes/province.json",
-        "types": "https://geogratis.gc.ca/services/geoname/en/codes/concise.json"
-      }
-    }
-  },
-  "map": {
-    "initialBasemapId": "baseNrCan",
-    "components": {
-      "geoSearch": {
-        "enabled": true,
-        "showGraphic": true,
-        "showInfo": true
-      },
-      "mouseInfo": {
-        "enabled": true,
-        "spatialReference": {
-          "wkid": 4326
-        }
-      },
-      "northArrow": {
-        "enabled": false
-      },
-      "basemap": {
-        "enabled": true
-      },
-      "overviewMap": {
-        "enabled": true,
-        "layerType": "imagery"
-      },
-      "scaleBar": {
-        "enabled": true
-      }
-    },
-    "extentSets": [
-      {
-        "id": "EXT_NRCAN_Lambert_3978",
-        "default": {
-          "xmax": 2849492,
-          "xmin": -5281457,
-          "ymax": 4482193,
-          "ymin": -983440
+    "version": "2.0",
+    "language": "en",
+    "ui": {
+        "title": "Interactive map",
+        "fullscreen": true,
+        "navBar": {
+            "zoom": "buttons",
+            "extra": ["fullscreen", "geoLocator", "home", "help"]
         },
-        "spatialReference": {
-          "wkid": 3978
-        }
-      },
-      {
-        "id": "EXT_ESRI_World_AuxMerc_3857",
-        "default": {
-          "xmax": -5007771.626060756,
-          "xmin": -16632697.354854,
-          "ymax": 10015875.184845109,
-          "ymin": 5022907.964742964
+        "appBar": {
+            "basemap": true
         },
-        "spatialReference": {
-          "wkid": 102100,
-          "latestWkid": 3857
+        "help": {
+            "folderName": "default"
+        },
+        "sideMenu": {
+            "items": [["fullscreen", "export", "touch", "help", "about"]],
+            "logo": false
+        },
+        "legend": {
+            "allowImport": true,
+            "isOpen": {
+                "large": true,
+                "medium": false,
+                "small": false
+            }
         }
-      }
-    ],
-    "lodSets": [
-      {
-        "id": "LOD_NRCAN_Lambert_3978",
-        "lods": [
-          {
-            "level": 0,
-            "resolution": 38364.660062653464,
-            "scale": 145000000
-          },
-          {
-            "level": 1,
-            "resolution": 22489.628312589961,
-            "scale": 85000000
-          },
-          {
-            "level": 2,
-            "resolution": 13229.193125052918,
-            "scale": 50000000
-          },
-          {
-            "level": 3,
-            "resolution": 7937.5158750317505,
-            "scale": 30000000
-          },
-          {
-            "level": 4,
-            "resolution": 4630.2175937685215,
-            "scale": 17500000
-          },
-          {
-            "level": 5,
-            "resolution": 2645.8386250105837,
-            "scale": 10000000
-          },
-          {
-            "level": 6,
-            "resolution": 1587.5031750063501,
-            "scale": 6000000
-          },
-          {
-            "level": 7,
-            "resolution": 926.04351875370423,
-            "scale": 3500000
-          },
-          {
-            "level": 8,
-            "resolution": 529.16772500211675,
-            "scale": 2000000
-          },
-          {
-            "level": 9,
-            "resolution": 317.50063500127004,
-            "scale": 1200000
-          },
-          {
-            "level": 10,
-            "resolution": 185.20870375074085,
-            "scale": 700000
-          },
-          {
-            "level": 11,
-            "resolution": 111.12522225044451,
-            "scale": 420000
-          },
-          {
-            "level": 12,
-            "resolution": 66.1459656252646,
-            "scale": 250000
-          },
-          {
-            "level": 13,
-            "resolution": 38.364660062653464,
-            "scale": 145000
-          },
-          {
-            "level": 14,
-            "resolution": 22.489628312589961,
-            "scale": 85000
-          },
-          {
-            "level": 15,
-            "resolution": 13.229193125052918,
-            "scale": 50000
-          },
-          {
-            "level": 16,
-            "resolution": 7.9375158750317505,
-            "scale": 30000
-          },
-          {
-            "level": 17,
-            "resolution": 4.6302175937685215,
-            "scale": 17500
-          }
-        ]
-      },
-      {
-        "id": "LOD_ESRI_World_AuxMerc_3857",
-        "lods": [
-          {
-            "level": 0,
-            "resolution": 19567.879240999919,
-            "scale": 73957190.948944
-          },
-          {
-            "level": 1,
-            "resolution": 9783.93962049996,
-            "scale": 36978595.474472
-          },
-          {
-            "level": 2,
-            "resolution": 4891.96981024998,
-            "scale": 18489297.737236
-          },
-          {
-            "level": 3,
-            "resolution": 2445.98490512499,
-            "scale": 9244648.868618
-          },
-          {
-            "level": 4,
-            "resolution": 1222.9924525624949,
-            "scale": 4622324.434309
-          },
-          {
-            "level": 5,
-            "resolution": 611.49622628137968,
-            "scale": 2311162.217155
-          },
-          {
-            "level": 6,
-            "resolution": 305.74811314055756,
-            "scale": 1155581.108577
-          },
-          {
-            "level": 7,
-            "resolution": 152.87405657041106,
-            "scale": 577790.554289
-          },
-          {
-            "level": 8,
-            "resolution": 76.437028285073239,
-            "scale": 288895.277144
-          },
-          {
-            "level": 9,
-            "resolution": 38.21851414253662,
-            "scale": 144447.638572
-          },
-          {
-            "level": 10,
-            "resolution": 19.10925707126831,
-            "scale": 72223.819286
-          },
-          {
-            "level": 11,
-            "resolution": 9.5546285356341549,
-            "scale": 36111.909643
-          },
-          {
-            "level": 12,
-            "resolution": 4.77731426794937,
-            "scale": 18055.954822
-          },
-          {
-            "level": 13,
-            "resolution": 2.3886571339746849,
-            "scale": 9027.977411
-          },
-          {
-            "level": 14,
-            "resolution": 1.1943285668550503,
-            "scale": 4513.988705
-          },
-          {
-            "level": 15,
-            "resolution": 0.59716428355981721,
-            "scale": 2256.994353
-          },
-          {
-            "level": 16,
-            "resolution": 0.29858214164761665,
-            "scale": 1128.497176
-          },
-          {
-            "level": 17,
-            "resolution": 0.14929107082380833,
-            "scale": 564.248588
-          },
-          {
-            "level": 18,
-            "resolution": 0.074645535411904163,
-            "scale": 282.124294
-          },
-          {
-            "level": 19,
-            "resolution": 0.037322767705952081,
-            "scale": 141.062147
-          },
-          {
-            "level": 20,
-            "resolution": 0.018661383852976041,
-            "scale": 70.5310735
-          }
-        ]
-      }
-    ],
-    "legend": {
-      "type": "structured",
-      "root": {
-          "name": "root",
-          "children": [
+    },
+    "services": {
+        "proxyUrl": "http://167.40.64.74/wmsproxy/ws/wmsproxy/executeFromProxy",
+        "exportMapUrl": "https://maps-cartes.dev.ec.gc.ca/arcgis/rest/services/Utilities/PrintingTools/GPServer/Export%20Web%20Map%20Task",
+        "export": {
+            "title": {
+                "value": "Phosphorus and nitrates released by pulp and paper facilities that reported to the NPRI from 2010 to 2019"
+            },
+            "map": {},
+            "mapElements": {},
+            "legend": {},
+            "footnote": {
+                "value": "Phosphorus and nitrates released by pulp and paper facilities that reported to the NPRI from 2010 to 2019"
+            }
+        },
+        "search": {
+            "settings": {
+                "categories": [
+                    "CITY",
+                    "HAM",
+                    "IR",
+                    "LTM",
+                    "MUN1",
+                    "MUN2",
+                    "PROV",
+                    "STM",
+                    "TERR",
+                    "TOWN",
+                    "UTM",
+                    "VILG",
+                    "UNP"
+                ],
+                "sortOrder": [
+                    "CITY",
+                    "HAM",
+                    "IR",
+                    "LTM",
+                    "MUN1",
+                    "MUN2",
+                    "PROV",
+                    "STM",
+                    "TERR",
+                    "TOWN",
+                    "UTM",
+                    "VILG",
+                    "UNP"
+                ],
+                "maxResults": 1000,
+                "officialOnly": true
+            },
+            "serviceUrls": {
+                "geoNames": "https://geogratis.gc.ca/services/geoname/en/geonames.json",
+                "geoLocation": "https://geogratis.gc.ca/services/geolocation/en/locate?q=",
+                "geoSuggest": "https://geogratis.gc.ca/services/geolocation/en/suggest?q=",
+                "provinces": "https://geogratis.gc.ca/services/geoname/en/codes/province.json",
+                "types": "https://geogratis.gc.ca/services/geoname/en/codes/concise.json"
+            }
+        }
+    },
+    "map": {
+        "initialBasemapId": "baseNrCan",
+        "components": {
+            "geoSearch": {
+                "enabled": true,
+                "showGraphic": true,
+                "showInfo": true
+            },
+            "mouseInfo": {
+                "enabled": true,
+                "spatialReference": {
+                    "wkid": 4326
+                }
+            },
+            "northArrow": {
+                "enabled": false
+            },
+            "basemap": {
+                "enabled": true
+            },
+            "overviewMap": {
+                "enabled": true,
+                "layerType": "imagery"
+            },
+            "scaleBar": {
+                "enabled": true
+            }
+        },
+        "extentSets": [
             {
-                "layerId": "Nitrates",
-                "description": "Nitrates released by pulp and paper facilities that reported to the NPRI from 2010 to 2019 (tonnes)",
-                "symbologyExpanded": true
+                "id": "EXT_NRCAN_Lambert_3978",
+                "default": {
+                    "xmax": 2249492,
+                    "xmin": -5881457,
+                    "ymax": 4482193,
+                    "ymin": -983440
+                },
+                "spatialReference": {
+                    "wkid": 3978
+                }
             },
             {
-              "layerId": "Phosphorus",
-              "description": "Phosphorus released by pulp and paper facilities that reported to the NPRI from 2010 to 2019 (tonnes)",
-              "symbologyExpanded": true
-          }            
+                "id": "EXT_ESRI_World_AuxMerc_3857",
+                "default": {
+                    "xmax": -5007771.626060756,
+                    "xmin": -16632697.354854,
+                    "ymax": 10015875.184845109,
+                    "ymin": 5022907.964742964
+                },
+                "spatialReference": {
+                    "wkid": 102100,
+                    "latestWkid": 3857
+                }
+            }
+        ],
+        "lodSets": [
+            {
+                "id": "LOD_NRCAN_Lambert_3978",
+                "lods": [
+                    {
+                        "level": 0,
+                        "resolution": 38364.660062653464,
+                        "scale": 145000000
+                    },
+                    {
+                        "level": 1,
+                        "resolution": 22489.628312589961,
+                        "scale": 85000000
+                    },
+                    {
+                        "level": 2,
+                        "resolution": 13229.193125052918,
+                        "scale": 50000000
+                    },
+                    {
+                        "level": 3,
+                        "resolution": 7937.5158750317505,
+                        "scale": 30000000
+                    },
+                    {
+                        "level": 4,
+                        "resolution": 4630.2175937685215,
+                        "scale": 17500000
+                    },
+                    {
+                        "level": 5,
+                        "resolution": 2645.8386250105837,
+                        "scale": 10000000
+                    },
+                    {
+                        "level": 6,
+                        "resolution": 1587.5031750063501,
+                        "scale": 6000000
+                    },
+                    {
+                        "level": 7,
+                        "resolution": 926.04351875370423,
+                        "scale": 3500000
+                    },
+                    {
+                        "level": 8,
+                        "resolution": 529.16772500211675,
+                        "scale": 2000000
+                    },
+                    {
+                        "level": 9,
+                        "resolution": 317.50063500127004,
+                        "scale": 1200000
+                    },
+                    {
+                        "level": 10,
+                        "resolution": 185.20870375074085,
+                        "scale": 700000
+                    },
+                    {
+                        "level": 11,
+                        "resolution": 111.12522225044451,
+                        "scale": 420000
+                    },
+                    {
+                        "level": 12,
+                        "resolution": 66.1459656252646,
+                        "scale": 250000
+                    },
+                    {
+                        "level": 13,
+                        "resolution": 38.364660062653464,
+                        "scale": 145000
+                    },
+                    {
+                        "level": 14,
+                        "resolution": 22.489628312589961,
+                        "scale": 85000
+                    },
+                    {
+                        "level": 15,
+                        "resolution": 13.229193125052918,
+                        "scale": 50000
+                    },
+                    {
+                        "level": 16,
+                        "resolution": 7.9375158750317505,
+                        "scale": 30000
+                    },
+                    {
+                        "level": 17,
+                        "resolution": 4.6302175937685215,
+                        "scale": 17500
+                    }
+                ]
+            },
+            {
+                "id": "LOD_ESRI_World_AuxMerc_3857",
+                "lods": [
+                    {
+                        "level": 0,
+                        "resolution": 19567.879240999919,
+                        "scale": 73957190.948944
+                    },
+                    {
+                        "level": 1,
+                        "resolution": 9783.93962049996,
+                        "scale": 36978595.474472
+                    },
+                    {
+                        "level": 2,
+                        "resolution": 4891.96981024998,
+                        "scale": 18489297.737236
+                    },
+                    {
+                        "level": 3,
+                        "resolution": 2445.98490512499,
+                        "scale": 9244648.868618
+                    },
+                    {
+                        "level": 4,
+                        "resolution": 1222.9924525624949,
+                        "scale": 4622324.434309
+                    },
+                    {
+                        "level": 5,
+                        "resolution": 611.49622628137968,
+                        "scale": 2311162.217155
+                    },
+                    {
+                        "level": 6,
+                        "resolution": 305.74811314055756,
+                        "scale": 1155581.108577
+                    },
+                    {
+                        "level": 7,
+                        "resolution": 152.87405657041106,
+                        "scale": 577790.554289
+                    },
+                    {
+                        "level": 8,
+                        "resolution": 76.437028285073239,
+                        "scale": 288895.277144
+                    },
+                    {
+                        "level": 9,
+                        "resolution": 38.21851414253662,
+                        "scale": 144447.638572
+                    },
+                    {
+                        "level": 10,
+                        "resolution": 19.10925707126831,
+                        "scale": 72223.819286
+                    },
+                    {
+                        "level": 11,
+                        "resolution": 9.5546285356341549,
+                        "scale": 36111.909643
+                    },
+                    {
+                        "level": 12,
+                        "resolution": 4.77731426794937,
+                        "scale": 18055.954822
+                    },
+                    {
+                        "level": 13,
+                        "resolution": 2.3886571339746849,
+                        "scale": 9027.977411
+                    },
+                    {
+                        "level": 14,
+                        "resolution": 1.1943285668550503,
+                        "scale": 4513.988705
+                    },
+                    {
+                        "level": 15,
+                        "resolution": 0.59716428355981721,
+                        "scale": 2256.994353
+                    },
+                    {
+                        "level": 16,
+                        "resolution": 0.29858214164761665,
+                        "scale": 1128.497176
+                    },
+                    {
+                        "level": 17,
+                        "resolution": 0.14929107082380833,
+                        "scale": 564.248588
+                    },
+                    {
+                        "level": 18,
+                        "resolution": 0.074645535411904163,
+                        "scale": 282.124294
+                    },
+                    {
+                        "level": 19,
+                        "resolution": 0.037322767705952081,
+                        "scale": 141.062147
+                    },
+                    {
+                        "level": 20,
+                        "resolution": 0.018661383852976041,
+                        "scale": 70.5310735
+                    }
+                ]
+            }
+        ],
+        "legend": {
+            "type": "structured",
+            "root": {
+                "name": "root",
+                "children": [
+                    {
+                        "layerId": "Nitrates",
+                        "description": "Nitrates released by pulp and paper facilities that reported to the NPRI from 2010 to 2019 (tonnes)",
+                        "symbologyExpanded": true
+                    },
+                    {
+                        "layerId": "Phosphorus",
+                        "description": "Phosphorus released by pulp and paper facilities that reported to the NPRI from 2010 to 2019 (tonnes)",
+                        "symbologyExpanded": true
+                    }
+                ]
+            }
+        },
+        "layers": [
+            {
+                "id": "Nitrates",
+                "name": "Nitrates",
+                "layerType": "esriFeature",
+                "tolerance": 20,
+                "singleEntryCollapse": true,
+                "symbologyExpanded": true,
+                "url": "https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/StoryRAMP/f6f7baf4_cccb_4521_a037_b4691b0f0d49/MapServer/5",
+                "state": {
+                    "opacity": 0.75
+                }
+            },
+            {
+                "id": "Phosphorus",
+                "name": "Phosphorus",
+                "layerType": "esriFeature",
+                "tolerance": 20,
+                "singleEntryCollapse": true,
+                "symbologyExpanded": true,
+                "url": "https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/StoryRAMP/f6f7baf4_cccb_4521_a037_b4691b0f0d49/MapServer/6",
+                "state": {
+                    "opacity": 0.75
+                }
+            }
+        ],
+        "tileSchemas": [
+            {
+                "id": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978",
+                "name": "Lambert Maps",
+                "extentSetId": "EXT_NRCAN_Lambert_3978",
+                "lodSetId": "LOD_NRCAN_Lambert_3978",
+                "hasNorthPole": true
+            },
+            {
+                "id": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857",
+                "name": "Web Mercator Maps",
+                "extentSetId": "EXT_ESRI_World_AuxMerc_3857",
+                "lodSetId": "LOD_ESRI_World_AuxMerc_3857"
+            }
+        ],
+        "baseMaps": [
+            {
+                "id": "baseNrCan",
+                "name": "Canada Base Map - Transportation (CBMT)",
+                "description": "The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.",
+                "altText": "altText - The Canada Base Map - Transportation (CBMT)",
+                "layers": [
+                    {
+                        "id": "CBMT",
+                        "layerType": "esriFeature",
+                        "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+            },
+            {
+                "id": "baseSimple",
+                "name": "Canada Base Map - Simple",
+                "description": "Canada Base Map - Simple",
+                "altText": "altText - Canada base map - Simple",
+                "layers": [
+                    {
+                        "id": "SMR",
+                        "layerType": "esriFeature",
+                        "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+            },
+            {
+                "id": "baseCBME_CBCE_HS_RO_3978",
+                "name": "Canada Base Map - Elevation (CBME)",
+                "description": "The Canada Base Map - Elevation (CBME) web mapping services of the Earth Sciences Sector at Natural Resources Canada, is intended primarily for online mapping application users and developers.",
+                "altText": "altText - Canada Base Map - Elevation (CBME)",
+                "layers": [
+                    {
+                        "id": "CBME_CBCE_HS_RO_3978",
+                        "layerType": "esriFeature",
+                        "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+            },
+            {
+                "id": "baseCBMT_CBCT_GEOM_3978",
+                "name": "Canada Base Map - Transportation (CBMT)",
+                "description": " The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.",
+                "altText": "altText - Canada Base Map - Transportation (CBMT)",
+                "layers": [
+                    {
+                        "id": "CBMT_CBCT_GEOM_3978",
+                        "layerType": "esriFeature",
+                        "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+            },
+            {
+                "id": "baseEsriWorld",
+                "name": "World Imagery",
+                "description": "World Imagery provides one meter or better satellite and aerial imagery in many parts of the world and lower resolution satellite imagery worldwide.",
+                "altText": "altText - World Imagery",
+                "layers": [
+                    {
+                        "id": "World_Imagery",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriPhysical",
+                "name": "World Physical Map",
+                "description": "This map presents the Natural Earth physical map at 1.24km per pixel for the world and 500m for the coterminous United States.",
+                "altText": "altText - World Physical Map",
+                "layers": [
+                    {
+                        "id": "World_Physical_Map",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Physical_Map/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriRelief",
+                "name": "World Shaded Relief",
+                "description": "This map portrays surface elevation as shaded relief. This map is used as a basemap layer to add shaded relief to other GIS maps, such as the ArcGIS Online World Street Map.",
+                "altText": "altText - World Shaded Relief",
+                "layers": [
+                    {
+                        "id": "World_Shaded_Relief",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Shaded_Relief/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriStreet",
+                "name": "World Street Map",
+                "description": "This worldwide street map presents highway-level data for the world.",
+                "altText": "altText - ESWorld Street Map",
+                "layers": [
+                    {
+                        "id": "World_Street_Map",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Street_Map/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriTerrain",
+                "name": "World Terrain Base",
+                "description": "This map is designed to be used as a base map by GIS professionals to overlay other thematic layers such as demographics or land cover.",
+                "altText": "altText - World Terrain Base",
+                "layers": [
+                    {
+                        "id": "World_Terrain_Base",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Terrain_Base/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriTopo",
+                "name": "World Topographic Map",
+                "description": "This map is designed to be used as a basemap by GIS professionals and as a reference map by anyone.",
+                "altText": "altText - World Topographic Map",
+                "layers": [
+                    {
+                        "id": "World_Topo_Map",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            }
         ]
-      }
-  },
-    "layers": [
-      {
-          "id": "Nitrates",
-          "name": "Nitrates",
-          "layerType": "esriFeature",
-          "tolerance": 20,
-          "singleEntryCollapse": true,
-          "symbologyExpanded": true,
-          "url": "https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/StoryRAMP/f6f7baf4_cccb_4521_a037_b4691b0f0d49/MapServer/5",
-          "state": {
-            "opacity": 0.75
-          }               
-      },
-      {
-        "id": "Phosphorus",
-        "name": "Phosphorus",
-        "layerType": "esriFeature",
-        "tolerance": 20,
-        "singleEntryCollapse": true,
-        "symbologyExpanded": true,
-        "url": "https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/StoryRAMP/f6f7baf4_cccb_4521_a037_b4691b0f0d49/MapServer/6",
-        "state": {
-          "opacity": 0.75
-        }           
-      }      
-    ],
-    "tileSchemas": [
-      {
-        "id": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978",
-        "name": "Lambert Maps",
-        "extentSetId": "EXT_NRCAN_Lambert_3978",
-        "lodSetId": "LOD_NRCAN_Lambert_3978",
-        "hasNorthPole": true
-      },
-      {
-        "id": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857",
-        "name": "Web Mercator Maps",
-        "extentSetId": "EXT_ESRI_World_AuxMerc_3857",
-        "lodSetId": "LOD_ESRI_World_AuxMerc_3857"
-      }
-    ],
-    "baseMaps": [
-      {
-        "id": "baseNrCan",
-        "name": "Canada Base Map - Transportation (CBMT)",
-        "description": "The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.",
-        "altText": "altText - The Canada Base Map - Transportation (CBMT)",
-        "layers": [
-          {
-            "id": "CBMT",
-            "layerType": "esriFeature",
-            "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
-      },
-      {
-        "id": "baseSimple",
-        "name": "Canada Base Map - Simple",
-        "description": "Canada Base Map - Simple",
-        "altText": "altText - Canada base map - Simple",
-        "layers": [
-          {
-            "id": "SMR",
-            "layerType": "esriFeature",
-            "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
-      },
-      {
-        "id": "baseCBME_CBCE_HS_RO_3978",
-        "name": "Canada Base Map - Elevation (CBME)",
-        "description": "The Canada Base Map - Elevation (CBME) web mapping services of the Earth Sciences Sector at Natural Resources Canada, is intended primarily for online mapping application users and developers.",
-        "altText": "altText - Canada Base Map - Elevation (CBME)",
-        "layers": [
-          {
-            "id": "CBME_CBCE_HS_RO_3978",
-            "layerType": "esriFeature",
-            "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
-      },
-      {
-        "id": "baseCBMT_CBCT_GEOM_3978",
-        "name": "Canada Base Map - Transportation (CBMT)",
-        "description": " The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.",
-        "altText": "altText - Canada Base Map - Transportation (CBMT)",
-        "layers": [
-          {
-            "id": "CBMT_CBCT_GEOM_3978",
-            "layerType": "esriFeature",
-            "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
-      },
-      {
-        "id": "baseEsriWorld",
-        "name": "World Imagery",
-        "description": "World Imagery provides one meter or better satellite and aerial imagery in many parts of the world and lower resolution satellite imagery worldwide.",
-        "altText": "altText - World Imagery",
-        "layers": [
-          {
-            "id": "World_Imagery",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      },
-      {
-        "id": "baseEsriPhysical",
-        "name": "World Physical Map",
-        "description": "This map presents the Natural Earth physical map at 1.24km per pixel for the world and 500m for the coterminous United States.",
-        "altText": "altText - World Physical Map",
-        "layers": [
-          {
-            "id": "World_Physical_Map",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Physical_Map/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      },
-      {
-        "id": "baseEsriRelief",
-        "name": "World Shaded Relief",
-        "description": "This map portrays surface elevation as shaded relief. This map is used as a basemap layer to add shaded relief to other GIS maps, such as the ArcGIS Online World Street Map.",
-        "altText": "altText - World Shaded Relief",
-        "layers": [
-          {
-            "id": "World_Shaded_Relief",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Shaded_Relief/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      },
-      {
-        "id": "baseEsriStreet",
-        "name": "World Street Map",
-        "description": "This worldwide street map presents highway-level data for the world.",
-        "altText": "altText - ESWorld Street Map",
-        "layers": [
-          {
-            "id": "World_Street_Map",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Street_Map/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      },
-      {
-        "id": "baseEsriTerrain",
-        "name": "World Terrain Base",
-        "description": "This map is designed to be used as a base map by GIS professionals to overlay other thematic layers such as demographics or land cover.",
-        "altText": "altText - World Terrain Base",
-        "layers": [
-          {
-            "id": "World_Terrain_Base",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Terrain_Base/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      },
-      {
-        "id": "baseEsriTopo",
-        "name": "World Topographic Map",
-        "description": "This map is designed to be used as a basemap by GIS professionals and as a reference map by anyone.",
-        "altText": "altText - World Topographic Map",
-        "layers": [
-          {
-            "id": "World_Topo_Map",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      }
-    ]
-  }
+    }
 }

--- a/public/f6f7baf4-cccb-4521-a037-b4691b0f0d49/ramp-config/en/pollution_prevention_activities.json
+++ b/public/f6f7baf4-cccb-4521-a037-b4691b0f0d49/ramp-config/en/pollution_prevention_activities.json
@@ -1,507 +1,534 @@
 {
-  "version": "2.0",
-  "language": "en",
-  "ui": {
-    "title": "Interactive map",
-    "fullscreen": true,
-    "navBar": {
-      "zoom": "buttons",
-      "extra": [ "fullscreen", "geoLocator", "home", "help" ]
-    },
-    "appBar": {
-      "basemap": true
-
-    },
-    "help": {
-      "folderName": "default"
-    },
-    "sideMenu": {
-      "items": [ [ "fullscreen", "export", "touch", "help", "about" ] ],
-      "logo": false
-    },
-    "legend": {
-      "allowImport": true,
-      "isOpen": {
-        "large": true,
-        "medium": false,
-        "small": false
-      }
-    }
-  },
-  "services": {
-    "proxyUrl": "http://167.40.64.74/wmsproxy/ws/wmsproxy/executeFromProxy",
-    "exportMapUrl": "https://maps-cartes.dev.ec.gc.ca/arcgis/rest/services/Utilities/PrintingTools/GPServer/Export%20Web%20Map%20Task",
-    "export": {
-      "title": {
-        "value": "Pollution prevention activities of pulp and paper facilities that reported to the NPRI in 2019"
-      },
-      "map": {},
-      "mapElements": {},
-      "legend": {},
-      "footnote": {
-        "value": "Pollution prevention activities of pulp and paper facilities that reported to the NPRI in 2019"
-      }
-    },
-    "search": {
-      "settings": {
-        "categories": [ "CITY", "HAM", "IR", "LTM", "MUN1", "MUN2", "PROV", "STM", "TERR", "TOWN", "UTM", "VILG", "UNP" ],
-        "sortOrder": [ "CITY", "HAM", "IR", "LTM", "MUN1", "MUN2", "PROV", "STM", "TERR", "TOWN", "UTM", "VILG", "UNP" ],
-        "maxResults": 1000,
-        "officialOnly": true
-      },	
-      "serviceUrls": {
-        "geoNames": "https://geogratis.gc.ca/services/geoname/en/geonames.json",
-        "geoLocation": "https://geogratis.gc.ca/services/geolocation/en/locate?q=",
-        "geoSuggest": "https://geogratis.gc.ca/services/geolocation/en/suggest?q=",
-        "provinces": "https://geogratis.gc.ca/services/geoname/en/codes/province.json",
-        "types": "https://geogratis.gc.ca/services/geoname/en/codes/concise.json"
-      }
-    }
-  },
-  "map": {
-    "initialBasemapId": "baseNrCan",
-    "components": {
-      "geoSearch": {
-        "enabled": true,
-        "showGraphic": true,
-        "showInfo": true
-      },
-      "mouseInfo": {
-        "enabled": true,
-        "spatialReference": {
-          "wkid": 4326
-        }
-      },
-      "northArrow": {
-        "enabled": false
-      },
-      "basemap": {
-        "enabled": true
-      },
-      "overviewMap": {
-        "enabled": true,
-        "layerType": "imagery"
-      },
-      "scaleBar": {
-        "enabled": true
-      }
-    },
-    "extentSets": [
-      {
-        "id": "EXT_NRCAN_Lambert_3978",
-        "default": {
-          "xmax": 2849492,
-          "xmin": -5281457,
-          "ymax": 4482193,
-          "ymin": -983440
+    "version": "2.0",
+    "language": "en",
+    "ui": {
+        "title": "Interactive map",
+        "fullscreen": true,
+        "navBar": {
+            "zoom": "buttons",
+            "extra": ["fullscreen", "geoLocator", "home", "help"]
         },
-        "spatialReference": {
-          "wkid": 3978
-        }
-      },
-      {
-        "id": "EXT_ESRI_World_AuxMerc_3857",
-        "default": {
-          "xmax": -5007771.626060756,
-          "xmin": -16632697.354854,
-          "ymax": 10015875.184845109,
-          "ymin": 5022907.964742964
+        "appBar": {
+            "basemap": true
         },
-        "spatialReference": {
-          "wkid": 102100,
-          "latestWkid": 3857
+        "help": {
+            "folderName": "default"
+        },
+        "sideMenu": {
+            "items": [["fullscreen", "export", "touch", "help", "about"]],
+            "logo": false
+        },
+        "legend": {
+            "allowImport": true,
+            "isOpen": {
+                "large": true,
+                "medium": false,
+                "small": false
+            }
         }
-      }
-    ],
-    "lodSets": [
-      {
-        "id": "LOD_NRCAN_Lambert_3978",
-        "lods": [
-          {
-            "level": 0,
-            "resolution": 38364.660062653464,
-            "scale": 145000000
-          },
-          {
-            "level": 1,
-            "resolution": 22489.628312589961,
-            "scale": 85000000
-          },
-          {
-            "level": 2,
-            "resolution": 13229.193125052918,
-            "scale": 50000000
-          },
-          {
-            "level": 3,
-            "resolution": 7937.5158750317505,
-            "scale": 30000000
-          },
-          {
-            "level": 4,
-            "resolution": 4630.2175937685215,
-            "scale": 17500000
-          },
-          {
-            "level": 5,
-            "resolution": 2645.8386250105837,
-            "scale": 10000000
-          },
-          {
-            "level": 6,
-            "resolution": 1587.5031750063501,
-            "scale": 6000000
-          },
-          {
-            "level": 7,
-            "resolution": 926.04351875370423,
-            "scale": 3500000
-          },
-          {
-            "level": 8,
-            "resolution": 529.16772500211675,
-            "scale": 2000000
-          },
-          {
-            "level": 9,
-            "resolution": 317.50063500127004,
-            "scale": 1200000
-          },
-          {
-            "level": 10,
-            "resolution": 185.20870375074085,
-            "scale": 700000
-          },
-          {
-            "level": 11,
-            "resolution": 111.12522225044451,
-            "scale": 420000
-          },
-          {
-            "level": 12,
-            "resolution": 66.1459656252646,
-            "scale": 250000
-          },
-          {
-            "level": 13,
-            "resolution": 38.364660062653464,
-            "scale": 145000
-          },
-          {
-            "level": 14,
-            "resolution": 22.489628312589961,
-            "scale": 85000
-          },
-          {
-            "level": 15,
-            "resolution": 13.229193125052918,
-            "scale": 50000
-          },
-          {
-            "level": 16,
-            "resolution": 7.9375158750317505,
-            "scale": 30000
-          },
-          {
-            "level": 17,
-            "resolution": 4.6302175937685215,
-            "scale": 17500
-          }
-        ]
-      },
-      {
-        "id": "LOD_ESRI_World_AuxMerc_3857",
-        "lods": [
-          {
-            "level": 0,
-            "resolution": 19567.879240999919,
-            "scale": 73957190.948944
-          },
-          {
-            "level": 1,
-            "resolution": 9783.93962049996,
-            "scale": 36978595.474472
-          },
-          {
-            "level": 2,
-            "resolution": 4891.96981024998,
-            "scale": 18489297.737236
-          },
-          {
-            "level": 3,
-            "resolution": 2445.98490512499,
-            "scale": 9244648.868618
-          },
-          {
-            "level": 4,
-            "resolution": 1222.9924525624949,
-            "scale": 4622324.434309
-          },
-          {
-            "level": 5,
-            "resolution": 611.49622628137968,
-            "scale": 2311162.217155
-          },
-          {
-            "level": 6,
-            "resolution": 305.74811314055756,
-            "scale": 1155581.108577
-          },
-          {
-            "level": 7,
-            "resolution": 152.87405657041106,
-            "scale": 577790.554289
-          },
-          {
-            "level": 8,
-            "resolution": 76.437028285073239,
-            "scale": 288895.277144
-          },
-          {
-            "level": 9,
-            "resolution": 38.21851414253662,
-            "scale": 144447.638572
-          },
-          {
-            "level": 10,
-            "resolution": 19.10925707126831,
-            "scale": 72223.819286
-          },
-          {
-            "level": 11,
-            "resolution": 9.5546285356341549,
-            "scale": 36111.909643
-          },
-          {
-            "level": 12,
-            "resolution": 4.77731426794937,
-            "scale": 18055.954822
-          },
-          {
-            "level": 13,
-            "resolution": 2.3886571339746849,
-            "scale": 9027.977411
-          },
-          {
-            "level": 14,
-            "resolution": 1.1943285668550503,
-            "scale": 4513.988705
-          },
-          {
-            "level": 15,
-            "resolution": 0.59716428355981721,
-            "scale": 2256.994353
-          },
-          {
-            "level": 16,
-            "resolution": 0.29858214164761665,
-            "scale": 1128.497176
-          },
-          {
-            "level": 17,
-            "resolution": 0.14929107082380833,
-            "scale": 564.248588
-          },
-          {
-            "level": 18,
-            "resolution": 0.074645535411904163,
-            "scale": 282.124294
-          },
-          {
-            "level": 19,
-            "resolution": 0.037322767705952081,
-            "scale": 141.062147
-          },
-          {
-            "level": 20,
-            "resolution": 0.018661383852976041,
-            "scale": 70.5310735
-          }
-        ]
-      }
-    ],
-    "legend": {
-      "type": "structured",
-      "root": {
-          "name": "root",
-          "children": [
+    },
+    "services": {
+        "proxyUrl": "http://167.40.64.74/wmsproxy/ws/wmsproxy/executeFromProxy",
+        "exportMapUrl": "https://maps-cartes.dev.ec.gc.ca/arcgis/rest/services/Utilities/PrintingTools/GPServer/Export%20Web%20Map%20Task",
+        "export": {
+            "title": {
+                "value": "Pollution prevention activities of pulp and paper facilities that reported to the NPRI in 2019"
+            },
+            "map": {},
+            "mapElements": {},
+            "legend": {},
+            "footnote": {
+                "value": "Pollution prevention activities of pulp and paper facilities that reported to the NPRI in 2019"
+            }
+        },
+        "search": {
+            "settings": {
+                "categories": [
+                    "CITY",
+                    "HAM",
+                    "IR",
+                    "LTM",
+                    "MUN1",
+                    "MUN2",
+                    "PROV",
+                    "STM",
+                    "TERR",
+                    "TOWN",
+                    "UTM",
+                    "VILG",
+                    "UNP"
+                ],
+                "sortOrder": [
+                    "CITY",
+                    "HAM",
+                    "IR",
+                    "LTM",
+                    "MUN1",
+                    "MUN2",
+                    "PROV",
+                    "STM",
+                    "TERR",
+                    "TOWN",
+                    "UTM",
+                    "VILG",
+                    "UNP"
+                ],
+                "maxResults": 1000,
+                "officialOnly": true
+            },
+            "serviceUrls": {
+                "geoNames": "https://geogratis.gc.ca/services/geoname/en/geonames.json",
+                "geoLocation": "https://geogratis.gc.ca/services/geolocation/en/locate?q=",
+                "geoSuggest": "https://geogratis.gc.ca/services/geolocation/en/suggest?q=",
+                "provinces": "https://geogratis.gc.ca/services/geoname/en/codes/province.json",
+                "types": "https://geogratis.gc.ca/services/geoname/en/codes/concise.json"
+            }
+        }
+    },
+    "map": {
+        "initialBasemapId": "baseNrCan",
+        "components": {
+            "geoSearch": {
+                "enabled": true,
+                "showGraphic": true,
+                "showInfo": true
+            },
+            "mouseInfo": {
+                "enabled": true,
+                "spatialReference": {
+                    "wkid": 4326
+                }
+            },
+            "northArrow": {
+                "enabled": false
+            },
+            "basemap": {
+                "enabled": true
+            },
+            "overviewMap": {
+                "enabled": true,
+                "layerType": "imagery"
+            },
+            "scaleBar": {
+                "enabled": true
+            }
+        },
+        "extentSets": [
             {
-                "layerId": "PPA",
-                "description": "Pollution prevention activities of pulp and paper facilities that reported to the NPRI in 2019",                
-                "symbologyExpanded": true
+                "id": "EXT_NRCAN_Lambert_3978",
+                "default": {
+                    "xmax": 2249492,
+                    "xmin": -5881457,
+                    "ymax": 4482193,
+                    "ymin": -983440
+                },
+                "spatialReference": {
+                    "wkid": 3978
+                }
+            },
+            {
+                "id": "EXT_ESRI_World_AuxMerc_3857",
+                "default": {
+                    "xmax": -5007771.626060756,
+                    "xmin": -16632697.354854,
+                    "ymax": 10015875.184845109,
+                    "ymin": 5022907.964742964
+                },
+                "spatialReference": {
+                    "wkid": 102100,
+                    "latestWkid": 3857
+                }
+            }
+        ],
+        "lodSets": [
+            {
+                "id": "LOD_NRCAN_Lambert_3978",
+                "lods": [
+                    {
+                        "level": 0,
+                        "resolution": 38364.660062653464,
+                        "scale": 145000000
+                    },
+                    {
+                        "level": 1,
+                        "resolution": 22489.628312589961,
+                        "scale": 85000000
+                    },
+                    {
+                        "level": 2,
+                        "resolution": 13229.193125052918,
+                        "scale": 50000000
+                    },
+                    {
+                        "level": 3,
+                        "resolution": 7937.5158750317505,
+                        "scale": 30000000
+                    },
+                    {
+                        "level": 4,
+                        "resolution": 4630.2175937685215,
+                        "scale": 17500000
+                    },
+                    {
+                        "level": 5,
+                        "resolution": 2645.8386250105837,
+                        "scale": 10000000
+                    },
+                    {
+                        "level": 6,
+                        "resolution": 1587.5031750063501,
+                        "scale": 6000000
+                    },
+                    {
+                        "level": 7,
+                        "resolution": 926.04351875370423,
+                        "scale": 3500000
+                    },
+                    {
+                        "level": 8,
+                        "resolution": 529.16772500211675,
+                        "scale": 2000000
+                    },
+                    {
+                        "level": 9,
+                        "resolution": 317.50063500127004,
+                        "scale": 1200000
+                    },
+                    {
+                        "level": 10,
+                        "resolution": 185.20870375074085,
+                        "scale": 700000
+                    },
+                    {
+                        "level": 11,
+                        "resolution": 111.12522225044451,
+                        "scale": 420000
+                    },
+                    {
+                        "level": 12,
+                        "resolution": 66.1459656252646,
+                        "scale": 250000
+                    },
+                    {
+                        "level": 13,
+                        "resolution": 38.364660062653464,
+                        "scale": 145000
+                    },
+                    {
+                        "level": 14,
+                        "resolution": 22.489628312589961,
+                        "scale": 85000
+                    },
+                    {
+                        "level": 15,
+                        "resolution": 13.229193125052918,
+                        "scale": 50000
+                    },
+                    {
+                        "level": 16,
+                        "resolution": 7.9375158750317505,
+                        "scale": 30000
+                    },
+                    {
+                        "level": 17,
+                        "resolution": 4.6302175937685215,
+                        "scale": 17500
+                    }
+                ]
+            },
+            {
+                "id": "LOD_ESRI_World_AuxMerc_3857",
+                "lods": [
+                    {
+                        "level": 0,
+                        "resolution": 19567.879240999919,
+                        "scale": 73957190.948944
+                    },
+                    {
+                        "level": 1,
+                        "resolution": 9783.93962049996,
+                        "scale": 36978595.474472
+                    },
+                    {
+                        "level": 2,
+                        "resolution": 4891.96981024998,
+                        "scale": 18489297.737236
+                    },
+                    {
+                        "level": 3,
+                        "resolution": 2445.98490512499,
+                        "scale": 9244648.868618
+                    },
+                    {
+                        "level": 4,
+                        "resolution": 1222.9924525624949,
+                        "scale": 4622324.434309
+                    },
+                    {
+                        "level": 5,
+                        "resolution": 611.49622628137968,
+                        "scale": 2311162.217155
+                    },
+                    {
+                        "level": 6,
+                        "resolution": 305.74811314055756,
+                        "scale": 1155581.108577
+                    },
+                    {
+                        "level": 7,
+                        "resolution": 152.87405657041106,
+                        "scale": 577790.554289
+                    },
+                    {
+                        "level": 8,
+                        "resolution": 76.437028285073239,
+                        "scale": 288895.277144
+                    },
+                    {
+                        "level": 9,
+                        "resolution": 38.21851414253662,
+                        "scale": 144447.638572
+                    },
+                    {
+                        "level": 10,
+                        "resolution": 19.10925707126831,
+                        "scale": 72223.819286
+                    },
+                    {
+                        "level": 11,
+                        "resolution": 9.5546285356341549,
+                        "scale": 36111.909643
+                    },
+                    {
+                        "level": 12,
+                        "resolution": 4.77731426794937,
+                        "scale": 18055.954822
+                    },
+                    {
+                        "level": 13,
+                        "resolution": 2.3886571339746849,
+                        "scale": 9027.977411
+                    },
+                    {
+                        "level": 14,
+                        "resolution": 1.1943285668550503,
+                        "scale": 4513.988705
+                    },
+                    {
+                        "level": 15,
+                        "resolution": 0.59716428355981721,
+                        "scale": 2256.994353
+                    },
+                    {
+                        "level": 16,
+                        "resolution": 0.29858214164761665,
+                        "scale": 1128.497176
+                    },
+                    {
+                        "level": 17,
+                        "resolution": 0.14929107082380833,
+                        "scale": 564.248588
+                    },
+                    {
+                        "level": 18,
+                        "resolution": 0.074645535411904163,
+                        "scale": 282.124294
+                    },
+                    {
+                        "level": 19,
+                        "resolution": 0.037322767705952081,
+                        "scale": 141.062147
+                    },
+                    {
+                        "level": 20,
+                        "resolution": 0.018661383852976041,
+                        "scale": 70.5310735
+                    }
+                ]
+            }
+        ],
+        "legend": {
+            "type": "structured",
+            "root": {
+                "name": "root",
+                "children": [
+                    {
+                        "layerId": "PPA",
+                        "description": "Pollution prevention activities of pulp and paper facilities that reported to the NPRI in 2019",
+                        "symbologyExpanded": true
+                    }
+                ]
+            }
+        },
+        "layers": [
+            {
+                "id": "PPA",
+                "name": "Pollution prevention activities",
+                "layerType": "esriFeature",
+                "singleEntryCollapse": true,
+                "symbologyExpanded": true,
+                "url": "https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/StoryRAMP/f6f7baf4_cccb_4521_a037_b4691b0f0d49/MapServer/8",
+                "state": {
+                    "opacity": 0.75
+                }
+            }
+        ],
+        "tileSchemas": [
+            {
+                "id": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978",
+                "name": "Lambert Maps",
+                "extentSetId": "EXT_NRCAN_Lambert_3978",
+                "lodSetId": "LOD_NRCAN_Lambert_3978",
+                "hasNorthPole": true
+            },
+            {
+                "id": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857",
+                "name": "Web Mercator Maps",
+                "extentSetId": "EXT_ESRI_World_AuxMerc_3857",
+                "lodSetId": "LOD_ESRI_World_AuxMerc_3857"
+            }
+        ],
+        "baseMaps": [
+            {
+                "id": "baseNrCan",
+                "name": "Canada Base Map - Transportation (CBMT)",
+                "description": "The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.",
+                "altText": "altText - The Canada Base Map - Transportation (CBMT)",
+                "layers": [
+                    {
+                        "id": "CBMT",
+                        "layerType": "esriFeature",
+                        "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+            },
+            {
+                "id": "baseSimple",
+                "name": "Canada Base Map - Simple",
+                "description": "Canada Base Map - Simple",
+                "altText": "altText - Canada base map - Simple",
+                "layers": [
+                    {
+                        "id": "SMR",
+                        "layerType": "esriFeature",
+                        "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+            },
+            {
+                "id": "baseCBME_CBCE_HS_RO_3978",
+                "name": "Canada Base Map - Elevation (CBME)",
+                "description": "The Canada Base Map - Elevation (CBME) web mapping services of the Earth Sciences Sector at Natural Resources Canada, is intended primarily for online mapping application users and developers.",
+                "altText": "altText - Canada Base Map - Elevation (CBME)",
+                "layers": [
+                    {
+                        "id": "CBME_CBCE_HS_RO_3978",
+                        "layerType": "esriFeature",
+                        "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+            },
+            {
+                "id": "baseCBMT_CBCT_GEOM_3978",
+                "name": "Canada Base Map - Transportation (CBMT)",
+                "description": " The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.",
+                "altText": "altText - Canada Base Map - Transportation (CBMT)",
+                "layers": [
+                    {
+                        "id": "CBMT_CBCT_GEOM_3978",
+                        "layerType": "esriFeature",
+                        "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+            },
+            {
+                "id": "baseEsriWorld",
+                "name": "World Imagery",
+                "description": "World Imagery provides one meter or better satellite and aerial imagery in many parts of the world and lower resolution satellite imagery worldwide.",
+                "altText": "altText - World Imagery",
+                "layers": [
+                    {
+                        "id": "World_Imagery",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriPhysical",
+                "name": "World Physical Map",
+                "description": "This map presents the Natural Earth physical map at 1.24km per pixel for the world and 500m for the coterminous United States.",
+                "altText": "altText - World Physical Map",
+                "layers": [
+                    {
+                        "id": "World_Physical_Map",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Physical_Map/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriRelief",
+                "name": "World Shaded Relief",
+                "description": "This map portrays surface elevation as shaded relief. This map is used as a basemap layer to add shaded relief to other GIS maps, such as the ArcGIS Online World Street Map.",
+                "altText": "altText - World Shaded Relief",
+                "layers": [
+                    {
+                        "id": "World_Shaded_Relief",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Shaded_Relief/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriStreet",
+                "name": "World Street Map",
+                "description": "This worldwide street map presents highway-level data for the world.",
+                "altText": "altText - ESWorld Street Map",
+                "layers": [
+                    {
+                        "id": "World_Street_Map",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Street_Map/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriTerrain",
+                "name": "World Terrain Base",
+                "description": "This map is designed to be used as a base map by GIS professionals to overlay other thematic layers such as demographics or land cover.",
+                "altText": "altText - World Terrain Base",
+                "layers": [
+                    {
+                        "id": "World_Terrain_Base",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Terrain_Base/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriTopo",
+                "name": "World Topographic Map",
+                "description": "This map is designed to be used as a basemap by GIS professionals and as a reference map by anyone.",
+                "altText": "altText - World Topographic Map",
+                "layers": [
+                    {
+                        "id": "World_Topo_Map",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
             }
         ]
-      }
-  },
-    "layers": [
-      {
-          "id": "PPA",
-          "name": "Pollution prevention activities",
-          "layerType": "esriFeature",
-          "singleEntryCollapse": true,
-          "symbologyExpanded": true,
-          "url": "https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/StoryRAMP/f6f7baf4_cccb_4521_a037_b4691b0f0d49/MapServer/8",
-          "state": {
-            "opacity": 0.75
-          }
-      }
-    ],
-    "tileSchemas": [
-      {
-        "id": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978",
-        "name": "Lambert Maps",
-        "extentSetId": "EXT_NRCAN_Lambert_3978",
-        "lodSetId": "LOD_NRCAN_Lambert_3978",
-        "hasNorthPole": true
-      },
-      {
-        "id": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857",
-        "name": "Web Mercator Maps",
-        "extentSetId": "EXT_ESRI_World_AuxMerc_3857",
-        "lodSetId": "LOD_ESRI_World_AuxMerc_3857"
-      }
-    ],
-    "baseMaps": [
-      {
-        "id": "baseNrCan",
-        "name": "Canada Base Map - Transportation (CBMT)",
-        "description": "The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.",
-        "altText": "altText - The Canada Base Map - Transportation (CBMT)",
-        "layers": [
-          {
-            "id": "CBMT",
-            "layerType": "esriFeature",
-            "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
-      },
-      {
-        "id": "baseSimple",
-        "name": "Canada Base Map - Simple",
-        "description": "Canada Base Map - Simple",
-        "altText": "altText - Canada base map - Simple",
-        "layers": [
-          {
-            "id": "SMR",
-            "layerType": "esriFeature",
-            "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
-      },
-      {
-        "id": "baseCBME_CBCE_HS_RO_3978",
-        "name": "Canada Base Map - Elevation (CBME)",
-        "description": "The Canada Base Map - Elevation (CBME) web mapping services of the Earth Sciences Sector at Natural Resources Canada, is intended primarily for online mapping application users and developers.",
-        "altText": "altText - Canada Base Map - Elevation (CBME)",
-        "layers": [
-          {
-            "id": "CBME_CBCE_HS_RO_3978",
-            "layerType": "esriFeature",
-            "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
-      },
-      {
-        "id": "baseCBMT_CBCT_GEOM_3978",
-        "name": "Canada Base Map - Transportation (CBMT)",
-        "description": " The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.",
-        "altText": "altText - Canada Base Map - Transportation (CBMT)",
-        "layers": [
-          {
-            "id": "CBMT_CBCT_GEOM_3978",
-            "layerType": "esriFeature",
-            "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
-      },
-      {
-        "id": "baseEsriWorld",
-        "name": "World Imagery",
-        "description": "World Imagery provides one meter or better satellite and aerial imagery in many parts of the world and lower resolution satellite imagery worldwide.",
-        "altText": "altText - World Imagery",
-        "layers": [
-          {
-            "id": "World_Imagery",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      },
-      {
-        "id": "baseEsriPhysical",
-        "name": "World Physical Map",
-        "description": "This map presents the Natural Earth physical map at 1.24km per pixel for the world and 500m for the coterminous United States.",
-        "altText": "altText - World Physical Map",
-        "layers": [
-          {
-            "id": "World_Physical_Map",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Physical_Map/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      },
-      {
-        "id": "baseEsriRelief",
-        "name": "World Shaded Relief",
-        "description": "This map portrays surface elevation as shaded relief. This map is used as a basemap layer to add shaded relief to other GIS maps, such as the ArcGIS Online World Street Map.",
-        "altText": "altText - World Shaded Relief",
-        "layers": [
-          {
-            "id": "World_Shaded_Relief",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Shaded_Relief/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      },
-      {
-        "id": "baseEsriStreet",
-        "name": "World Street Map",
-        "description": "This worldwide street map presents highway-level data for the world.",
-        "altText": "altText - ESWorld Street Map",
-        "layers": [
-          {
-            "id": "World_Street_Map",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Street_Map/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      },
-      {
-        "id": "baseEsriTerrain",
-        "name": "World Terrain Base",
-        "description": "This map is designed to be used as a base map by GIS professionals to overlay other thematic layers such as demographics or land cover.",
-        "altText": "altText - World Terrain Base",
-        "layers": [
-          {
-            "id": "World_Terrain_Base",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Terrain_Base/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      },
-      {
-        "id": "baseEsriTopo",
-        "name": "World Topographic Map",
-        "description": "This map is designed to be used as a basemap by GIS professionals and as a reference map by anyone.",
-        "altText": "altText - World Topographic Map",
-        "layers": [
-          {
-            "id": "World_Topo_Map",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      }
-    ]
-  }
+    }
 }

--- a/public/f6f7baf4-cccb-4521-a037-b4691b0f0d49/ramp-config/en/total_criteria_air_contaminants_of_pnp_2010-2019.json
+++ b/public/f6f7baf4-cccb-4521-a037-b4691b0f0d49/ramp-config/en/total_criteria_air_contaminants_of_pnp_2010-2019.json
@@ -1,508 +1,535 @@
 {
-  "version": "2.0",
-  "language": "en",
-  "ui": {
-    "title": "Interactive map",
-    "fullscreen": true,
-    "navBar": {
-      "zoom": "buttons",
-      "extra": [ "fullscreen", "geoLocator", "home", "help" ]
-    },
-    "appBar": {
-      "basemap": true
-
-    },
-    "help": {
-      "folderName": "default"
-    },
-    "sideMenu": {
-      "items": [ [ "fullscreen", "export", "touch", "help", "about" ] ],
-      "logo": false
-    },
-    "legend": {
-      "allowImport": true,
-      "isOpen": {
-        "large": true,
-        "medium": false,
-        "small": false
-      }
-    }
-  },
-  "services": {
-    "proxyUrl": "http://167.40.64.74/wmsproxy/ws/wmsproxy/executeFromProxy",
-    "exportMapUrl": "https://maps-cartes.dev.ec.gc.ca/arcgis/rest/services/Utilities/PrintingTools/GPServer/Export%20Web%20Map%20Task",
-    "export": {
-      "title": {
-        "value": "Total releases and disposals of pulp and paper facilities that reported to the NPRI from 2010 to 2019"
-      },
-      "map": {},
-      "mapElements": {},
-      "legend": {},
-      "footnote": {
-        "value": "Total releases and disposals of pulp and paper facilities that reported to the NPRI from 2010 to 2019"
-      }
-    },
-    "search": {
-      "settings": {
-        "categories": [ "CITY", "HAM", "IR", "LTM", "MUN1", "MUN2", "PROV", "STM", "TERR", "TOWN", "UTM", "VILG", "UNP" ],
-        "sortOrder": [ "CITY", "HAM", "IR", "LTM", "MUN1", "MUN2", "PROV", "STM", "TERR", "TOWN", "UTM", "VILG", "UNP" ],
-        "maxResults": 1000,
-        "officialOnly": true
-      },	
-      "serviceUrls": {
-        "geoNames": "https://geogratis.gc.ca/services/geoname/en/geonames.json",
-        "geoLocation": "https://geogratis.gc.ca/services/geolocation/en/locate?q=",
-        "geoSuggest": "https://geogratis.gc.ca/services/geolocation/en/suggest?q=",
-        "provinces": "https://geogratis.gc.ca/services/geoname/en/codes/province.json",
-        "types": "https://geogratis.gc.ca/services/geoname/en/codes/concise.json"
-      }
-    }
-  },
-  "map": {
-    "initialBasemapId": "baseNrCan",
-    "components": {
-      "geoSearch": {
-        "enabled": true,
-        "showGraphic": true,
-        "showInfo": true
-      },
-      "mouseInfo": {
-        "enabled": true,
-        "spatialReference": {
-          "wkid": 4326
-        }
-      },
-      "northArrow": {
-        "enabled": false
-      },
-      "basemap": {
-        "enabled": true
-      },
-      "overviewMap": {
-        "enabled": true,
-        "layerType": "imagery"
-      },
-      "scaleBar": {
-        "enabled": true
-      }
-    },
-    "extentSets": [
-      {
-        "id": "EXT_NRCAN_Lambert_3978",
-        "default": {
-          "xmax": 2849492,
-          "xmin": -5281457,
-          "ymax": 4482193,
-          "ymin": -983440
+    "version": "2.0",
+    "language": "en",
+    "ui": {
+        "title": "Interactive map",
+        "fullscreen": true,
+        "navBar": {
+            "zoom": "buttons",
+            "extra": ["fullscreen", "geoLocator", "home", "help"]
         },
-        "spatialReference": {
-          "wkid": 3978
-        }
-      },
-      {
-        "id": "EXT_ESRI_World_AuxMerc_3857",
-        "default": {
-          "xmax": -5007771.626060756,
-          "xmin": -16632697.354854,
-          "ymax": 10015875.184845109,
-          "ymin": 5022907.964742964
+        "appBar": {
+            "basemap": true
         },
-        "spatialReference": {
-          "wkid": 102100,
-          "latestWkid": 3857
+        "help": {
+            "folderName": "default"
+        },
+        "sideMenu": {
+            "items": [["fullscreen", "export", "touch", "help", "about"]],
+            "logo": false
+        },
+        "legend": {
+            "allowImport": true,
+            "isOpen": {
+                "large": true,
+                "medium": false,
+                "small": false
+            }
         }
-      }
-    ],
-    "lodSets": [
-      {
-        "id": "LOD_NRCAN_Lambert_3978",
-        "lods": [
-          {
-            "level": 0,
-            "resolution": 38364.660062653464,
-            "scale": 145000000
-          },
-          {
-            "level": 1,
-            "resolution": 22489.628312589961,
-            "scale": 85000000
-          },
-          {
-            "level": 2,
-            "resolution": 13229.193125052918,
-            "scale": 50000000
-          },
-          {
-            "level": 3,
-            "resolution": 7937.5158750317505,
-            "scale": 30000000
-          },
-          {
-            "level": 4,
-            "resolution": 4630.2175937685215,
-            "scale": 17500000
-          },
-          {
-            "level": 5,
-            "resolution": 2645.8386250105837,
-            "scale": 10000000
-          },
-          {
-            "level": 6,
-            "resolution": 1587.5031750063501,
-            "scale": 6000000
-          },
-          {
-            "level": 7,
-            "resolution": 926.04351875370423,
-            "scale": 3500000
-          },
-          {
-            "level": 8,
-            "resolution": 529.16772500211675,
-            "scale": 2000000
-          },
-          {
-            "level": 9,
-            "resolution": 317.50063500127004,
-            "scale": 1200000
-          },
-          {
-            "level": 10,
-            "resolution": 185.20870375074085,
-            "scale": 700000
-          },
-          {
-            "level": 11,
-            "resolution": 111.12522225044451,
-            "scale": 420000
-          },
-          {
-            "level": 12,
-            "resolution": 66.1459656252646,
-            "scale": 250000
-          },
-          {
-            "level": 13,
-            "resolution": 38.364660062653464,
-            "scale": 145000
-          },
-          {
-            "level": 14,
-            "resolution": 22.489628312589961,
-            "scale": 85000
-          },
-          {
-            "level": 15,
-            "resolution": 13.229193125052918,
-            "scale": 50000
-          },
-          {
-            "level": 16,
-            "resolution": 7.9375158750317505,
-            "scale": 30000
-          },
-          {
-            "level": 17,
-            "resolution": 4.6302175937685215,
-            "scale": 17500
-          }
-        ]
-      },
-      {
-        "id": "LOD_ESRI_World_AuxMerc_3857",
-        "lods": [
-          {
-            "level": 0,
-            "resolution": 19567.879240999919,
-            "scale": 73957190.948944
-          },
-          {
-            "level": 1,
-            "resolution": 9783.93962049996,
-            "scale": 36978595.474472
-          },
-          {
-            "level": 2,
-            "resolution": 4891.96981024998,
-            "scale": 18489297.737236
-          },
-          {
-            "level": 3,
-            "resolution": 2445.98490512499,
-            "scale": 9244648.868618
-          },
-          {
-            "level": 4,
-            "resolution": 1222.9924525624949,
-            "scale": 4622324.434309
-          },
-          {
-            "level": 5,
-            "resolution": 611.49622628137968,
-            "scale": 2311162.217155
-          },
-          {
-            "level": 6,
-            "resolution": 305.74811314055756,
-            "scale": 1155581.108577
-          },
-          {
-            "level": 7,
-            "resolution": 152.87405657041106,
-            "scale": 577790.554289
-          },
-          {
-            "level": 8,
-            "resolution": 76.437028285073239,
-            "scale": 288895.277144
-          },
-          {
-            "level": 9,
-            "resolution": 38.21851414253662,
-            "scale": 144447.638572
-          },
-          {
-            "level": 10,
-            "resolution": 19.10925707126831,
-            "scale": 72223.819286
-          },
-          {
-            "level": 11,
-            "resolution": 9.5546285356341549,
-            "scale": 36111.909643
-          },
-          {
-            "level": 12,
-            "resolution": 4.77731426794937,
-            "scale": 18055.954822
-          },
-          {
-            "level": 13,
-            "resolution": 2.3886571339746849,
-            "scale": 9027.977411
-          },
-          {
-            "level": 14,
-            "resolution": 1.1943285668550503,
-            "scale": 4513.988705
-          },
-          {
-            "level": 15,
-            "resolution": 0.59716428355981721,
-            "scale": 2256.994353
-          },
-          {
-            "level": 16,
-            "resolution": 0.29858214164761665,
-            "scale": 1128.497176
-          },
-          {
-            "level": 17,
-            "resolution": 0.14929107082380833,
-            "scale": 564.248588
-          },
-          {
-            "level": 18,
-            "resolution": 0.074645535411904163,
-            "scale": 282.124294
-          },
-          {
-            "level": 19,
-            "resolution": 0.037322767705952081,
-            "scale": 141.062147
-          },
-          {
-            "level": 20,
-            "resolution": 0.018661383852976041,
-            "scale": 70.5310735
-          }
-        ]
-      }
-    ],
-    "legend": {
-      "type": "structured",
-      "root": {
-          "name": "root",
-          "children": [
+    },
+    "services": {
+        "proxyUrl": "http://167.40.64.74/wmsproxy/ws/wmsproxy/executeFromProxy",
+        "exportMapUrl": "https://maps-cartes.dev.ec.gc.ca/arcgis/rest/services/Utilities/PrintingTools/GPServer/Export%20Web%20Map%20Task",
+        "export": {
+            "title": {
+                "value": "Total releases and disposals of pulp and paper facilities that reported to the NPRI from 2010 to 2019"
+            },
+            "map": {},
+            "mapElements": {},
+            "legend": {},
+            "footnote": {
+                "value": "Total releases and disposals of pulp and paper facilities that reported to the NPRI from 2010 to 2019"
+            }
+        },
+        "search": {
+            "settings": {
+                "categories": [
+                    "CITY",
+                    "HAM",
+                    "IR",
+                    "LTM",
+                    "MUN1",
+                    "MUN2",
+                    "PROV",
+                    "STM",
+                    "TERR",
+                    "TOWN",
+                    "UTM",
+                    "VILG",
+                    "UNP"
+                ],
+                "sortOrder": [
+                    "CITY",
+                    "HAM",
+                    "IR",
+                    "LTM",
+                    "MUN1",
+                    "MUN2",
+                    "PROV",
+                    "STM",
+                    "TERR",
+                    "TOWN",
+                    "UTM",
+                    "VILG",
+                    "UNP"
+                ],
+                "maxResults": 1000,
+                "officialOnly": true
+            },
+            "serviceUrls": {
+                "geoNames": "https://geogratis.gc.ca/services/geoname/en/geonames.json",
+                "geoLocation": "https://geogratis.gc.ca/services/geolocation/en/locate?q=",
+                "geoSuggest": "https://geogratis.gc.ca/services/geolocation/en/suggest?q=",
+                "provinces": "https://geogratis.gc.ca/services/geoname/en/codes/province.json",
+                "types": "https://geogratis.gc.ca/services/geoname/en/codes/concise.json"
+            }
+        }
+    },
+    "map": {
+        "initialBasemapId": "baseNrCan",
+        "components": {
+            "geoSearch": {
+                "enabled": true,
+                "showGraphic": true,
+                "showInfo": true
+            },
+            "mouseInfo": {
+                "enabled": true,
+                "spatialReference": {
+                    "wkid": 4326
+                }
+            },
+            "northArrow": {
+                "enabled": false
+            },
+            "basemap": {
+                "enabled": true
+            },
+            "overviewMap": {
+                "enabled": true,
+                "layerType": "imagery"
+            },
+            "scaleBar": {
+                "enabled": true
+            }
+        },
+        "extentSets": [
             {
-                "layerId": "Criteria",
-                "description": "Total criteria air contaminants released by pulp and paper facilities that reported to the NPRI from 2010 to 2019 (tonnes)",                
-                "symbologyExpanded": true
+                "id": "EXT_NRCAN_Lambert_3978",
+                "default": {
+                    "xmax": 2249492,
+                    "xmin": -5881457,
+                    "ymax": 4482193,
+                    "ymin": -983440
+                },
+                "spatialReference": {
+                    "wkid": 3978
+                }
+            },
+            {
+                "id": "EXT_ESRI_World_AuxMerc_3857",
+                "default": {
+                    "xmax": -5007771.626060756,
+                    "xmin": -16632697.354854,
+                    "ymax": 10015875.184845109,
+                    "ymin": 5022907.964742964
+                },
+                "spatialReference": {
+                    "wkid": 102100,
+                    "latestWkid": 3857
+                }
+            }
+        ],
+        "lodSets": [
+            {
+                "id": "LOD_NRCAN_Lambert_3978",
+                "lods": [
+                    {
+                        "level": 0,
+                        "resolution": 38364.660062653464,
+                        "scale": 145000000
+                    },
+                    {
+                        "level": 1,
+                        "resolution": 22489.628312589961,
+                        "scale": 85000000
+                    },
+                    {
+                        "level": 2,
+                        "resolution": 13229.193125052918,
+                        "scale": 50000000
+                    },
+                    {
+                        "level": 3,
+                        "resolution": 7937.5158750317505,
+                        "scale": 30000000
+                    },
+                    {
+                        "level": 4,
+                        "resolution": 4630.2175937685215,
+                        "scale": 17500000
+                    },
+                    {
+                        "level": 5,
+                        "resolution": 2645.8386250105837,
+                        "scale": 10000000
+                    },
+                    {
+                        "level": 6,
+                        "resolution": 1587.5031750063501,
+                        "scale": 6000000
+                    },
+                    {
+                        "level": 7,
+                        "resolution": 926.04351875370423,
+                        "scale": 3500000
+                    },
+                    {
+                        "level": 8,
+                        "resolution": 529.16772500211675,
+                        "scale": 2000000
+                    },
+                    {
+                        "level": 9,
+                        "resolution": 317.50063500127004,
+                        "scale": 1200000
+                    },
+                    {
+                        "level": 10,
+                        "resolution": 185.20870375074085,
+                        "scale": 700000
+                    },
+                    {
+                        "level": 11,
+                        "resolution": 111.12522225044451,
+                        "scale": 420000
+                    },
+                    {
+                        "level": 12,
+                        "resolution": 66.1459656252646,
+                        "scale": 250000
+                    },
+                    {
+                        "level": 13,
+                        "resolution": 38.364660062653464,
+                        "scale": 145000
+                    },
+                    {
+                        "level": 14,
+                        "resolution": 22.489628312589961,
+                        "scale": 85000
+                    },
+                    {
+                        "level": 15,
+                        "resolution": 13.229193125052918,
+                        "scale": 50000
+                    },
+                    {
+                        "level": 16,
+                        "resolution": 7.9375158750317505,
+                        "scale": 30000
+                    },
+                    {
+                        "level": 17,
+                        "resolution": 4.6302175937685215,
+                        "scale": 17500
+                    }
+                ]
+            },
+            {
+                "id": "LOD_ESRI_World_AuxMerc_3857",
+                "lods": [
+                    {
+                        "level": 0,
+                        "resolution": 19567.879240999919,
+                        "scale": 73957190.948944
+                    },
+                    {
+                        "level": 1,
+                        "resolution": 9783.93962049996,
+                        "scale": 36978595.474472
+                    },
+                    {
+                        "level": 2,
+                        "resolution": 4891.96981024998,
+                        "scale": 18489297.737236
+                    },
+                    {
+                        "level": 3,
+                        "resolution": 2445.98490512499,
+                        "scale": 9244648.868618
+                    },
+                    {
+                        "level": 4,
+                        "resolution": 1222.9924525624949,
+                        "scale": 4622324.434309
+                    },
+                    {
+                        "level": 5,
+                        "resolution": 611.49622628137968,
+                        "scale": 2311162.217155
+                    },
+                    {
+                        "level": 6,
+                        "resolution": 305.74811314055756,
+                        "scale": 1155581.108577
+                    },
+                    {
+                        "level": 7,
+                        "resolution": 152.87405657041106,
+                        "scale": 577790.554289
+                    },
+                    {
+                        "level": 8,
+                        "resolution": 76.437028285073239,
+                        "scale": 288895.277144
+                    },
+                    {
+                        "level": 9,
+                        "resolution": 38.21851414253662,
+                        "scale": 144447.638572
+                    },
+                    {
+                        "level": 10,
+                        "resolution": 19.10925707126831,
+                        "scale": 72223.819286
+                    },
+                    {
+                        "level": 11,
+                        "resolution": 9.5546285356341549,
+                        "scale": 36111.909643
+                    },
+                    {
+                        "level": 12,
+                        "resolution": 4.77731426794937,
+                        "scale": 18055.954822
+                    },
+                    {
+                        "level": 13,
+                        "resolution": 2.3886571339746849,
+                        "scale": 9027.977411
+                    },
+                    {
+                        "level": 14,
+                        "resolution": 1.1943285668550503,
+                        "scale": 4513.988705
+                    },
+                    {
+                        "level": 15,
+                        "resolution": 0.59716428355981721,
+                        "scale": 2256.994353
+                    },
+                    {
+                        "level": 16,
+                        "resolution": 0.29858214164761665,
+                        "scale": 1128.497176
+                    },
+                    {
+                        "level": 17,
+                        "resolution": 0.14929107082380833,
+                        "scale": 564.248588
+                    },
+                    {
+                        "level": 18,
+                        "resolution": 0.074645535411904163,
+                        "scale": 282.124294
+                    },
+                    {
+                        "level": 19,
+                        "resolution": 0.037322767705952081,
+                        "scale": 141.062147
+                    },
+                    {
+                        "level": 20,
+                        "resolution": 0.018661383852976041,
+                        "scale": 70.5310735
+                    }
+                ]
+            }
+        ],
+        "legend": {
+            "type": "structured",
+            "root": {
+                "name": "root",
+                "children": [
+                    {
+                        "layerId": "Criteria",
+                        "description": "Total criteria air contaminants released by pulp and paper facilities that reported to the NPRI from 2010 to 2019 (tonnes)",
+                        "symbologyExpanded": true
+                    }
+                ]
+            }
+        },
+        "layers": [
+            {
+                "id": "Criteria",
+                "name": "Total criteria air contaminants",
+                "layerType": "esriFeature",
+                "tolerance": 20,
+                "singleEntryCollapse": true,
+                "symbologyExpanded": true,
+                "url": "https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/StoryRAMP/f6f7baf4_cccb_4521_a037_b4691b0f0d49/MapServer/3",
+                "state": {
+                    "opacity": 0.75
+                }
+            }
+        ],
+        "tileSchemas": [
+            {
+                "id": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978",
+                "name": "Lambert Maps",
+                "extentSetId": "EXT_NRCAN_Lambert_3978",
+                "lodSetId": "LOD_NRCAN_Lambert_3978",
+                "hasNorthPole": true
+            },
+            {
+                "id": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857",
+                "name": "Web Mercator Maps",
+                "extentSetId": "EXT_ESRI_World_AuxMerc_3857",
+                "lodSetId": "LOD_ESRI_World_AuxMerc_3857"
+            }
+        ],
+        "baseMaps": [
+            {
+                "id": "baseNrCan",
+                "name": "Canada Base Map - Transportation (CBMT)",
+                "description": "The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.",
+                "altText": "altText - The Canada Base Map - Transportation (CBMT)",
+                "layers": [
+                    {
+                        "id": "CBMT",
+                        "layerType": "esriFeature",
+                        "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+            },
+            {
+                "id": "baseSimple",
+                "name": "Canada Base Map - Simple",
+                "description": "Canada Base Map - Simple",
+                "altText": "altText - Canada base map - Simple",
+                "layers": [
+                    {
+                        "id": "SMR",
+                        "layerType": "esriFeature",
+                        "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+            },
+            {
+                "id": "baseCBME_CBCE_HS_RO_3978",
+                "name": "Canada Base Map - Elevation (CBME)",
+                "description": "The Canada Base Map - Elevation (CBME) web mapping services of the Earth Sciences Sector at Natural Resources Canada, is intended primarily for online mapping application users and developers.",
+                "altText": "altText - Canada Base Map - Elevation (CBME)",
+                "layers": [
+                    {
+                        "id": "CBME_CBCE_HS_RO_3978",
+                        "layerType": "esriFeature",
+                        "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+            },
+            {
+                "id": "baseCBMT_CBCT_GEOM_3978",
+                "name": "Canada Base Map - Transportation (CBMT)",
+                "description": " The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.",
+                "altText": "altText - Canada Base Map - Transportation (CBMT)",
+                "layers": [
+                    {
+                        "id": "CBMT_CBCT_GEOM_3978",
+                        "layerType": "esriFeature",
+                        "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+            },
+            {
+                "id": "baseEsriWorld",
+                "name": "World Imagery",
+                "description": "World Imagery provides one meter or better satellite and aerial imagery in many parts of the world and lower resolution satellite imagery worldwide.",
+                "altText": "altText - World Imagery",
+                "layers": [
+                    {
+                        "id": "World_Imagery",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriPhysical",
+                "name": "World Physical Map",
+                "description": "This map presents the Natural Earth physical map at 1.24km per pixel for the world and 500m for the coterminous United States.",
+                "altText": "altText - World Physical Map",
+                "layers": [
+                    {
+                        "id": "World_Physical_Map",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Physical_Map/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriRelief",
+                "name": "World Shaded Relief",
+                "description": "This map portrays surface elevation as shaded relief. This map is used as a basemap layer to add shaded relief to other GIS maps, such as the ArcGIS Online World Street Map.",
+                "altText": "altText - World Shaded Relief",
+                "layers": [
+                    {
+                        "id": "World_Shaded_Relief",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Shaded_Relief/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriStreet",
+                "name": "World Street Map",
+                "description": "This worldwide street map presents highway-level data for the world.",
+                "altText": "altText - ESWorld Street Map",
+                "layers": [
+                    {
+                        "id": "World_Street_Map",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Street_Map/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriTerrain",
+                "name": "World Terrain Base",
+                "description": "This map is designed to be used as a base map by GIS professionals to overlay other thematic layers such as demographics or land cover.",
+                "altText": "altText - World Terrain Base",
+                "layers": [
+                    {
+                        "id": "World_Terrain_Base",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Terrain_Base/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriTopo",
+                "name": "World Topographic Map",
+                "description": "This map is designed to be used as a basemap by GIS professionals and as a reference map by anyone.",
+                "altText": "altText - World Topographic Map",
+                "layers": [
+                    {
+                        "id": "World_Topo_Map",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
             }
         ]
-      }
-  },
-    "layers": [
-      {
-          "id": "Criteria",
-          "name": "Total criteria air contaminants",
-          "layerType": "esriFeature",
-          "tolerance": 20,
-          "singleEntryCollapse": true,
-          "symbologyExpanded": true,
-          "url": "https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/StoryRAMP/f6f7baf4_cccb_4521_a037_b4691b0f0d49/MapServer/3",
-          "state": {
-            "opacity": 0.75
-          }
-      }
-    ],
-    "tileSchemas": [
-      {
-        "id": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978",
-        "name": "Lambert Maps",
-        "extentSetId": "EXT_NRCAN_Lambert_3978",
-        "lodSetId": "LOD_NRCAN_Lambert_3978",
-        "hasNorthPole": true
-      },
-      {
-        "id": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857",
-        "name": "Web Mercator Maps",
-        "extentSetId": "EXT_ESRI_World_AuxMerc_3857",
-        "lodSetId": "LOD_ESRI_World_AuxMerc_3857"
-      }
-    ],
-    "baseMaps": [
-      {
-        "id": "baseNrCan",
-        "name": "Canada Base Map - Transportation (CBMT)",
-        "description": "The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.",
-        "altText": "altText - The Canada Base Map - Transportation (CBMT)",
-        "layers": [
-          {
-            "id": "CBMT",
-            "layerType": "esriFeature",
-            "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
-      },
-      {
-        "id": "baseSimple",
-        "name": "Canada Base Map - Simple",
-        "description": "Canada Base Map - Simple",
-        "altText": "altText - Canada base map - Simple",
-        "layers": [
-          {
-            "id": "SMR",
-            "layerType": "esriFeature",
-            "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
-      },
-      {
-        "id": "baseCBME_CBCE_HS_RO_3978",
-        "name": "Canada Base Map - Elevation (CBME)",
-        "description": "The Canada Base Map - Elevation (CBME) web mapping services of the Earth Sciences Sector at Natural Resources Canada, is intended primarily for online mapping application users and developers.",
-        "altText": "altText - Canada Base Map - Elevation (CBME)",
-        "layers": [
-          {
-            "id": "CBME_CBCE_HS_RO_3978",
-            "layerType": "esriFeature",
-            "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
-      },
-      {
-        "id": "baseCBMT_CBCT_GEOM_3978",
-        "name": "Canada Base Map - Transportation (CBMT)",
-        "description": " The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.",
-        "altText": "altText - Canada Base Map - Transportation (CBMT)",
-        "layers": [
-          {
-            "id": "CBMT_CBCT_GEOM_3978",
-            "layerType": "esriFeature",
-            "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
-      },
-      {
-        "id": "baseEsriWorld",
-        "name": "World Imagery",
-        "description": "World Imagery provides one meter or better satellite and aerial imagery in many parts of the world and lower resolution satellite imagery worldwide.",
-        "altText": "altText - World Imagery",
-        "layers": [
-          {
-            "id": "World_Imagery",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      },
-      {
-        "id": "baseEsriPhysical",
-        "name": "World Physical Map",
-        "description": "This map presents the Natural Earth physical map at 1.24km per pixel for the world and 500m for the coterminous United States.",
-        "altText": "altText - World Physical Map",
-        "layers": [
-          {
-            "id": "World_Physical_Map",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Physical_Map/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      },
-      {
-        "id": "baseEsriRelief",
-        "name": "World Shaded Relief",
-        "description": "This map portrays surface elevation as shaded relief. This map is used as a basemap layer to add shaded relief to other GIS maps, such as the ArcGIS Online World Street Map.",
-        "altText": "altText - World Shaded Relief",
-        "layers": [
-          {
-            "id": "World_Shaded_Relief",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Shaded_Relief/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      },
-      {
-        "id": "baseEsriStreet",
-        "name": "World Street Map",
-        "description": "This worldwide street map presents highway-level data for the world.",
-        "altText": "altText - ESWorld Street Map",
-        "layers": [
-          {
-            "id": "World_Street_Map",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Street_Map/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      },
-      {
-        "id": "baseEsriTerrain",
-        "name": "World Terrain Base",
-        "description": "This map is designed to be used as a base map by GIS professionals to overlay other thematic layers such as demographics or land cover.",
-        "altText": "altText - World Terrain Base",
-        "layers": [
-          {
-            "id": "World_Terrain_Base",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Terrain_Base/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      },
-      {
-        "id": "baseEsriTopo",
-        "name": "World Topographic Map",
-        "description": "This map is designed to be used as a basemap by GIS professionals and as a reference map by anyone.",
-        "altText": "altText - World Topographic Map",
-        "layers": [
-          {
-            "id": "World_Topo_Map",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      }
-    ]
-  }
+    }
 }

--- a/public/f6f7baf4-cccb-4521-a037-b4691b0f0d49/ramp-config/en/total_disposals_and_transfers_of_pnp_2010-2019.json
+++ b/public/f6f7baf4-cccb-4521-a037-b4691b0f0d49/ramp-config/en/total_disposals_and_transfers_of_pnp_2010-2019.json
@@ -1,514 +1,541 @@
 {
-  "version": "2.0",
-  "language": "en",
-  "ui": {
-    "title": "Interactive map",
-    "fullscreen": true,
-    "navBar": {
-      "zoom": "buttons",
-      "extra": [ "fullscreen", "geoLocator", "home", "help" ]
+    "version": "2.0",
+    "language": "en",
+    "ui": {
+        "title": "Interactive map",
+        "fullscreen": true,
+        "navBar": {
+            "zoom": "buttons",
+            "extra": ["fullscreen", "geoLocator", "home", "help"]
+        },
+        "appBar": {
+            "basemap": true
+        },
+        "help": {
+            "folderName": "default"
+        },
+        "sideMenu": {
+            "items": [["fullscreen", "export", "touch", "help", "about"]],
+            "logo": false
+        },
+        "legend": {
+            "allowImport": true,
+            "isOpen": {
+                "large": true,
+                "medium": false,
+                "small": false
+            }
+        }
     },
-    "appBar": {
-      "basemap": true
+    "services": {
+        "proxyUrl": "http://167.40.64.74/wmsproxy/ws/wmsproxy/executeFromProxy",
+        "exportMapUrl": "https://maps-cartes.dev.ec.gc.ca/arcgis/rest/services/Utilities/PrintingTools/GPServer/Export%20Web%20Map%20Task",
+        "export": {
+            "title": {
+                "value": "Total releases and disposals of pulp and paper facilities that reported to the NPRI from 2010 to 2019"
+            },
+            "map": {},
+            "mapElements": {},
+            "legend": {},
+            "footnote": {
+                "value": "Total releases and disposals of pulp and paper facilities that reported to the NPRI from 2010 to 2019"
+            }
+        },
+        "search": {
+            "settings": {
+                "categories": [
+                    "CITY",
+                    "HAM",
+                    "IR",
+                    "LTM",
+                    "MUN1",
+                    "MUN2",
+                    "PROV",
+                    "STM",
+                    "TERR",
+                    "TOWN",
+                    "UTM",
+                    "VILG",
+                    "UNP"
+                ],
+                "sortOrder": [
+                    "CITY",
+                    "HAM",
+                    "IR",
+                    "LTM",
+                    "MUN1",
+                    "MUN2",
+                    "PROV",
+                    "STM",
+                    "TERR",
+                    "TOWN",
+                    "UTM",
+                    "VILG",
+                    "UNP"
+                ],
+                "maxResults": 1000,
+                "officialOnly": true
+            },
+            "serviceUrls": {
+                "geoNames": "https://geogratis.gc.ca/services/geoname/en/geonames.json",
+                "geoLocation": "https://geogratis.gc.ca/services/geolocation/en/locate?q=",
+                "geoSuggest": "https://geogratis.gc.ca/services/geolocation/en/suggest?q=",
+                "provinces": "https://geogratis.gc.ca/services/geoname/en/codes/province.json",
+                "types": "https://geogratis.gc.ca/services/geoname/en/codes/concise.json"
+            }
+        }
+    },
+    "map": {
+        "initialBasemapId": "baseNrCan",
+        "components": {
+            "geoSearch": {
+                "enabled": true,
+                "showGraphic": true,
+                "showInfo": true
+            },
+            "mouseInfo": {
+                "enabled": true,
+                "spatialReference": {
+                    "wkid": 4326
+                }
+            },
+            "northArrow": {
+                "enabled": false
+            },
+            "basemap": {
+                "enabled": true
+            },
+            "overviewMap": {
+                "enabled": true,
+                "layerType": "imagery"
+            },
+            "scaleBar": {
+                "enabled": true
+            }
+        },
+        "extentSets": [
+            {
+                "id": "EXT_NRCAN_Lambert_3978",
+                "default": {
+                    "xmax": 2249492,
+                    "xmin": -5881457,
+                    "ymax": 4482193,
+                    "ymin": -983440
+                },
+                "spatialReference": {
+                    "wkid": 3978
+                }
+            },
+            {
+                "id": "EXT_ESRI_World_AuxMerc_3857",
+                "default": {
+                    "xmax": -5007771.626060756,
+                    "xmin": -16632697.354854,
+                    "ymax": 10015875.184845109,
+                    "ymin": 5022907.964742964
+                },
+                "spatialReference": {
+                    "wkid": 102100,
+                    "latestWkid": 3857
+                }
+            }
+        ],
+        "lodSets": [
+            {
+                "id": "LOD_NRCAN_Lambert_3978",
+                "lods": [
+                    {
+                        "level": 0,
+                        "resolution": 38364.660062653464,
+                        "scale": 145000000
+                    },
+                    {
+                        "level": 1,
+                        "resolution": 22489.628312589961,
+                        "scale": 85000000
+                    },
+                    {
+                        "level": 2,
+                        "resolution": 13229.193125052918,
+                        "scale": 50000000
+                    },
+                    {
+                        "level": 3,
+                        "resolution": 7937.5158750317505,
+                        "scale": 30000000
+                    },
+                    {
+                        "level": 4,
+                        "resolution": 4630.2175937685215,
+                        "scale": 17500000
+                    },
+                    {
+                        "level": 5,
+                        "resolution": 2645.8386250105837,
+                        "scale": 10000000
+                    },
+                    {
+                        "level": 6,
+                        "resolution": 1587.5031750063501,
+                        "scale": 6000000
+                    },
+                    {
+                        "level": 7,
+                        "resolution": 926.04351875370423,
+                        "scale": 3500000
+                    },
+                    {
+                        "level": 8,
+                        "resolution": 529.16772500211675,
+                        "scale": 2000000
+                    },
+                    {
+                        "level": 9,
+                        "resolution": 317.50063500127004,
+                        "scale": 1200000
+                    },
+                    {
+                        "level": 10,
+                        "resolution": 185.20870375074085,
+                        "scale": 700000
+                    },
+                    {
+                        "level": 11,
+                        "resolution": 111.12522225044451,
+                        "scale": 420000
+                    },
+                    {
+                        "level": 12,
+                        "resolution": 66.1459656252646,
+                        "scale": 250000
+                    },
+                    {
+                        "level": 13,
+                        "resolution": 38.364660062653464,
+                        "scale": 145000
+                    },
+                    {
+                        "level": 14,
+                        "resolution": 22.489628312589961,
+                        "scale": 85000
+                    },
+                    {
+                        "level": 15,
+                        "resolution": 13.229193125052918,
+                        "scale": 50000
+                    },
+                    {
+                        "level": 16,
+                        "resolution": 7.9375158750317505,
+                        "scale": 30000
+                    },
+                    {
+                        "level": 17,
+                        "resolution": 4.6302175937685215,
+                        "scale": 17500
+                    }
+                ]
+            },
+            {
+                "id": "LOD_ESRI_World_AuxMerc_3857",
+                "lods": [
+                    {
+                        "level": 0,
+                        "resolution": 19567.879240999919,
+                        "scale": 73957190.948944
+                    },
+                    {
+                        "level": 1,
+                        "resolution": 9783.93962049996,
+                        "scale": 36978595.474472
+                    },
+                    {
+                        "level": 2,
+                        "resolution": 4891.96981024998,
+                        "scale": 18489297.737236
+                    },
+                    {
+                        "level": 3,
+                        "resolution": 2445.98490512499,
+                        "scale": 9244648.868618
+                    },
+                    {
+                        "level": 4,
+                        "resolution": 1222.9924525624949,
+                        "scale": 4622324.434309
+                    },
+                    {
+                        "level": 5,
+                        "resolution": 611.49622628137968,
+                        "scale": 2311162.217155
+                    },
+                    {
+                        "level": 6,
+                        "resolution": 305.74811314055756,
+                        "scale": 1155581.108577
+                    },
+                    {
+                        "level": 7,
+                        "resolution": 152.87405657041106,
+                        "scale": 577790.554289
+                    },
+                    {
+                        "level": 8,
+                        "resolution": 76.437028285073239,
+                        "scale": 288895.277144
+                    },
+                    {
+                        "level": 9,
+                        "resolution": 38.21851414253662,
+                        "scale": 144447.638572
+                    },
+                    {
+                        "level": 10,
+                        "resolution": 19.10925707126831,
+                        "scale": 72223.819286
+                    },
+                    {
+                        "level": 11,
+                        "resolution": 9.5546285356341549,
+                        "scale": 36111.909643
+                    },
+                    {
+                        "level": 12,
+                        "resolution": 4.77731426794937,
+                        "scale": 18055.954822
+                    },
+                    {
+                        "level": 13,
+                        "resolution": 2.3886571339746849,
+                        "scale": 9027.977411
+                    },
+                    {
+                        "level": 14,
+                        "resolution": 1.1943285668550503,
+                        "scale": 4513.988705
+                    },
+                    {
+                        "level": 15,
+                        "resolution": 0.59716428355981721,
+                        "scale": 2256.994353
+                    },
+                    {
+                        "level": 16,
+                        "resolution": 0.29858214164761665,
+                        "scale": 1128.497176
+                    },
+                    {
+                        "level": 17,
+                        "resolution": 0.14929107082380833,
+                        "scale": 564.248588
+                    },
+                    {
+                        "level": 18,
+                        "resolution": 0.074645535411904163,
+                        "scale": 282.124294
+                    },
+                    {
+                        "level": 19,
+                        "resolution": 0.037322767705952081,
+                        "scale": 141.062147
+                    },
+                    {
+                        "level": 20,
+                        "resolution": 0.018661383852976041,
+                        "scale": 70.5310735
+                    }
+                ]
+            }
+        ],
+        "legend": {
+            "type": "structured",
+            "root": {
+                "name": "root",
+                "children": [
+                    {
+                        "layerId": "Criteria",
+                        "description": "Total disposals and transfers of pulp and paper facilities that reported to the NPRI from 2010 to 2019 (tonnes)",
+                        "symbologyExpanded": true
+                    }
+                ]
+            }
+        },
+        "layers": [
+            {
+                "id": "Criteria",
 
-    },
-    "help": {
-      "folderName": "default"
-    },
-    "sideMenu": {
-      "items": [ [ "fullscreen", "export", "touch", "help", "about" ] ],
-      "logo": false
-    },
-    "legend": {
-      "allowImport": true,
-      "isOpen": {
-        "large": true,
-        "medium": false,
-        "small": false
-      }
-    }
-  },
-  "services": {
-    "proxyUrl": "http://167.40.64.74/wmsproxy/ws/wmsproxy/executeFromProxy",
-    "exportMapUrl": "https://maps-cartes.dev.ec.gc.ca/arcgis/rest/services/Utilities/PrintingTools/GPServer/Export%20Web%20Map%20Task",
-    "export": {
-      "title": {
-        "value": "Total releases and disposals of pulp and paper facilities that reported to the NPRI from 2010 to 2019"
-      },
-      "map": {},
-      "mapElements": {},
-      "legend": {},
-      "footnote": {
-        "value": "Total releases and disposals of pulp and paper facilities that reported to the NPRI from 2010 to 2019"
-      }
-    },
-    "search": {
-      "settings": {
-        "categories": [ "CITY", "HAM", "IR", "LTM", "MUN1", "MUN2", "PROV", "STM", "TERR", "TOWN", "UTM", "VILG", "UNP" ],
-        "sortOrder": [ "CITY", "HAM", "IR", "LTM", "MUN1", "MUN2", "PROV", "STM", "TERR", "TOWN", "UTM", "VILG", "UNP" ],
-        "maxResults": 1000,
-        "officialOnly": true
-      },	
-      "serviceUrls": {
-        "geoNames": "https://geogratis.gc.ca/services/geoname/en/geonames.json",
-        "geoLocation": "https://geogratis.gc.ca/services/geolocation/en/locate?q=",
-        "geoSuggest": "https://geogratis.gc.ca/services/geolocation/en/suggest?q=",
-        "provinces": "https://geogratis.gc.ca/services/geoname/en/codes/province.json",
-        "types": "https://geogratis.gc.ca/services/geoname/en/codes/concise.json"
-      }
-    }
-  },
-  "map": {
-    "initialBasemapId": "baseNrCan",
-    "components": {
-      "geoSearch": {
-        "enabled": true,
-        "showGraphic": true,
-        "showInfo": true
-      },
-      "mouseInfo": {
-        "enabled": true,
-        "spatialReference": {
-          "wkid": 4326
-        }
-      },
-      "northArrow": {
-        "enabled": false
-      },
-      "basemap": {
-        "enabled": true
-      },
-      "overviewMap": {
-        "enabled": true,
-        "layerType": "imagery"
-      },
-      "scaleBar": {
-        "enabled": true
-      }
-    },
-    "extentSets": [
-      {
-        "id": "EXT_NRCAN_Lambert_3978",
-        "default": {
-          "xmax": 2849492,
-          "xmin": -5281457,
-          "ymax": 4482193,
-          "ymin": -983440
-        },
-        "spatialReference": {
-          "wkid": 3978
-        }
-      },
-      {
-        "id": "EXT_ESRI_World_AuxMerc_3857",
-        "default": {
-          "xmax": -5007771.626060756,
-          "xmin": -16632697.354854,
-          "ymax": 10015875.184845109,
-          "ymin": 5022907.964742964
-        },
-        "spatialReference": {
-          "wkid": 102100,
-          "latestWkid": 3857
-        }
-      }
-    ],
-    "lodSets": [
-      {
-        "id": "LOD_NRCAN_Lambert_3978",
-        "lods": [
-          {
-            "level": 0,
-            "resolution": 38364.660062653464,
-            "scale": 145000000
-          },
-          {
-            "level": 1,
-            "resolution": 22489.628312589961,
-            "scale": 85000000
-          },
-          {
-            "level": 2,
-            "resolution": 13229.193125052918,
-            "scale": 50000000
-          },
-          {
-            "level": 3,
-            "resolution": 7937.5158750317505,
-            "scale": 30000000
-          },
-          {
-            "level": 4,
-            "resolution": 4630.2175937685215,
-            "scale": 17500000
-          },
-          {
-            "level": 5,
-            "resolution": 2645.8386250105837,
-            "scale": 10000000
-          },
-          {
-            "level": 6,
-            "resolution": 1587.5031750063501,
-            "scale": 6000000
-          },
-          {
-            "level": 7,
-            "resolution": 926.04351875370423,
-            "scale": 3500000
-          },
-          {
-            "level": 8,
-            "resolution": 529.16772500211675,
-            "scale": 2000000
-          },
-          {
-            "level": 9,
-            "resolution": 317.50063500127004,
-            "scale": 1200000
-          },
-          {
-            "level": 10,
-            "resolution": 185.20870375074085,
-            "scale": 700000
-          },
-          {
-            "level": 11,
-            "resolution": 111.12522225044451,
-            "scale": 420000
-          },
-          {
-            "level": 12,
-            "resolution": 66.1459656252646,
-            "scale": 250000
-          },
-          {
-            "level": 13,
-            "resolution": 38.364660062653464,
-            "scale": 145000
-          },
-          {
-            "level": 14,
-            "resolution": 22.489628312589961,
-            "scale": 85000
-          },
-          {
-            "level": 15,
-            "resolution": 13.229193125052918,
-            "scale": 50000
-          },
-          {
-            "level": 16,
-            "resolution": 7.9375158750317505,
-            "scale": 30000
-          },
-          {
-            "level": 17,
-            "resolution": 4.6302175937685215,
-            "scale": 17500
-          }
-        ]
-      },
-      {
-        "id": "LOD_ESRI_World_AuxMerc_3857",
-        "lods": [
-          {
-            "level": 0,
-            "resolution": 19567.879240999919,
-            "scale": 73957190.948944
-          },
-          {
-            "level": 1,
-            "resolution": 9783.93962049996,
-            "scale": 36978595.474472
-          },
-          {
-            "level": 2,
-            "resolution": 4891.96981024998,
-            "scale": 18489297.737236
-          },
-          {
-            "level": 3,
-            "resolution": 2445.98490512499,
-            "scale": 9244648.868618
-          },
-          {
-            "level": 4,
-            "resolution": 1222.9924525624949,
-            "scale": 4622324.434309
-          },
-          {
-            "level": 5,
-            "resolution": 611.49622628137968,
-            "scale": 2311162.217155
-          },
-          {
-            "level": 6,
-            "resolution": 305.74811314055756,
-            "scale": 1155581.108577
-          },
-          {
-            "level": 7,
-            "resolution": 152.87405657041106,
-            "scale": 577790.554289
-          },
-          {
-            "level": 8,
-            "resolution": 76.437028285073239,
-            "scale": 288895.277144
-          },
-          {
-            "level": 9,
-            "resolution": 38.21851414253662,
-            "scale": 144447.638572
-          },
-          {
-            "level": 10,
-            "resolution": 19.10925707126831,
-            "scale": 72223.819286
-          },
-          {
-            "level": 11,
-            "resolution": 9.5546285356341549,
-            "scale": 36111.909643
-          },
-          {
-            "level": 12,
-            "resolution": 4.77731426794937,
-            "scale": 18055.954822
-          },
-          {
-            "level": 13,
-            "resolution": 2.3886571339746849,
-            "scale": 9027.977411
-          },
-          {
-            "level": 14,
-            "resolution": 1.1943285668550503,
-            "scale": 4513.988705
-          },
-          {
-            "level": 15,
-            "resolution": 0.59716428355981721,
-            "scale": 2256.994353
-          },
-          {
-            "level": 16,
-            "resolution": 0.29858214164761665,
-            "scale": 1128.497176
-          },
-          {
-            "level": 17,
-            "resolution": 0.14929107082380833,
-            "scale": 564.248588
-          },
-          {
-            "level": 18,
-            "resolution": 0.074645535411904163,
-            "scale": 282.124294
-          },
-          {
-            "level": 19,
-            "resolution": 0.037322767705952081,
-            "scale": 141.062147
-          },
-          {
-            "level": 20,
-            "resolution": 0.018661383852976041,
-            "scale": 70.5310735
-          }
-        ]
-      }
-    ],
-    "legend": {
-      "type": "structured",
-      "root": {
-          "name": "root",
-          "children": [
+                "layerType": "esriDynamic",
+                "tolerance": 20,
+                "singleEntryCollapse": true,
+                "symbologyExpanded": true,
+                "url": "https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/StoryRAMP/f6f7baf4_cccb_4521_a037_b4691b0f0d49/MapServer",
+                "state": {
+                    "opacity": 0.75
+                },
+                "layerEntries": [
+                    {
+                        "index": 7,
+                        "name": "Total disposals and transfers"
+                    }
+                ]
+            }
+        ],
+        "tileSchemas": [
             {
-                "layerId": "Criteria",
-                "description": "Total disposals and transfers of pulp and paper facilities that reported to the NPRI from 2010 to 2019 (tonnes)",
-                "symbologyExpanded": true
+                "id": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978",
+                "name": "Lambert Maps",
+                "extentSetId": "EXT_NRCAN_Lambert_3978",
+                "lodSetId": "LOD_NRCAN_Lambert_3978",
+                "hasNorthPole": true
+            },
+            {
+                "id": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857",
+                "name": "Web Mercator Maps",
+                "extentSetId": "EXT_ESRI_World_AuxMerc_3857",
+                "lodSetId": "LOD_ESRI_World_AuxMerc_3857"
+            }
+        ],
+        "baseMaps": [
+            {
+                "id": "baseNrCan",
+                "name": "Canada Base Map - Transportation (CBMT)",
+                "description": "The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.",
+                "altText": "altText - The Canada Base Map - Transportation (CBMT)",
+                "layers": [
+                    {
+                        "id": "CBMT",
+                        "layerType": "esriFeature",
+                        "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+            },
+            {
+                "id": "baseSimple",
+                "name": "Canada Base Map - Simple",
+                "description": "Canada Base Map - Simple",
+                "altText": "altText - Canada base map - Simple",
+                "layers": [
+                    {
+                        "id": "SMR",
+                        "layerType": "esriFeature",
+                        "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+            },
+            {
+                "id": "baseCBME_CBCE_HS_RO_3978",
+                "name": "Canada Base Map - Elevation (CBME)",
+                "description": "The Canada Base Map - Elevation (CBME) web mapping services of the Earth Sciences Sector at Natural Resources Canada, is intended primarily for online mapping application users and developers.",
+                "altText": "altText - Canada Base Map - Elevation (CBME)",
+                "layers": [
+                    {
+                        "id": "CBME_CBCE_HS_RO_3978",
+                        "layerType": "esriFeature",
+                        "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+            },
+            {
+                "id": "baseCBMT_CBCT_GEOM_3978",
+                "name": "Canada Base Map - Transportation (CBMT)",
+                "description": " The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.",
+                "altText": "altText - Canada Base Map - Transportation (CBMT)",
+                "layers": [
+                    {
+                        "id": "CBMT_CBCT_GEOM_3978",
+                        "layerType": "esriFeature",
+                        "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+            },
+            {
+                "id": "baseEsriWorld",
+                "name": "World Imagery",
+                "description": "World Imagery provides one meter or better satellite and aerial imagery in many parts of the world and lower resolution satellite imagery worldwide.",
+                "altText": "altText - World Imagery",
+                "layers": [
+                    {
+                        "id": "World_Imagery",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriPhysical",
+                "name": "World Physical Map",
+                "description": "This map presents the Natural Earth physical map at 1.24km per pixel for the world and 500m for the coterminous United States.",
+                "altText": "altText - World Physical Map",
+                "layers": [
+                    {
+                        "id": "World_Physical_Map",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Physical_Map/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriRelief",
+                "name": "World Shaded Relief",
+                "description": "This map portrays surface elevation as shaded relief. This map is used as a basemap layer to add shaded relief to other GIS maps, such as the ArcGIS Online World Street Map.",
+                "altText": "altText - World Shaded Relief",
+                "layers": [
+                    {
+                        "id": "World_Shaded_Relief",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Shaded_Relief/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriStreet",
+                "name": "World Street Map",
+                "description": "This worldwide street map presents highway-level data for the world.",
+                "altText": "altText - ESWorld Street Map",
+                "layers": [
+                    {
+                        "id": "World_Street_Map",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Street_Map/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriTerrain",
+                "name": "World Terrain Base",
+                "description": "This map is designed to be used as a base map by GIS professionals to overlay other thematic layers such as demographics or land cover.",
+                "altText": "altText - World Terrain Base",
+                "layers": [
+                    {
+                        "id": "World_Terrain_Base",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Terrain_Base/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriTopo",
+                "name": "World Topographic Map",
+                "description": "This map is designed to be used as a basemap by GIS professionals and as a reference map by anyone.",
+                "altText": "altText - World Topographic Map",
+                "layers": [
+                    {
+                        "id": "World_Topo_Map",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
             }
         ]
-      }
-  },
-    "layers": [
-      {
-          "id": "Criteria",
-          
-          "layerType": "esriDynamic",
-          "tolerance": 20,
-          "singleEntryCollapse": true,
-          "symbologyExpanded": true,
-          "url": "https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/StoryRAMP/f6f7baf4_cccb_4521_a037_b4691b0f0d49/MapServer",
-          "state": {
-            "opacity": 0.75
-          },
-          "layerEntries": [
-            {
-              "index": 7,
-              "name": "Total disposals and transfers"
-            }
-          ]            
-      }
-    ],
-    "tileSchemas": [
-      {
-        "id": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978",
-        "name": "Lambert Maps",
-        "extentSetId": "EXT_NRCAN_Lambert_3978",
-        "lodSetId": "LOD_NRCAN_Lambert_3978",
-        "hasNorthPole": true
-      },
-      {
-        "id": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857",
-        "name": "Web Mercator Maps",
-        "extentSetId": "EXT_ESRI_World_AuxMerc_3857",
-        "lodSetId": "LOD_ESRI_World_AuxMerc_3857"
-      }
-    ],
-    "baseMaps": [
-      {
-        "id": "baseNrCan",
-        "name": "Canada Base Map - Transportation (CBMT)",
-        "description": "The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.",
-        "altText": "altText - The Canada Base Map - Transportation (CBMT)",
-        "layers": [
-          {
-            "id": "CBMT",
-            "layerType": "esriFeature",
-            "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
-      },
-      {
-        "id": "baseSimple",
-        "name": "Canada Base Map - Simple",
-        "description": "Canada Base Map - Simple",
-        "altText": "altText - Canada base map - Simple",
-        "layers": [
-          {
-            "id": "SMR",
-            "layerType": "esriFeature",
-            "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
-      },
-      {
-        "id": "baseCBME_CBCE_HS_RO_3978",
-        "name": "Canada Base Map - Elevation (CBME)",
-        "description": "The Canada Base Map - Elevation (CBME) web mapping services of the Earth Sciences Sector at Natural Resources Canada, is intended primarily for online mapping application users and developers.",
-        "altText": "altText - Canada Base Map - Elevation (CBME)",
-        "layers": [
-          {
-            "id": "CBME_CBCE_HS_RO_3978",
-            "layerType": "esriFeature",
-            "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
-      },
-      {
-        "id": "baseCBMT_CBCT_GEOM_3978",
-        "name": "Canada Base Map - Transportation (CBMT)",
-        "description": " The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.",
-        "altText": "altText - Canada Base Map - Transportation (CBMT)",
-        "layers": [
-          {
-            "id": "CBMT_CBCT_GEOM_3978",
-            "layerType": "esriFeature",
-            "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
-      },
-      {
-        "id": "baseEsriWorld",
-        "name": "World Imagery",
-        "description": "World Imagery provides one meter or better satellite and aerial imagery in many parts of the world and lower resolution satellite imagery worldwide.",
-        "altText": "altText - World Imagery",
-        "layers": [
-          {
-            "id": "World_Imagery",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      },
-      {
-        "id": "baseEsriPhysical",
-        "name": "World Physical Map",
-        "description": "This map presents the Natural Earth physical map at 1.24km per pixel for the world and 500m for the coterminous United States.",
-        "altText": "altText - World Physical Map",
-        "layers": [
-          {
-            "id": "World_Physical_Map",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Physical_Map/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      },
-      {
-        "id": "baseEsriRelief",
-        "name": "World Shaded Relief",
-        "description": "This map portrays surface elevation as shaded relief. This map is used as a basemap layer to add shaded relief to other GIS maps, such as the ArcGIS Online World Street Map.",
-        "altText": "altText - World Shaded Relief",
-        "layers": [
-          {
-            "id": "World_Shaded_Relief",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Shaded_Relief/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      },
-      {
-        "id": "baseEsriStreet",
-        "name": "World Street Map",
-        "description": "This worldwide street map presents highway-level data for the world.",
-        "altText": "altText - ESWorld Street Map",
-        "layers": [
-          {
-            "id": "World_Street_Map",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Street_Map/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      },
-      {
-        "id": "baseEsriTerrain",
-        "name": "World Terrain Base",
-        "description": "This map is designed to be used as a base map by GIS professionals to overlay other thematic layers such as demographics or land cover.",
-        "altText": "altText - World Terrain Base",
-        "layers": [
-          {
-            "id": "World_Terrain_Base",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Terrain_Base/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      },
-      {
-        "id": "baseEsriTopo",
-        "name": "World Topographic Map",
-        "description": "This map is designed to be used as a basemap by GIS professionals and as a reference map by anyone.",
-        "altText": "altText - World Topographic Map",
-        "layers": [
-          {
-            "id": "World_Topo_Map",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      }
-    ]
-  }
+    }
 }

--- a/public/f6f7baf4-cccb-4521-a037-b4691b0f0d49/ramp-config/en/total_reduced_sulphur_of_pnp_2010-2019.json
+++ b/public/f6f7baf4-cccb-4521-a037-b4691b0f0d49/ramp-config/en/total_reduced_sulphur_of_pnp_2010-2019.json
@@ -1,508 +1,535 @@
 {
-  "version": "2.0",
-  "language": "en",
-  "ui": {
-    "title": "Interactive map",
-    "fullscreen": true,
-    "navBar": {
-      "zoom": "buttons",
-      "extra": [ "fullscreen", "geoLocator", "home", "help" ]
-    },
-    "appBar": {
-      "basemap": true
-
-    },
-    "help": {
-      "folderName": "default"
-    },
-    "sideMenu": {
-      "items": [ [ "fullscreen", "export", "touch", "help", "about" ] ],
-      "logo": false
-    },
-    "legend": {
-      "allowImport": true,
-      "isOpen": {
-        "large": true,
-        "medium": false,
-        "small": false
-      }
-    }
-  },
-  "services": {
-    "proxyUrl": "http://167.40.64.74/wmsproxy/ws/wmsproxy/executeFromProxy",
-    "exportMapUrl": "https://maps-cartes.dev.ec.gc.ca/arcgis/rest/services/Utilities/PrintingTools/GPServer/Export%20Web%20Map%20Task",
-    "export": {
-      "title": {
-        "value": "Total releases and disposals of pulp and paper facilities that reported to the NPRI from 2010 to 2019"
-      },
-      "map": {},
-      "mapElements": {},
-      "legend": {},
-      "footnote": {
-        "value": "Total releases and disposals of pulp and paper facilities that reported to the NPRI from 2010 to 2019"
-      }
-    },
-    "search": {
-      "settings": {
-        "categories": [ "CITY", "HAM", "IR", "LTM", "MUN1", "MUN2", "PROV", "STM", "TERR", "TOWN", "UTM", "VILG", "UNP" ],
-        "sortOrder": [ "CITY", "HAM", "IR", "LTM", "MUN1", "MUN2", "PROV", "STM", "TERR", "TOWN", "UTM", "VILG", "UNP" ],
-        "maxResults": 1000,
-        "officialOnly": true
-      },	
-      "serviceUrls": {
-        "geoNames": "https://geogratis.gc.ca/services/geoname/en/geonames.json",
-        "geoLocation": "https://geogratis.gc.ca/services/geolocation/en/locate?q=",
-        "geoSuggest": "https://geogratis.gc.ca/services/geolocation/en/suggest?q=",
-        "provinces": "https://geogratis.gc.ca/services/geoname/en/codes/province.json",
-        "types": "https://geogratis.gc.ca/services/geoname/en/codes/concise.json"
-      }
-    }
-  },
-  "map": {
-    "initialBasemapId": "baseNrCan",
-    "components": {
-      "geoSearch": {
-        "enabled": true,
-        "showGraphic": true,
-        "showInfo": true
-      },
-      "mouseInfo": {
-        "enabled": true,
-        "spatialReference": {
-          "wkid": 4326
-        }
-      },
-      "northArrow": {
-        "enabled": false
-      },
-      "basemap": {
-        "enabled": true
-      },
-      "overviewMap": {
-        "enabled": true,
-        "layerType": "imagery"
-      },
-      "scaleBar": {
-        "enabled": true
-      }
-    },
-    "extentSets": [
-      {
-        "id": "EXT_NRCAN_Lambert_3978",
-        "default": {
-          "xmax": 2849492,
-          "xmin": -5281457,
-          "ymax": 4482193,
-          "ymin": -983440
+    "version": "2.0",
+    "language": "en",
+    "ui": {
+        "title": "Interactive map",
+        "fullscreen": true,
+        "navBar": {
+            "zoom": "buttons",
+            "extra": ["fullscreen", "geoLocator", "home", "help"]
         },
-        "spatialReference": {
-          "wkid": 3978
-        }
-      },
-      {
-        "id": "EXT_ESRI_World_AuxMerc_3857",
-        "default": {
-          "xmax": -5007771.626060756,
-          "xmin": -16632697.354854,
-          "ymax": 10015875.184845109,
-          "ymin": 5022907.964742964
+        "appBar": {
+            "basemap": true
         },
-        "spatialReference": {
-          "wkid": 102100,
-          "latestWkid": 3857
+        "help": {
+            "folderName": "default"
+        },
+        "sideMenu": {
+            "items": [["fullscreen", "export", "touch", "help", "about"]],
+            "logo": false
+        },
+        "legend": {
+            "allowImport": true,
+            "isOpen": {
+                "large": true,
+                "medium": false,
+                "small": false
+            }
         }
-      }
-    ],
-    "lodSets": [
-      {
-        "id": "LOD_NRCAN_Lambert_3978",
-        "lods": [
-          {
-            "level": 0,
-            "resolution": 38364.660062653464,
-            "scale": 145000000
-          },
-          {
-            "level": 1,
-            "resolution": 22489.628312589961,
-            "scale": 85000000
-          },
-          {
-            "level": 2,
-            "resolution": 13229.193125052918,
-            "scale": 50000000
-          },
-          {
-            "level": 3,
-            "resolution": 7937.5158750317505,
-            "scale": 30000000
-          },
-          {
-            "level": 4,
-            "resolution": 4630.2175937685215,
-            "scale": 17500000
-          },
-          {
-            "level": 5,
-            "resolution": 2645.8386250105837,
-            "scale": 10000000
-          },
-          {
-            "level": 6,
-            "resolution": 1587.5031750063501,
-            "scale": 6000000
-          },
-          {
-            "level": 7,
-            "resolution": 926.04351875370423,
-            "scale": 3500000
-          },
-          {
-            "level": 8,
-            "resolution": 529.16772500211675,
-            "scale": 2000000
-          },
-          {
-            "level": 9,
-            "resolution": 317.50063500127004,
-            "scale": 1200000
-          },
-          {
-            "level": 10,
-            "resolution": 185.20870375074085,
-            "scale": 700000
-          },
-          {
-            "level": 11,
-            "resolution": 111.12522225044451,
-            "scale": 420000
-          },
-          {
-            "level": 12,
-            "resolution": 66.1459656252646,
-            "scale": 250000
-          },
-          {
-            "level": 13,
-            "resolution": 38.364660062653464,
-            "scale": 145000
-          },
-          {
-            "level": 14,
-            "resolution": 22.489628312589961,
-            "scale": 85000
-          },
-          {
-            "level": 15,
-            "resolution": 13.229193125052918,
-            "scale": 50000
-          },
-          {
-            "level": 16,
-            "resolution": 7.9375158750317505,
-            "scale": 30000
-          },
-          {
-            "level": 17,
-            "resolution": 4.6302175937685215,
-            "scale": 17500
-          }
-        ]
-      },
-      {
-        "id": "LOD_ESRI_World_AuxMerc_3857",
-        "lods": [
-          {
-            "level": 0,
-            "resolution": 19567.879240999919,
-            "scale": 73957190.948944
-          },
-          {
-            "level": 1,
-            "resolution": 9783.93962049996,
-            "scale": 36978595.474472
-          },
-          {
-            "level": 2,
-            "resolution": 4891.96981024998,
-            "scale": 18489297.737236
-          },
-          {
-            "level": 3,
-            "resolution": 2445.98490512499,
-            "scale": 9244648.868618
-          },
-          {
-            "level": 4,
-            "resolution": 1222.9924525624949,
-            "scale": 4622324.434309
-          },
-          {
-            "level": 5,
-            "resolution": 611.49622628137968,
-            "scale": 2311162.217155
-          },
-          {
-            "level": 6,
-            "resolution": 305.74811314055756,
-            "scale": 1155581.108577
-          },
-          {
-            "level": 7,
-            "resolution": 152.87405657041106,
-            "scale": 577790.554289
-          },
-          {
-            "level": 8,
-            "resolution": 76.437028285073239,
-            "scale": 288895.277144
-          },
-          {
-            "level": 9,
-            "resolution": 38.21851414253662,
-            "scale": 144447.638572
-          },
-          {
-            "level": 10,
-            "resolution": 19.10925707126831,
-            "scale": 72223.819286
-          },
-          {
-            "level": 11,
-            "resolution": 9.5546285356341549,
-            "scale": 36111.909643
-          },
-          {
-            "level": 12,
-            "resolution": 4.77731426794937,
-            "scale": 18055.954822
-          },
-          {
-            "level": 13,
-            "resolution": 2.3886571339746849,
-            "scale": 9027.977411
-          },
-          {
-            "level": 14,
-            "resolution": 1.1943285668550503,
-            "scale": 4513.988705
-          },
-          {
-            "level": 15,
-            "resolution": 0.59716428355981721,
-            "scale": 2256.994353
-          },
-          {
-            "level": 16,
-            "resolution": 0.29858214164761665,
-            "scale": 1128.497176
-          },
-          {
-            "level": 17,
-            "resolution": 0.14929107082380833,
-            "scale": 564.248588
-          },
-          {
-            "level": 18,
-            "resolution": 0.074645535411904163,
-            "scale": 282.124294
-          },
-          {
-            "level": 19,
-            "resolution": 0.037322767705952081,
-            "scale": 141.062147
-          },
-          {
-            "level": 20,
-            "resolution": 0.018661383852976041,
-            "scale": 70.5310735
-          }
-        ]
-      }
-    ],
-    "legend": {
-      "type": "structured",
-      "root": {
-          "name": "root",
-          "children": [
+    },
+    "services": {
+        "proxyUrl": "http://167.40.64.74/wmsproxy/ws/wmsproxy/executeFromProxy",
+        "exportMapUrl": "https://maps-cartes.dev.ec.gc.ca/arcgis/rest/services/Utilities/PrintingTools/GPServer/Export%20Web%20Map%20Task",
+        "export": {
+            "title": {
+                "value": "Total releases and disposals of pulp and paper facilities that reported to the NPRI from 2010 to 2019"
+            },
+            "map": {},
+            "mapElements": {},
+            "legend": {},
+            "footnote": {
+                "value": "Total releases and disposals of pulp and paper facilities that reported to the NPRI from 2010 to 2019"
+            }
+        },
+        "search": {
+            "settings": {
+                "categories": [
+                    "CITY",
+                    "HAM",
+                    "IR",
+                    "LTM",
+                    "MUN1",
+                    "MUN2",
+                    "PROV",
+                    "STM",
+                    "TERR",
+                    "TOWN",
+                    "UTM",
+                    "VILG",
+                    "UNP"
+                ],
+                "sortOrder": [
+                    "CITY",
+                    "HAM",
+                    "IR",
+                    "LTM",
+                    "MUN1",
+                    "MUN2",
+                    "PROV",
+                    "STM",
+                    "TERR",
+                    "TOWN",
+                    "UTM",
+                    "VILG",
+                    "UNP"
+                ],
+                "maxResults": 1000,
+                "officialOnly": true
+            },
+            "serviceUrls": {
+                "geoNames": "https://geogratis.gc.ca/services/geoname/en/geonames.json",
+                "geoLocation": "https://geogratis.gc.ca/services/geolocation/en/locate?q=",
+                "geoSuggest": "https://geogratis.gc.ca/services/geolocation/en/suggest?q=",
+                "provinces": "https://geogratis.gc.ca/services/geoname/en/codes/province.json",
+                "types": "https://geogratis.gc.ca/services/geoname/en/codes/concise.json"
+            }
+        }
+    },
+    "map": {
+        "initialBasemapId": "baseNrCan",
+        "components": {
+            "geoSearch": {
+                "enabled": true,
+                "showGraphic": true,
+                "showInfo": true
+            },
+            "mouseInfo": {
+                "enabled": true,
+                "spatialReference": {
+                    "wkid": 4326
+                }
+            },
+            "northArrow": {
+                "enabled": false
+            },
+            "basemap": {
+                "enabled": true
+            },
+            "overviewMap": {
+                "enabled": true,
+                "layerType": "imagery"
+            },
+            "scaleBar": {
+                "enabled": true
+            }
+        },
+        "extentSets": [
             {
-                "layerId": "Sulphur",
-                "description": "Total reduced sulphur released by pulp and paper facilities that reported to the NPRI from 2010 to 2019 (tonnes)",                
-                "symbologyExpanded": true
+                "id": "EXT_NRCAN_Lambert_3978",
+                "default": {
+                    "xmax": 2249492,
+                    "xmin": -5881457,
+                    "ymax": 4482193,
+                    "ymin": -983440
+                },
+                "spatialReference": {
+                    "wkid": 3978
+                }
+            },
+            {
+                "id": "EXT_ESRI_World_AuxMerc_3857",
+                "default": {
+                    "xmax": -5007771.626060756,
+                    "xmin": -16632697.354854,
+                    "ymax": 10015875.184845109,
+                    "ymin": 5022907.964742964
+                },
+                "spatialReference": {
+                    "wkid": 102100,
+                    "latestWkid": 3857
+                }
+            }
+        ],
+        "lodSets": [
+            {
+                "id": "LOD_NRCAN_Lambert_3978",
+                "lods": [
+                    {
+                        "level": 0,
+                        "resolution": 38364.660062653464,
+                        "scale": 145000000
+                    },
+                    {
+                        "level": 1,
+                        "resolution": 22489.628312589961,
+                        "scale": 85000000
+                    },
+                    {
+                        "level": 2,
+                        "resolution": 13229.193125052918,
+                        "scale": 50000000
+                    },
+                    {
+                        "level": 3,
+                        "resolution": 7937.5158750317505,
+                        "scale": 30000000
+                    },
+                    {
+                        "level": 4,
+                        "resolution": 4630.2175937685215,
+                        "scale": 17500000
+                    },
+                    {
+                        "level": 5,
+                        "resolution": 2645.8386250105837,
+                        "scale": 10000000
+                    },
+                    {
+                        "level": 6,
+                        "resolution": 1587.5031750063501,
+                        "scale": 6000000
+                    },
+                    {
+                        "level": 7,
+                        "resolution": 926.04351875370423,
+                        "scale": 3500000
+                    },
+                    {
+                        "level": 8,
+                        "resolution": 529.16772500211675,
+                        "scale": 2000000
+                    },
+                    {
+                        "level": 9,
+                        "resolution": 317.50063500127004,
+                        "scale": 1200000
+                    },
+                    {
+                        "level": 10,
+                        "resolution": 185.20870375074085,
+                        "scale": 700000
+                    },
+                    {
+                        "level": 11,
+                        "resolution": 111.12522225044451,
+                        "scale": 420000
+                    },
+                    {
+                        "level": 12,
+                        "resolution": 66.1459656252646,
+                        "scale": 250000
+                    },
+                    {
+                        "level": 13,
+                        "resolution": 38.364660062653464,
+                        "scale": 145000
+                    },
+                    {
+                        "level": 14,
+                        "resolution": 22.489628312589961,
+                        "scale": 85000
+                    },
+                    {
+                        "level": 15,
+                        "resolution": 13.229193125052918,
+                        "scale": 50000
+                    },
+                    {
+                        "level": 16,
+                        "resolution": 7.9375158750317505,
+                        "scale": 30000
+                    },
+                    {
+                        "level": 17,
+                        "resolution": 4.6302175937685215,
+                        "scale": 17500
+                    }
+                ]
+            },
+            {
+                "id": "LOD_ESRI_World_AuxMerc_3857",
+                "lods": [
+                    {
+                        "level": 0,
+                        "resolution": 19567.879240999919,
+                        "scale": 73957190.948944
+                    },
+                    {
+                        "level": 1,
+                        "resolution": 9783.93962049996,
+                        "scale": 36978595.474472
+                    },
+                    {
+                        "level": 2,
+                        "resolution": 4891.96981024998,
+                        "scale": 18489297.737236
+                    },
+                    {
+                        "level": 3,
+                        "resolution": 2445.98490512499,
+                        "scale": 9244648.868618
+                    },
+                    {
+                        "level": 4,
+                        "resolution": 1222.9924525624949,
+                        "scale": 4622324.434309
+                    },
+                    {
+                        "level": 5,
+                        "resolution": 611.49622628137968,
+                        "scale": 2311162.217155
+                    },
+                    {
+                        "level": 6,
+                        "resolution": 305.74811314055756,
+                        "scale": 1155581.108577
+                    },
+                    {
+                        "level": 7,
+                        "resolution": 152.87405657041106,
+                        "scale": 577790.554289
+                    },
+                    {
+                        "level": 8,
+                        "resolution": 76.437028285073239,
+                        "scale": 288895.277144
+                    },
+                    {
+                        "level": 9,
+                        "resolution": 38.21851414253662,
+                        "scale": 144447.638572
+                    },
+                    {
+                        "level": 10,
+                        "resolution": 19.10925707126831,
+                        "scale": 72223.819286
+                    },
+                    {
+                        "level": 11,
+                        "resolution": 9.5546285356341549,
+                        "scale": 36111.909643
+                    },
+                    {
+                        "level": 12,
+                        "resolution": 4.77731426794937,
+                        "scale": 18055.954822
+                    },
+                    {
+                        "level": 13,
+                        "resolution": 2.3886571339746849,
+                        "scale": 9027.977411
+                    },
+                    {
+                        "level": 14,
+                        "resolution": 1.1943285668550503,
+                        "scale": 4513.988705
+                    },
+                    {
+                        "level": 15,
+                        "resolution": 0.59716428355981721,
+                        "scale": 2256.994353
+                    },
+                    {
+                        "level": 16,
+                        "resolution": 0.29858214164761665,
+                        "scale": 1128.497176
+                    },
+                    {
+                        "level": 17,
+                        "resolution": 0.14929107082380833,
+                        "scale": 564.248588
+                    },
+                    {
+                        "level": 18,
+                        "resolution": 0.074645535411904163,
+                        "scale": 282.124294
+                    },
+                    {
+                        "level": 19,
+                        "resolution": 0.037322767705952081,
+                        "scale": 141.062147
+                    },
+                    {
+                        "level": 20,
+                        "resolution": 0.018661383852976041,
+                        "scale": 70.5310735
+                    }
+                ]
+            }
+        ],
+        "legend": {
+            "type": "structured",
+            "root": {
+                "name": "root",
+                "children": [
+                    {
+                        "layerId": "Sulphur",
+                        "description": "Total reduced sulphur released by pulp and paper facilities that reported to the NPRI from 2010 to 2019 (tonnes)",
+                        "symbologyExpanded": true
+                    }
+                ]
+            }
+        },
+        "layers": [
+            {
+                "id": "Sulphur",
+                "name": "Total reduced sulphur released",
+                "layerType": "esriFeature",
+                "tolerance": 20,
+                "singleEntryCollapse": true,
+                "symbologyExpanded": true,
+                "url": "https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/StoryRAMP/f6f7baf4_cccb_4521_a037_b4691b0f0d49/MapServer/4",
+                "state": {
+                    "opacity": 0.75
+                }
+            }
+        ],
+        "tileSchemas": [
+            {
+                "id": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978",
+                "name": "Lambert Maps",
+                "extentSetId": "EXT_NRCAN_Lambert_3978",
+                "lodSetId": "LOD_NRCAN_Lambert_3978",
+                "hasNorthPole": true
+            },
+            {
+                "id": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857",
+                "name": "Web Mercator Maps",
+                "extentSetId": "EXT_ESRI_World_AuxMerc_3857",
+                "lodSetId": "LOD_ESRI_World_AuxMerc_3857"
+            }
+        ],
+        "baseMaps": [
+            {
+                "id": "baseNrCan",
+                "name": "Canada Base Map - Transportation (CBMT)",
+                "description": "The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.",
+                "altText": "altText - The Canada Base Map - Transportation (CBMT)",
+                "layers": [
+                    {
+                        "id": "CBMT",
+                        "layerType": "esriFeature",
+                        "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+            },
+            {
+                "id": "baseSimple",
+                "name": "Canada Base Map - Simple",
+                "description": "Canada Base Map - Simple",
+                "altText": "altText - Canada base map - Simple",
+                "layers": [
+                    {
+                        "id": "SMR",
+                        "layerType": "esriFeature",
+                        "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+            },
+            {
+                "id": "baseCBME_CBCE_HS_RO_3978",
+                "name": "Canada Base Map - Elevation (CBME)",
+                "description": "The Canada Base Map - Elevation (CBME) web mapping services of the Earth Sciences Sector at Natural Resources Canada, is intended primarily for online mapping application users and developers.",
+                "altText": "altText - Canada Base Map - Elevation (CBME)",
+                "layers": [
+                    {
+                        "id": "CBME_CBCE_HS_RO_3978",
+                        "layerType": "esriFeature",
+                        "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+            },
+            {
+                "id": "baseCBMT_CBCT_GEOM_3978",
+                "name": "Canada Base Map - Transportation (CBMT)",
+                "description": " The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.",
+                "altText": "altText - Canada Base Map - Transportation (CBMT)",
+                "layers": [
+                    {
+                        "id": "CBMT_CBCT_GEOM_3978",
+                        "layerType": "esriFeature",
+                        "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+            },
+            {
+                "id": "baseEsriWorld",
+                "name": "World Imagery",
+                "description": "World Imagery provides one meter or better satellite and aerial imagery in many parts of the world and lower resolution satellite imagery worldwide.",
+                "altText": "altText - World Imagery",
+                "layers": [
+                    {
+                        "id": "World_Imagery",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriPhysical",
+                "name": "World Physical Map",
+                "description": "This map presents the Natural Earth physical map at 1.24km per pixel for the world and 500m for the coterminous United States.",
+                "altText": "altText - World Physical Map",
+                "layers": [
+                    {
+                        "id": "World_Physical_Map",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Physical_Map/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriRelief",
+                "name": "World Shaded Relief",
+                "description": "This map portrays surface elevation as shaded relief. This map is used as a basemap layer to add shaded relief to other GIS maps, such as the ArcGIS Online World Street Map.",
+                "altText": "altText - World Shaded Relief",
+                "layers": [
+                    {
+                        "id": "World_Shaded_Relief",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Shaded_Relief/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriStreet",
+                "name": "World Street Map",
+                "description": "This worldwide street map presents highway-level data for the world.",
+                "altText": "altText - ESWorld Street Map",
+                "layers": [
+                    {
+                        "id": "World_Street_Map",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Street_Map/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriTerrain",
+                "name": "World Terrain Base",
+                "description": "This map is designed to be used as a base map by GIS professionals to overlay other thematic layers such as demographics or land cover.",
+                "altText": "altText - World Terrain Base",
+                "layers": [
+                    {
+                        "id": "World_Terrain_Base",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Terrain_Base/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriTopo",
+                "name": "World Topographic Map",
+                "description": "This map is designed to be used as a basemap by GIS professionals and as a reference map by anyone.",
+                "altText": "altText - World Topographic Map",
+                "layers": [
+                    {
+                        "id": "World_Topo_Map",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
             }
         ]
-      }
-  },
-    "layers": [
-      {
-          "id": "Sulphur",
-          "name": "Total reduced sulphur released",
-          "layerType": "esriFeature",
-          "tolerance": 20,
-          "singleEntryCollapse": true,
-          "symbologyExpanded": true,
-          "url": "https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/StoryRAMP/f6f7baf4_cccb_4521_a037_b4691b0f0d49/MapServer/4",
-          "state": {
-            "opacity": 0.75
-          }
-      }
-    ],
-    "tileSchemas": [
-      {
-        "id": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978",
-        "name": "Lambert Maps",
-        "extentSetId": "EXT_NRCAN_Lambert_3978",
-        "lodSetId": "LOD_NRCAN_Lambert_3978",
-        "hasNorthPole": true
-      },
-      {
-        "id": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857",
-        "name": "Web Mercator Maps",
-        "extentSetId": "EXT_ESRI_World_AuxMerc_3857",
-        "lodSetId": "LOD_ESRI_World_AuxMerc_3857"
-      }
-    ],
-    "baseMaps": [
-      {
-        "id": "baseNrCan",
-        "name": "Canada Base Map - Transportation (CBMT)",
-        "description": "The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.",
-        "altText": "altText - The Canada Base Map - Transportation (CBMT)",
-        "layers": [
-          {
-            "id": "CBMT",
-            "layerType": "esriFeature",
-            "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
-      },
-      {
-        "id": "baseSimple",
-        "name": "Canada Base Map - Simple",
-        "description": "Canada Base Map - Simple",
-        "altText": "altText - Canada base map - Simple",
-        "layers": [
-          {
-            "id": "SMR",
-            "layerType": "esriFeature",
-            "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
-      },
-      {
-        "id": "baseCBME_CBCE_HS_RO_3978",
-        "name": "Canada Base Map - Elevation (CBME)",
-        "description": "The Canada Base Map - Elevation (CBME) web mapping services of the Earth Sciences Sector at Natural Resources Canada, is intended primarily for online mapping application users and developers.",
-        "altText": "altText - Canada Base Map - Elevation (CBME)",
-        "layers": [
-          {
-            "id": "CBME_CBCE_HS_RO_3978",
-            "layerType": "esriFeature",
-            "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
-      },
-      {
-        "id": "baseCBMT_CBCT_GEOM_3978",
-        "name": "Canada Base Map - Transportation (CBMT)",
-        "description": " The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.",
-        "altText": "altText - Canada Base Map - Transportation (CBMT)",
-        "layers": [
-          {
-            "id": "CBMT_CBCT_GEOM_3978",
-            "layerType": "esriFeature",
-            "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
-      },
-      {
-        "id": "baseEsriWorld",
-        "name": "World Imagery",
-        "description": "World Imagery provides one meter or better satellite and aerial imagery in many parts of the world and lower resolution satellite imagery worldwide.",
-        "altText": "altText - World Imagery",
-        "layers": [
-          {
-            "id": "World_Imagery",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      },
-      {
-        "id": "baseEsriPhysical",
-        "name": "World Physical Map",
-        "description": "This map presents the Natural Earth physical map at 1.24km per pixel for the world and 500m for the coterminous United States.",
-        "altText": "altText - World Physical Map",
-        "layers": [
-          {
-            "id": "World_Physical_Map",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Physical_Map/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      },
-      {
-        "id": "baseEsriRelief",
-        "name": "World Shaded Relief",
-        "description": "This map portrays surface elevation as shaded relief. This map is used as a basemap layer to add shaded relief to other GIS maps, such as the ArcGIS Online World Street Map.",
-        "altText": "altText - World Shaded Relief",
-        "layers": [
-          {
-            "id": "World_Shaded_Relief",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Shaded_Relief/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      },
-      {
-        "id": "baseEsriStreet",
-        "name": "World Street Map",
-        "description": "This worldwide street map presents highway-level data for the world.",
-        "altText": "altText - ESWorld Street Map",
-        "layers": [
-          {
-            "id": "World_Street_Map",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Street_Map/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      },
-      {
-        "id": "baseEsriTerrain",
-        "name": "World Terrain Base",
-        "description": "This map is designed to be used as a base map by GIS professionals to overlay other thematic layers such as demographics or land cover.",
-        "altText": "altText - World Terrain Base",
-        "layers": [
-          {
-            "id": "World_Terrain_Base",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Terrain_Base/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      },
-      {
-        "id": "baseEsriTopo",
-        "name": "World Topographic Map",
-        "description": "This map is designed to be used as a basemap by GIS professionals and as a reference map by anyone.",
-        "altText": "altText - World Topographic Map",
-        "layers": [
-          {
-            "id": "World_Topo_Map",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      }
-    ]
-  }
+    }
 }

--- a/public/f6f7baf4-cccb-4521-a037-b4691b0f0d49/ramp-config/en/total_releases_and_disposals_of_pnp_2010-2019.json
+++ b/public/f6f7baf4-cccb-4521-a037-b4691b0f0d49/ramp-config/en/total_releases_and_disposals_of_pnp_2010-2019.json
@@ -1,513 +1,540 @@
 {
-  "version": "2.0",
-  "language": "en",
-  "ui": {
-    "title": "Interactive map",
-    "fullscreen": true,
-    "navBar": {
-      "zoom": "buttons",
-      "extra": [ "fullscreen", "geoLocator", "home", "help" ]
-    },
-    "appBar": {
-      "basemap": true
-
-    },
-    "help": {
-      "folderName": "default"
-    },
-    "sideMenu": {
-      "items": [ [ "fullscreen", "export", "touch", "help", "about" ] ],
-      "logo": false
-    },
-    "legend": {
-      "allowImport": true,
-      "isOpen": {
-        "large": true,
-        "medium": false,
-        "small": false
-      }
-    }
-  },
-  "services": {
-    "proxyUrl": "http://167.40.64.74/wmsproxy/ws/wmsproxy/executeFromProxy",
-    "exportMapUrl": "https://maps-cartes.dev.ec.gc.ca/arcgis/rest/services/Utilities/PrintingTools/GPServer/Export%20Web%20Map%20Task",
-    "export": {
-      "title": {
-        "value": "Total releases and disposals of pulp and paper facilities that reported to the NPRI from 2010 to 2019"
-      },
-      "map": {},
-      "mapElements": {},
-      "legend": {},
-      "footnote": {
-        "value": "Total releases and disposals of pulp and paper facilities that reported to the NPRI from 2010 to 2019"
-      }
-    },
-    "search": {
-      "settings": {
-        "categories": [ "CITY", "HAM", "IR", "LTM", "MUN1", "MUN2", "PROV", "STM", "TERR", "TOWN", "UTM", "VILG", "UNP" ],
-        "sortOrder": [ "CITY", "HAM", "IR", "LTM", "MUN1", "MUN2", "PROV", "STM", "TERR", "TOWN", "UTM", "VILG", "UNP" ],
-        "maxResults": 1000,
-        "officialOnly": true
-      },	
-      "serviceUrls": {
-        "geoNames": "https://geogratis.gc.ca/services/geoname/en/geonames.json",
-        "geoLocation": "https://geogratis.gc.ca/services/geolocation/en/locate?q=",
-        "geoSuggest": "https://geogratis.gc.ca/services/geolocation/en/suggest?q=",
-        "provinces": "https://geogratis.gc.ca/services/geoname/en/codes/province.json",
-        "types": "https://geogratis.gc.ca/services/geoname/en/codes/concise.json"
-      }
-    }
-  },
-  "map": {
-    "initialBasemapId": "baseNrCan",
-    "components": {
-      "geoSearch": {
-        "enabled": true,
-        "showGraphic": true,
-        "showInfo": true
-      },
-      "mouseInfo": {
-        "enabled": true,
-        "spatialReference": {
-          "wkid": 4326
-        }
-      },
-      "northArrow": {
-        "enabled": false
-      },
-      "basemap": {
-        "enabled": true
-      },
-      "overviewMap": {
-        "enabled": true,
-        "layerType": "imagery"
-      },
-      "scaleBar": {
-        "enabled": true
-      }
-    },
-    "extentSets": [
-      {
-        "id": "EXT_NRCAN_Lambert_3978",
-        "default": {
-          "xmax": 2849492,
-          "xmin": -5281457,
-          "ymax": 4482193,
-          "ymin": -983440
+    "version": "2.0",
+    "language": "en",
+    "ui": {
+        "title": "Interactive map",
+        "fullscreen": true,
+        "navBar": {
+            "zoom": "buttons",
+            "extra": ["fullscreen", "geoLocator", "home", "help"]
         },
-        "spatialReference": {
-          "wkid": 3978
-        }
-      },
-      {
-        "id": "EXT_ESRI_World_AuxMerc_3857",
-        "default": {
-          "xmax": -5007771.626060756,
-          "xmin": -16632697.354854,
-          "ymax": 10015875.184845109,
-          "ymin": 5022907.964742964
+        "appBar": {
+            "basemap": true
         },
-        "spatialReference": {
-          "wkid": 102100,
-          "latestWkid": 3857
+        "help": {
+            "folderName": "default"
+        },
+        "sideMenu": {
+            "items": [["fullscreen", "export", "touch", "help", "about"]],
+            "logo": false
+        },
+        "legend": {
+            "allowImport": true,
+            "isOpen": {
+                "large": true,
+                "medium": false,
+                "small": false
+            }
         }
-      }
-    ],
-    "lodSets": [
-      {
-        "id": "LOD_NRCAN_Lambert_3978",
-        "lods": [
-          {
-            "level": 0,
-            "resolution": 38364.660062653464,
-            "scale": 145000000
-          },
-          {
-            "level": 1,
-            "resolution": 22489.628312589961,
-            "scale": 85000000
-          },
-          {
-            "level": 2,
-            "resolution": 13229.193125052918,
-            "scale": 50000000
-          },
-          {
-            "level": 3,
-            "resolution": 7937.5158750317505,
-            "scale": 30000000
-          },
-          {
-            "level": 4,
-            "resolution": 4630.2175937685215,
-            "scale": 17500000
-          },
-          {
-            "level": 5,
-            "resolution": 2645.8386250105837,
-            "scale": 10000000
-          },
-          {
-            "level": 6,
-            "resolution": 1587.5031750063501,
-            "scale": 6000000
-          },
-          {
-            "level": 7,
-            "resolution": 926.04351875370423,
-            "scale": 3500000
-          },
-          {
-            "level": 8,
-            "resolution": 529.16772500211675,
-            "scale": 2000000
-          },
-          {
-            "level": 9,
-            "resolution": 317.50063500127004,
-            "scale": 1200000
-          },
-          {
-            "level": 10,
-            "resolution": 185.20870375074085,
-            "scale": 700000
-          },
-          {
-            "level": 11,
-            "resolution": 111.12522225044451,
-            "scale": 420000
-          },
-          {
-            "level": 12,
-            "resolution": 66.1459656252646,
-            "scale": 250000
-          },
-          {
-            "level": 13,
-            "resolution": 38.364660062653464,
-            "scale": 145000
-          },
-          {
-            "level": 14,
-            "resolution": 22.489628312589961,
-            "scale": 85000
-          },
-          {
-            "level": 15,
-            "resolution": 13.229193125052918,
-            "scale": 50000
-          },
-          {
-            "level": 16,
-            "resolution": 7.9375158750317505,
-            "scale": 30000
-          },
-          {
-            "level": 17,
-            "resolution": 4.6302175937685215,
-            "scale": 17500
-          }
-        ]
-      },
-      {
-        "id": "LOD_ESRI_World_AuxMerc_3857",
-        "lods": [
-          {
-            "level": 0,
-            "resolution": 19567.879240999919,
-            "scale": 73957190.948944
-          },
-          {
-            "level": 1,
-            "resolution": 9783.93962049996,
-            "scale": 36978595.474472
-          },
-          {
-            "level": 2,
-            "resolution": 4891.96981024998,
-            "scale": 18489297.737236
-          },
-          {
-            "level": 3,
-            "resolution": 2445.98490512499,
-            "scale": 9244648.868618
-          },
-          {
-            "level": 4,
-            "resolution": 1222.9924525624949,
-            "scale": 4622324.434309
-          },
-          {
-            "level": 5,
-            "resolution": 611.49622628137968,
-            "scale": 2311162.217155
-          },
-          {
-            "level": 6,
-            "resolution": 305.74811314055756,
-            "scale": 1155581.108577
-          },
-          {
-            "level": 7,
-            "resolution": 152.87405657041106,
-            "scale": 577790.554289
-          },
-          {
-            "level": 8,
-            "resolution": 76.437028285073239,
-            "scale": 288895.277144
-          },
-          {
-            "level": 9,
-            "resolution": 38.21851414253662,
-            "scale": 144447.638572
-          },
-          {
-            "level": 10,
-            "resolution": 19.10925707126831,
-            "scale": 72223.819286
-          },
-          {
-            "level": 11,
-            "resolution": 9.5546285356341549,
-            "scale": 36111.909643
-          },
-          {
-            "level": 12,
-            "resolution": 4.77731426794937,
-            "scale": 18055.954822
-          },
-          {
-            "level": 13,
-            "resolution": 2.3886571339746849,
-            "scale": 9027.977411
-          },
-          {
-            "level": 14,
-            "resolution": 1.1943285668550503,
-            "scale": 4513.988705
-          },
-          {
-            "level": 15,
-            "resolution": 0.59716428355981721,
-            "scale": 2256.994353
-          },
-          {
-            "level": 16,
-            "resolution": 0.29858214164761665,
-            "scale": 1128.497176
-          },
-          {
-            "level": 17,
-            "resolution": 0.14929107082380833,
-            "scale": 564.248588
-          },
-          {
-            "level": 18,
-            "resolution": 0.074645535411904163,
-            "scale": 282.124294
-          },
-          {
-            "level": 19,
-            "resolution": 0.037322767705952081,
-            "scale": 141.062147
-          },
-          {
-            "level": 20,
-            "resolution": 0.018661383852976041,
-            "scale": 70.5310735
-          }
-        ]
-      }
-    ],
-    "legend": {
-      "type": "structured",
-      "root": {
-          "name": "root",
-          "children": [
+    },
+    "services": {
+        "proxyUrl": "http://167.40.64.74/wmsproxy/ws/wmsproxy/executeFromProxy",
+        "exportMapUrl": "https://maps-cartes.dev.ec.gc.ca/arcgis/rest/services/Utilities/PrintingTools/GPServer/Export%20Web%20Map%20Task",
+        "export": {
+            "title": {
+                "value": "Total releases and disposals of pulp and paper facilities that reported to the NPRI from 2010 to 2019"
+            },
+            "map": {},
+            "mapElements": {},
+            "legend": {},
+            "footnote": {
+                "value": "Total releases and disposals of pulp and paper facilities that reported to the NPRI from 2010 to 2019"
+            }
+        },
+        "search": {
+            "settings": {
+                "categories": [
+                    "CITY",
+                    "HAM",
+                    "IR",
+                    "LTM",
+                    "MUN1",
+                    "MUN2",
+                    "PROV",
+                    "STM",
+                    "TERR",
+                    "TOWN",
+                    "UTM",
+                    "VILG",
+                    "UNP"
+                ],
+                "sortOrder": [
+                    "CITY",
+                    "HAM",
+                    "IR",
+                    "LTM",
+                    "MUN1",
+                    "MUN2",
+                    "PROV",
+                    "STM",
+                    "TERR",
+                    "TOWN",
+                    "UTM",
+                    "VILG",
+                    "UNP"
+                ],
+                "maxResults": 1000,
+                "officialOnly": true
+            },
+            "serviceUrls": {
+                "geoNames": "https://geogratis.gc.ca/services/geoname/en/geonames.json",
+                "geoLocation": "https://geogratis.gc.ca/services/geolocation/en/locate?q=",
+                "geoSuggest": "https://geogratis.gc.ca/services/geolocation/en/suggest?q=",
+                "provinces": "https://geogratis.gc.ca/services/geoname/en/codes/province.json",
+                "types": "https://geogratis.gc.ca/services/geoname/en/codes/concise.json"
+            }
+        }
+    },
+    "map": {
+        "initialBasemapId": "baseNrCan",
+        "components": {
+            "geoSearch": {
+                "enabled": true,
+                "showGraphic": true,
+                "showInfo": true
+            },
+            "mouseInfo": {
+                "enabled": true,
+                "spatialReference": {
+                    "wkid": 4326
+                }
+            },
+            "northArrow": {
+                "enabled": false
+            },
+            "basemap": {
+                "enabled": true
+            },
+            "overviewMap": {
+                "enabled": true,
+                "layerType": "imagery"
+            },
+            "scaleBar": {
+                "enabled": true
+            }
+        },
+        "extentSets": [
             {
-                "layerId": "Releases",
-                "description": "Total releases and disposals of pulp and paper facilities that reported to the NPRI from 2010 to 2019 (tonnes)",                
-                "symbologyExpanded": true
+                "id": "EXT_NRCAN_Lambert_3978",
+                "default": {
+                    "xmax": 2249492,
+                    "xmin": -5881457,
+                    "ymax": 4482193,
+                    "ymin": -983440
+                },
+                "spatialReference": {
+                    "wkid": 3978
+                }
+            },
+            {
+                "id": "EXT_ESRI_World_AuxMerc_3857",
+                "default": {
+                    "xmax": -5007771.626060756,
+                    "xmin": -16632697.354854,
+                    "ymax": 10015875.184845109,
+                    "ymin": 5022907.964742964
+                },
+                "spatialReference": {
+                    "wkid": 102100,
+                    "latestWkid": 3857
+                }
+            }
+        ],
+        "lodSets": [
+            {
+                "id": "LOD_NRCAN_Lambert_3978",
+                "lods": [
+                    {
+                        "level": 0,
+                        "resolution": 38364.660062653464,
+                        "scale": 145000000
+                    },
+                    {
+                        "level": 1,
+                        "resolution": 22489.628312589961,
+                        "scale": 85000000
+                    },
+                    {
+                        "level": 2,
+                        "resolution": 13229.193125052918,
+                        "scale": 50000000
+                    },
+                    {
+                        "level": 3,
+                        "resolution": 7937.5158750317505,
+                        "scale": 30000000
+                    },
+                    {
+                        "level": 4,
+                        "resolution": 4630.2175937685215,
+                        "scale": 17500000
+                    },
+                    {
+                        "level": 5,
+                        "resolution": 2645.8386250105837,
+                        "scale": 10000000
+                    },
+                    {
+                        "level": 6,
+                        "resolution": 1587.5031750063501,
+                        "scale": 6000000
+                    },
+                    {
+                        "level": 7,
+                        "resolution": 926.04351875370423,
+                        "scale": 3500000
+                    },
+                    {
+                        "level": 8,
+                        "resolution": 529.16772500211675,
+                        "scale": 2000000
+                    },
+                    {
+                        "level": 9,
+                        "resolution": 317.50063500127004,
+                        "scale": 1200000
+                    },
+                    {
+                        "level": 10,
+                        "resolution": 185.20870375074085,
+                        "scale": 700000
+                    },
+                    {
+                        "level": 11,
+                        "resolution": 111.12522225044451,
+                        "scale": 420000
+                    },
+                    {
+                        "level": 12,
+                        "resolution": 66.1459656252646,
+                        "scale": 250000
+                    },
+                    {
+                        "level": 13,
+                        "resolution": 38.364660062653464,
+                        "scale": 145000
+                    },
+                    {
+                        "level": 14,
+                        "resolution": 22.489628312589961,
+                        "scale": 85000
+                    },
+                    {
+                        "level": 15,
+                        "resolution": 13.229193125052918,
+                        "scale": 50000
+                    },
+                    {
+                        "level": 16,
+                        "resolution": 7.9375158750317505,
+                        "scale": 30000
+                    },
+                    {
+                        "level": 17,
+                        "resolution": 4.6302175937685215,
+                        "scale": 17500
+                    }
+                ]
+            },
+            {
+                "id": "LOD_ESRI_World_AuxMerc_3857",
+                "lods": [
+                    {
+                        "level": 0,
+                        "resolution": 19567.879240999919,
+                        "scale": 73957190.948944
+                    },
+                    {
+                        "level": 1,
+                        "resolution": 9783.93962049996,
+                        "scale": 36978595.474472
+                    },
+                    {
+                        "level": 2,
+                        "resolution": 4891.96981024998,
+                        "scale": 18489297.737236
+                    },
+                    {
+                        "level": 3,
+                        "resolution": 2445.98490512499,
+                        "scale": 9244648.868618
+                    },
+                    {
+                        "level": 4,
+                        "resolution": 1222.9924525624949,
+                        "scale": 4622324.434309
+                    },
+                    {
+                        "level": 5,
+                        "resolution": 611.49622628137968,
+                        "scale": 2311162.217155
+                    },
+                    {
+                        "level": 6,
+                        "resolution": 305.74811314055756,
+                        "scale": 1155581.108577
+                    },
+                    {
+                        "level": 7,
+                        "resolution": 152.87405657041106,
+                        "scale": 577790.554289
+                    },
+                    {
+                        "level": 8,
+                        "resolution": 76.437028285073239,
+                        "scale": 288895.277144
+                    },
+                    {
+                        "level": 9,
+                        "resolution": 38.21851414253662,
+                        "scale": 144447.638572
+                    },
+                    {
+                        "level": 10,
+                        "resolution": 19.10925707126831,
+                        "scale": 72223.819286
+                    },
+                    {
+                        "level": 11,
+                        "resolution": 9.5546285356341549,
+                        "scale": 36111.909643
+                    },
+                    {
+                        "level": 12,
+                        "resolution": 4.77731426794937,
+                        "scale": 18055.954822
+                    },
+                    {
+                        "level": 13,
+                        "resolution": 2.3886571339746849,
+                        "scale": 9027.977411
+                    },
+                    {
+                        "level": 14,
+                        "resolution": 1.1943285668550503,
+                        "scale": 4513.988705
+                    },
+                    {
+                        "level": 15,
+                        "resolution": 0.59716428355981721,
+                        "scale": 2256.994353
+                    },
+                    {
+                        "level": 16,
+                        "resolution": 0.29858214164761665,
+                        "scale": 1128.497176
+                    },
+                    {
+                        "level": 17,
+                        "resolution": 0.14929107082380833,
+                        "scale": 564.248588
+                    },
+                    {
+                        "level": 18,
+                        "resolution": 0.074645535411904163,
+                        "scale": 282.124294
+                    },
+                    {
+                        "level": 19,
+                        "resolution": 0.037322767705952081,
+                        "scale": 141.062147
+                    },
+                    {
+                        "level": 20,
+                        "resolution": 0.018661383852976041,
+                        "scale": 70.5310735
+                    }
+                ]
+            }
+        ],
+        "legend": {
+            "type": "structured",
+            "root": {
+                "name": "root",
+                "children": [
+                    {
+                        "layerId": "Releases",
+                        "description": "Total releases and disposals of pulp and paper facilities that reported to the NPRI from 2010 to 2019 (tonnes)",
+                        "symbologyExpanded": true
+                    }
+                ]
+            }
+        },
+        "layers": [
+            {
+                "id": "Releases",
+                "layerType": "esriDynamic",
+                "tolerance": 20,
+                "singleEntryCollapse": true,
+                "symbologyExpanded": true,
+                "url": "https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/StoryRAMP/f6f7baf4_cccb_4521_a037_b4691b0f0d49/MapServer",
+                "state": {
+                    "opacity": 0.75
+                },
+                "layerEntries": [
+                    {
+                        "index": 2,
+                        "name": "Total releases and disposals"
+                    }
+                ]
+            }
+        ],
+        "tileSchemas": [
+            {
+                "id": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978",
+                "name": "Lambert Maps",
+                "extentSetId": "EXT_NRCAN_Lambert_3978",
+                "lodSetId": "LOD_NRCAN_Lambert_3978",
+                "hasNorthPole": true
+            },
+            {
+                "id": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857",
+                "name": "Web Mercator Maps",
+                "extentSetId": "EXT_ESRI_World_AuxMerc_3857",
+                "lodSetId": "LOD_ESRI_World_AuxMerc_3857"
+            }
+        ],
+        "baseMaps": [
+            {
+                "id": "baseNrCan",
+                "name": "Canada Base Map - Transportation (CBMT)",
+                "description": "The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.",
+                "altText": "altText - The Canada Base Map - Transportation (CBMT)",
+                "layers": [
+                    {
+                        "id": "CBMT",
+                        "layerType": "esriFeature",
+                        "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+            },
+            {
+                "id": "baseSimple",
+                "name": "Canada Base Map - Simple",
+                "description": "Canada Base Map - Simple",
+                "altText": "altText - Canada base map - Simple",
+                "layers": [
+                    {
+                        "id": "SMR",
+                        "layerType": "esriFeature",
+                        "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+            },
+            {
+                "id": "baseCBME_CBCE_HS_RO_3978",
+                "name": "Canada Base Map - Elevation (CBME)",
+                "description": "The Canada Base Map - Elevation (CBME) web mapping services of the Earth Sciences Sector at Natural Resources Canada, is intended primarily for online mapping application users and developers.",
+                "altText": "altText - Canada Base Map - Elevation (CBME)",
+                "layers": [
+                    {
+                        "id": "CBME_CBCE_HS_RO_3978",
+                        "layerType": "esriFeature",
+                        "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+            },
+            {
+                "id": "baseCBMT_CBCT_GEOM_3978",
+                "name": "Canada Base Map - Transportation (CBMT)",
+                "description": " The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.",
+                "altText": "altText - Canada Base Map - Transportation (CBMT)",
+                "layers": [
+                    {
+                        "id": "CBMT_CBCT_GEOM_3978",
+                        "layerType": "esriFeature",
+                        "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+            },
+            {
+                "id": "baseEsriWorld",
+                "name": "World Imagery",
+                "description": "World Imagery provides one meter or better satellite and aerial imagery in many parts of the world and lower resolution satellite imagery worldwide.",
+                "altText": "altText - World Imagery",
+                "layers": [
+                    {
+                        "id": "World_Imagery",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriPhysical",
+                "name": "World Physical Map",
+                "description": "This map presents the Natural Earth physical map at 1.24km per pixel for the world and 500m for the coterminous United States.",
+                "altText": "altText - World Physical Map",
+                "layers": [
+                    {
+                        "id": "World_Physical_Map",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Physical_Map/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriRelief",
+                "name": "World Shaded Relief",
+                "description": "This map portrays surface elevation as shaded relief. This map is used as a basemap layer to add shaded relief to other GIS maps, such as the ArcGIS Online World Street Map.",
+                "altText": "altText - World Shaded Relief",
+                "layers": [
+                    {
+                        "id": "World_Shaded_Relief",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Shaded_Relief/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriStreet",
+                "name": "World Street Map",
+                "description": "This worldwide street map presents highway-level data for the world.",
+                "altText": "altText - ESWorld Street Map",
+                "layers": [
+                    {
+                        "id": "World_Street_Map",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Street_Map/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriTerrain",
+                "name": "World Terrain Base",
+                "description": "This map is designed to be used as a base map by GIS professionals to overlay other thematic layers such as demographics or land cover.",
+                "altText": "altText - World Terrain Base",
+                "layers": [
+                    {
+                        "id": "World_Terrain_Base",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Terrain_Base/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriTopo",
+                "name": "World Topographic Map",
+                "description": "This map is designed to be used as a basemap by GIS professionals and as a reference map by anyone.",
+                "altText": "altText - World Topographic Map",
+                "layers": [
+                    {
+                        "id": "World_Topo_Map",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
             }
         ]
-      }
-  },
-    "layers": [
-      {
-          "id": "Releases",
-          "layerType": "esriDynamic",
-          "tolerance": 20,
-          "singleEntryCollapse": true,
-          "symbologyExpanded": true,
-          "url": "https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/StoryRAMP/f6f7baf4_cccb_4521_a037_b4691b0f0d49/MapServer",
-          "state": {
-            "opacity": 0.75
-          },
-          "layerEntries": [
-            {
-              "index": 2,
-              "name": "Total releases and disposals"              
-            }
-          ]  
-      }
-    ],
-    "tileSchemas": [
-      {
-        "id": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978",
-        "name": "Lambert Maps",
-        "extentSetId": "EXT_NRCAN_Lambert_3978",
-        "lodSetId": "LOD_NRCAN_Lambert_3978",
-        "hasNorthPole": true
-      },
-      {
-        "id": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857",
-        "name": "Web Mercator Maps",
-        "extentSetId": "EXT_ESRI_World_AuxMerc_3857",
-        "lodSetId": "LOD_ESRI_World_AuxMerc_3857"
-      }
-    ],
-    "baseMaps": [
-      {
-        "id": "baseNrCan",
-        "name": "Canada Base Map - Transportation (CBMT)",
-        "description": "The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.",
-        "altText": "altText - The Canada Base Map - Transportation (CBMT)",
-        "layers": [
-          {
-            "id": "CBMT",
-            "layerType": "esriFeature",
-            "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
-      },
-      {
-        "id": "baseSimple",
-        "name": "Canada Base Map - Simple",
-        "description": "Canada Base Map - Simple",
-        "altText": "altText - Canada base map - Simple",
-        "layers": [
-          {
-            "id": "SMR",
-            "layerType": "esriFeature",
-            "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
-      },
-      {
-        "id": "baseCBME_CBCE_HS_RO_3978",
-        "name": "Canada Base Map - Elevation (CBME)",
-        "description": "The Canada Base Map - Elevation (CBME) web mapping services of the Earth Sciences Sector at Natural Resources Canada, is intended primarily for online mapping application users and developers.",
-        "altText": "altText - Canada Base Map - Elevation (CBME)",
-        "layers": [
-          {
-            "id": "CBME_CBCE_HS_RO_3978",
-            "layerType": "esriFeature",
-            "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
-      },
-      {
-        "id": "baseCBMT_CBCT_GEOM_3978",
-        "name": "Canada Base Map - Transportation (CBMT)",
-        "description": " The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.",
-        "altText": "altText - Canada Base Map - Transportation (CBMT)",
-        "layers": [
-          {
-            "id": "CBMT_CBCT_GEOM_3978",
-            "layerType": "esriFeature",
-            "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
-      },
-      {
-        "id": "baseEsriWorld",
-        "name": "World Imagery",
-        "description": "World Imagery provides one meter or better satellite and aerial imagery in many parts of the world and lower resolution satellite imagery worldwide.",
-        "altText": "altText - World Imagery",
-        "layers": [
-          {
-            "id": "World_Imagery",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      },
-      {
-        "id": "baseEsriPhysical",
-        "name": "World Physical Map",
-        "description": "This map presents the Natural Earth physical map at 1.24km per pixel for the world and 500m for the coterminous United States.",
-        "altText": "altText - World Physical Map",
-        "layers": [
-          {
-            "id": "World_Physical_Map",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Physical_Map/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      },
-      {
-        "id": "baseEsriRelief",
-        "name": "World Shaded Relief",
-        "description": "This map portrays surface elevation as shaded relief. This map is used as a basemap layer to add shaded relief to other GIS maps, such as the ArcGIS Online World Street Map.",
-        "altText": "altText - World Shaded Relief",
-        "layers": [
-          {
-            "id": "World_Shaded_Relief",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Shaded_Relief/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      },
-      {
-        "id": "baseEsriStreet",
-        "name": "World Street Map",
-        "description": "This worldwide street map presents highway-level data for the world.",
-        "altText": "altText - ESWorld Street Map",
-        "layers": [
-          {
-            "id": "World_Street_Map",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Street_Map/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      },
-      {
-        "id": "baseEsriTerrain",
-        "name": "World Terrain Base",
-        "description": "This map is designed to be used as a base map by GIS professionals to overlay other thematic layers such as demographics or land cover.",
-        "altText": "altText - World Terrain Base",
-        "layers": [
-          {
-            "id": "World_Terrain_Base",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Terrain_Base/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      },
-      {
-        "id": "baseEsriTopo",
-        "name": "World Topographic Map",
-        "description": "This map is designed to be used as a basemap by GIS professionals and as a reference map by anyone.",
-        "altText": "altText - World Topographic Map",
-        "layers": [
-          {
-            "id": "World_Topo_Map",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      }
-    ]
-  }
+    }
 }

--- a/public/f6f7baf4-cccb-4521-a037-b4691b0f0d49/ramp-config/fr/phosphorus_and_nitrates_of_pnp_2010-2019.json
+++ b/public/f6f7baf4-cccb-4521-a037-b4691b0f0d49/ramp-config/fr/phosphorus_and_nitrates_of_pnp_2010-2019.json
@@ -1,570 +1,557 @@
 {
-  "version": "2.0",
-  "language": "fr",
-  "ui": {
-    "title": "Carte interactive",
-    "fullscreen": true,
-    "navBar": {
-      "zoom": "buttons",
-      "extra": [
-        "fullscreen",
-        "geoLocator",
-        "home",
-        "help"
-      ]
-    },
-    "appBar": {
-      "basemap": true
-    },
-    "help": {
-      "folderName": "default"
-    },
-    "sideMenu": {
-      "items": [
-        [
-          "fullscreen",
-          "export",
-          "touch",
-          "help",
-          "about"
-        ]
-      ],
-      "logo": false
-    },
-    "legend": {
-      "allowImport": true,
-      "isOpen": {
-        "large": true,
-        "medium": false,
-        "small": false
-      }
-    }
-  },
-  "services": {
-    "proxyUrl": "http://167.40.64.74/wmsproxy/ws/wmsproxy/executeFromProxy",
-    "exportMapUrl": "https://maps-cartes.dev.ec.gc.ca/arcgis/rest/services/Utilities/PrintingTools/GPServer/Export%20Web%20Map%20Task",
-    "export": {
-      "title": {
-        "value": "Rejets de phosphore et de nitrates par les installations de pâtes et papiers déclarant à l’INRP de 2010 à 2019"
-      },
-      "map": {},
-      "mapElements": {},
-      "legend": {},
-      "footnote": {
-        "value": "Rejets de phosphore et de nitrates par les installations de pâtes et papiers déclarant à l’INRP de 2010 à 2019"
-      }
-    },
-    "search": {
-      "settings": {
-        "categories": [
-          "CITY",
-          "HAM",
-          "IR",
-          "LTM",
-          "MUN1",
-          "MUN2",
-          "PROV",
-          "STM",
-          "TERR",
-          "TOWN",
-          "UTM",
-          "VILG",
-          "UNP"
-        ],
-        "sortOrder": [
-          "CITY",
-          "HAM",
-          "IR",
-          "LTM",
-          "MUN1",
-          "MUN2",
-          "PROV",
-          "STM",
-          "TERR",
-          "TOWN",
-          "UTM",
-          "VILG",
-          "UNP"
-        ],
-        "maxResults": 1000,
-        "officialOnly": true
-      },
-      "serviceUrls": {
-        "geoNames": "https://geogratis.gc.ca/services/geoname/fr/geonames.json",
-        "geoLocation": "https://geogratis.gc.ca/services/geolocation/fr/locate?q=",
-        "geoSuggest": "https://geogratis.gc.ca/services/geolocation/fr/suggest?q=",
-        "provinces": "https://geogratis.gc.ca/services/geoname/fr/codes/province.json",
-        "types": "https://geogratis.gc.ca/services/geoname/fr/codes/concise.json"
-      }
-    }
-  },
-  "map": {
-    "initialBasemapId": "baseNrCan",
-    "components": {
-      "geoSearch": {
-        "enabled": true,
-        "showGraphic": true,
-        "showInfo": true
-      },
-      "mouseInfo": {
-        "enabled": true,
-        "spatialReference": {
-          "wkid": 4326
-        }
-      },
-      "northArrow": {
-        "enabled": false
-      },
-      "basemap": {
-        "enabled": true
-      },
-      "overviewMap": {
-        "enabled": true,
-        "layerType": "imagery"
-      },
-      "scaleBar": {
-        "enabled": true
-      }
-    },
-    "extentSets": [
-      {
-        "id": "EXT_NRCAN_Lambert_3978",
-        "default": {
-          "xmax": 2849492,
-          "xmin": -5281457,
-          "ymax": 4482193,
-          "ymin": -983440
+    "version": "2.0",
+    "language": "fr",
+    "ui": {
+        "title": "Carte interactive",
+        "fullscreen": true,
+        "navBar": {
+            "zoom": "buttons",
+            "extra": ["fullscreen", "geoLocator", "home", "help"]
         },
-        "spatialReference": {
-          "wkid": 3978
-        }
-      },
-      {
-        "id": "EXT_ESRI_World_AuxMerc_3857",
-        "default": {
-          "xmax": -5007771.626060756,
-          "xmin": -16632697.354854,
-          "ymax": 10015875.184845109,
-          "ymin": 5022907.964742964
+        "appBar": {
+            "basemap": true
         },
-        "spatialReference": {
-          "wkid": 102100,
-          "latestWkid": 3857
+        "help": {
+            "folderName": "default"
+        },
+        "sideMenu": {
+            "items": [["fullscreen", "export", "touch", "help", "about"]],
+            "logo": false
+        },
+        "legend": {
+            "allowImport": true,
+            "isOpen": {
+                "large": true,
+                "medium": false,
+                "small": false
+            }
         }
-      }
-    ],
-    "lodSets": [
-      {
-        "id": "LOD_NRCAN_Lambert_3978",
-        "lods": [
-          {
-            "level": 0,
-            "resolution": 38364.660062653464,
-            "scale": 145000000
-          },
-          {
-            "level": 1,
-            "resolution": 22489.628312589961,
-            "scale": 85000000
-          },
-          {
-            "level": 2,
-            "resolution": 13229.193125052918,
-            "scale": 50000000
-          },
-          {
-            "level": 3,
-            "resolution": 7937.5158750317505,
-            "scale": 30000000
-          },
-          {
-            "level": 4,
-            "resolution": 4630.2175937685215,
-            "scale": 17500000
-          },
-          {
-            "level": 5,
-            "resolution": 2645.8386250105837,
-            "scale": 10000000
-          },
-          {
-            "level": 6,
-            "resolution": 1587.5031750063501,
-            "scale": 6000000
-          },
-          {
-            "level": 7,
-            "resolution": 926.04351875370423,
-            "scale": 3500000
-          },
-          {
-            "level": 8,
-            "resolution": 529.16772500211675,
-            "scale": 2000000
-          },
-          {
-            "level": 9,
-            "resolution": 317.50063500127004,
-            "scale": 1200000
-          },
-          {
-            "level": 10,
-            "resolution": 185.20870375074085,
-            "scale": 700000
-          },
-          {
-            "level": 11,
-            "resolution": 111.12522225044451,
-            "scale": 420000
-          },
-          {
-            "level": 12,
-            "resolution": 66.1459656252646,
-            "scale": 250000
-          },
-          {
-            "level": 13,
-            "resolution": 38.364660062653464,
-            "scale": 145000
-          },
-          {
-            "level": 14,
-            "resolution": 22.489628312589961,
-            "scale": 85000
-          },
-          {
-            "level": 15,
-            "resolution": 13.229193125052918,
-            "scale": 50000
-          },
-          {
-            "level": 16,
-            "resolution": 7.9375158750317505,
-            "scale": 30000
-          },
-          {
-            "level": 17,
-            "resolution": 4.6302175937685215,
-            "scale": 17500
-          }
-        ]
-      },
-      {
-        "id": "LOD_ESRI_World_AuxMerc_3857",
-        "lods": [
-          {
-            "level": 0,
-            "resolution": 19567.879240999919,
-            "scale": 73957190.948944
-          },
-          {
-            "level": 1,
-            "resolution": 9783.93962049996,
-            "scale": 36978595.474472
-          },
-          {
-            "level": 2,
-            "resolution": 4891.96981024998,
-            "scale": 18489297.737236
-          },
-          {
-            "level": 3,
-            "resolution": 2445.98490512499,
-            "scale": 9244648.868618
-          },
-          {
-            "level": 4,
-            "resolution": 1222.9924525624949,
-            "scale": 4622324.434309
-          },
-          {
-            "level": 5,
-            "resolution": 611.49622628137968,
-            "scale": 2311162.217155
-          },
-          {
-            "level": 6,
-            "resolution": 305.74811314055756,
-            "scale": 1155581.108577
-          },
-          {
-            "level": 7,
-            "resolution": 152.87405657041106,
-            "scale": 577790.554289
-          },
-          {
-            "level": 8,
-            "resolution": 76.437028285073239,
-            "scale": 288895.277144
-          },
-          {
-            "level": 9,
-            "resolution": 38.21851414253662,
-            "scale": 144447.638572
-          },
-          {
-            "level": 10,
-            "resolution": 19.10925707126831,
-            "scale": 72223.819286
-          },
-          {
-            "level": 11,
-            "resolution": 9.5546285356341549,
-            "scale": 36111.909643
-          },
-          {
-            "level": 12,
-            "resolution": 4.77731426794937,
-            "scale": 18055.954822
-          },
-          {
-            "level": 13,
-            "resolution": 2.3886571339746849,
-            "scale": 9027.977411
-          },
-          {
-            "level": 14,
-            "resolution": 1.1943285668550503,
-            "scale": 4513.988705
-          },
-          {
-            "level": 15,
-            "resolution": 0.59716428355981721,
-            "scale": 2256.994353
-          },
-          {
-            "level": 16,
-            "resolution": 0.29858214164761665,
-            "scale": 1128.497176
-          },
-          {
-            "level": 17,
-            "resolution": 0.14929107082380833,
-            "scale": 564.248588
-          },
-          {
-            "level": 18,
-            "resolution": 0.074645535411904163,
-            "scale": 282.124294
-          },
-          {
-            "level": 19,
-            "resolution": 0.037322767705952081,
-            "scale": 141.062147
-          },
-          {
-            "level": 20,
-            "resolution": 0.018661383852976041,
-            "scale": 70.5310735
-          }
-        ]
-      }
-    ],
-    "legend": {
-      "type": "structured",
-      "root": {
-        "name": "root",
-        "children": [
-          {
-            "layerId": "Nitrates",
-            "description": "Rejets de nitrates par les installations de pâtes et papiers déclarant à l’INRP de 2010 à 2019 (tonnes)",
-            "symbologyExpanded": true
-          },
-          {
-            "layerId": "Phosphorus",
-            "description": "Rejets de phosphore par les installations de pâtes et papiers déclarant à l’INRP de 2010 à 2019 (tonnes)",
-            "symbologyExpanded": true
-          }
-        ]
-      }
     },
-    "layers": [
-      {
-        "id": "Nitrates",
-        "name": "Nitrates",
-        "layerType": "esriFeature",
-        "tolerance": 20,
-        "singleEntryCollapse": true,
-        "symbologyExpanded": true,
-        "url": "https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/StoryRAMP/f6f7baf4_cccb_4521_a037_b4691b0f0d49/MapServer/14",
-        "state": {
-          "opacity": 0.5
+    "services": {
+        "proxyUrl": "http://167.40.64.74/wmsproxy/ws/wmsproxy/executeFromProxy",
+        "exportMapUrl": "https://maps-cartes.dev.ec.gc.ca/arcgis/rest/services/Utilities/PrintingTools/GPServer/Export%20Web%20Map%20Task",
+        "export": {
+            "title": {
+                "value": "Rejets de phosphore et de nitrates par les installations de pâtes et papiers déclarant à l’INRP de 2010 à 2019"
+            },
+            "map": {},
+            "mapElements": {},
+            "legend": {},
+            "footnote": {
+                "value": "Rejets de phosphore et de nitrates par les installations de pâtes et papiers déclarant à l’INRP de 2010 à 2019"
+            }
+        },
+        "search": {
+            "settings": {
+                "categories": [
+                    "CITY",
+                    "HAM",
+                    "IR",
+                    "LTM",
+                    "MUN1",
+                    "MUN2",
+                    "PROV",
+                    "STM",
+                    "TERR",
+                    "TOWN",
+                    "UTM",
+                    "VILG",
+                    "UNP"
+                ],
+                "sortOrder": [
+                    "CITY",
+                    "HAM",
+                    "IR",
+                    "LTM",
+                    "MUN1",
+                    "MUN2",
+                    "PROV",
+                    "STM",
+                    "TERR",
+                    "TOWN",
+                    "UTM",
+                    "VILG",
+                    "UNP"
+                ],
+                "maxResults": 1000,
+                "officialOnly": true
+            },
+            "serviceUrls": {
+                "geoNames": "https://geogratis.gc.ca/services/geoname/fr/geonames.json",
+                "geoLocation": "https://geogratis.gc.ca/services/geolocation/fr/locate?q=",
+                "geoSuggest": "https://geogratis.gc.ca/services/geolocation/fr/suggest?q=",
+                "provinces": "https://geogratis.gc.ca/services/geoname/fr/codes/province.json",
+                "types": "https://geogratis.gc.ca/services/geoname/fr/codes/concise.json"
+            }
         }
-      },
-      {
-        "id": "Phosphorus",
-        "name": "Phosphore",
-        "layerType": "esriFeature",
-        "tolerance": 20,
-        "singleEntryCollapse": true,
-        "symbologyExpanded": true,
-        "url": "https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/StoryRAMP/f6f7baf4_cccb_4521_a037_b4691b0f0d49/MapServer/15",
-        "state": {
-          "opacity": 0.5
-        }
-      }
-    ],
-    "tileSchemas": [
-      {
-        "id": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978",
-        "name": "Lambert Maps",
-        "extentSetId": "EXT_NRCAN_Lambert_3978",
-        "lodSetId": "LOD_NRCAN_Lambert_3978",
-        "hasNorthPole": true
-      },
-      {
-        "id": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857",
-        "name": "Web Mercator Maps",
-        "extentSetId": "EXT_ESRI_World_AuxMerc_3857",
-        "lodSetId": "LOD_ESRI_World_AuxMerc_3857"
-      }
-    ],
-    "baseMaps": [
-      {
-        "id": "baseNrCan",
-        "name": "Carte de base du Canada – transport (CBCT) avec étiquettes",
-        "description": "La carte de base du Canada – transport (CBCT) du Secteur des sciences de la Terre de Ressources naturelles Canada est un service Internet qui s'adresse principalement aux utilisateurs et développeurs d'applications cartographiques en ligne.",
-        "altText": "altText - La carte de base du Canada – transport (CBCT)",
-        "layers": [
-          {
-            "id": "CBCT",
-            "layerType": "esriFeature",
-            "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBCT3978/MapServer"
-          }
+    },
+    "map": {
+        "initialBasemapId": "baseNrCan",
+        "components": {
+            "geoSearch": {
+                "enabled": true,
+                "showGraphic": true,
+                "showInfo": true
+            },
+            "mouseInfo": {
+                "enabled": true,
+                "spatialReference": {
+                    "wkid": 4326
+                }
+            },
+            "northArrow": {
+                "enabled": false
+            },
+            "basemap": {
+                "enabled": true
+            },
+            "overviewMap": {
+                "enabled": true,
+                "layerType": "imagery"
+            },
+            "scaleBar": {
+                "enabled": true
+            }
+        },
+        "extentSets": [
+            {
+                "id": "EXT_NRCAN_Lambert_3978",
+                "default": {
+                    "xmax": 2249492,
+                    "xmin": -5881457,
+                    "ymax": 4482193,
+                    "ymin": -983440
+                },
+                "spatialReference": {
+                    "wkid": 3978
+                }
+            },
+            {
+                "id": "EXT_ESRI_World_AuxMerc_3857",
+                "default": {
+                    "xmax": -5007771.626060756,
+                    "xmin": -16632697.354854,
+                    "ymax": 10015875.184845109,
+                    "ymin": 5022907.964742964
+                },
+                "spatialReference": {
+                    "wkid": 102100,
+                    "latestWkid": 3857
+                }
+            }
         ],
-        "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
-      },
-      {
-        "id": "baseSimple",
-        "name": "Carte de base du Canada - simple",
-        "description": "La carte de base du Canada - simple",
-        "altText": "altText - La carte de base du Canada - simple",
-        "layers": [
-          {
-            "id": "SMR",
-            "layerType": "esriFeature",
-            "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer"
-          },
-          {
-            "id": "SMW",
-            "layerType": "esriFeature",
-            "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_TXT_3978/MapServer"
-          }
+        "lodSets": [
+            {
+                "id": "LOD_NRCAN_Lambert_3978",
+                "lods": [
+                    {
+                        "level": 0,
+                        "resolution": 38364.660062653464,
+                        "scale": 145000000
+                    },
+                    {
+                        "level": 1,
+                        "resolution": 22489.628312589961,
+                        "scale": 85000000
+                    },
+                    {
+                        "level": 2,
+                        "resolution": 13229.193125052918,
+                        "scale": 50000000
+                    },
+                    {
+                        "level": 3,
+                        "resolution": 7937.5158750317505,
+                        "scale": 30000000
+                    },
+                    {
+                        "level": 4,
+                        "resolution": 4630.2175937685215,
+                        "scale": 17500000
+                    },
+                    {
+                        "level": 5,
+                        "resolution": 2645.8386250105837,
+                        "scale": 10000000
+                    },
+                    {
+                        "level": 6,
+                        "resolution": 1587.5031750063501,
+                        "scale": 6000000
+                    },
+                    {
+                        "level": 7,
+                        "resolution": 926.04351875370423,
+                        "scale": 3500000
+                    },
+                    {
+                        "level": 8,
+                        "resolution": 529.16772500211675,
+                        "scale": 2000000
+                    },
+                    {
+                        "level": 9,
+                        "resolution": 317.50063500127004,
+                        "scale": 1200000
+                    },
+                    {
+                        "level": 10,
+                        "resolution": 185.20870375074085,
+                        "scale": 700000
+                    },
+                    {
+                        "level": 11,
+                        "resolution": 111.12522225044451,
+                        "scale": 420000
+                    },
+                    {
+                        "level": 12,
+                        "resolution": 66.1459656252646,
+                        "scale": 250000
+                    },
+                    {
+                        "level": 13,
+                        "resolution": 38.364660062653464,
+                        "scale": 145000
+                    },
+                    {
+                        "level": 14,
+                        "resolution": 22.489628312589961,
+                        "scale": 85000
+                    },
+                    {
+                        "level": 15,
+                        "resolution": 13.229193125052918,
+                        "scale": 50000
+                    },
+                    {
+                        "level": 16,
+                        "resolution": 7.9375158750317505,
+                        "scale": 30000
+                    },
+                    {
+                        "level": 17,
+                        "resolution": 4.6302175937685215,
+                        "scale": 17500
+                    }
+                ]
+            },
+            {
+                "id": "LOD_ESRI_World_AuxMerc_3857",
+                "lods": [
+                    {
+                        "level": 0,
+                        "resolution": 19567.879240999919,
+                        "scale": 73957190.948944
+                    },
+                    {
+                        "level": 1,
+                        "resolution": 9783.93962049996,
+                        "scale": 36978595.474472
+                    },
+                    {
+                        "level": 2,
+                        "resolution": 4891.96981024998,
+                        "scale": 18489297.737236
+                    },
+                    {
+                        "level": 3,
+                        "resolution": 2445.98490512499,
+                        "scale": 9244648.868618
+                    },
+                    {
+                        "level": 4,
+                        "resolution": 1222.9924525624949,
+                        "scale": 4622324.434309
+                    },
+                    {
+                        "level": 5,
+                        "resolution": 611.49622628137968,
+                        "scale": 2311162.217155
+                    },
+                    {
+                        "level": 6,
+                        "resolution": 305.74811314055756,
+                        "scale": 1155581.108577
+                    },
+                    {
+                        "level": 7,
+                        "resolution": 152.87405657041106,
+                        "scale": 577790.554289
+                    },
+                    {
+                        "level": 8,
+                        "resolution": 76.437028285073239,
+                        "scale": 288895.277144
+                    },
+                    {
+                        "level": 9,
+                        "resolution": 38.21851414253662,
+                        "scale": 144447.638572
+                    },
+                    {
+                        "level": 10,
+                        "resolution": 19.10925707126831,
+                        "scale": 72223.819286
+                    },
+                    {
+                        "level": 11,
+                        "resolution": 9.5546285356341549,
+                        "scale": 36111.909643
+                    },
+                    {
+                        "level": 12,
+                        "resolution": 4.77731426794937,
+                        "scale": 18055.954822
+                    },
+                    {
+                        "level": 13,
+                        "resolution": 2.3886571339746849,
+                        "scale": 9027.977411
+                    },
+                    {
+                        "level": 14,
+                        "resolution": 1.1943285668550503,
+                        "scale": 4513.988705
+                    },
+                    {
+                        "level": 15,
+                        "resolution": 0.59716428355981721,
+                        "scale": 2256.994353
+                    },
+                    {
+                        "level": 16,
+                        "resolution": 0.29858214164761665,
+                        "scale": 1128.497176
+                    },
+                    {
+                        "level": 17,
+                        "resolution": 0.14929107082380833,
+                        "scale": 564.248588
+                    },
+                    {
+                        "level": 18,
+                        "resolution": 0.074645535411904163,
+                        "scale": 282.124294
+                    },
+                    {
+                        "level": 19,
+                        "resolution": 0.037322767705952081,
+                        "scale": 141.062147
+                    },
+                    {
+                        "level": 20,
+                        "resolution": 0.018661383852976041,
+                        "scale": 70.5310735
+                    }
+                ]
+            }
         ],
-        "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
-      },
-      {
-        "id": "baseCBME_CBCE_HS_RO_3978",
-        "name": "Carte de base du Canada - élevation (CBCE)",
-        "description": "La carte de base du Canada - élevation (CBCE) du Secteur des sciences de la Terre de Ressources naturelles Canada est un service Internet qui s'adresse principalement aux utilisateurs et développeurs d'applications cartographiques en ligne.",
-        "altText": "altText - La carte de base du Canada - élevation (CBCE)",
+        "legend": {
+            "type": "structured",
+            "root": {
+                "name": "root",
+                "children": [
+                    {
+                        "layerId": "Nitrates",
+                        "description": "Rejets de nitrates par les installations de pâtes et papiers déclarant à l’INRP de 2010 à 2019 (tonnes)",
+                        "symbologyExpanded": true
+                    },
+                    {
+                        "layerId": "Phosphorus",
+                        "description": "Rejets de phosphore par les installations de pâtes et papiers déclarant à l’INRP de 2010 à 2019 (tonnes)",
+                        "symbologyExpanded": true
+                    }
+                ]
+            }
+        },
         "layers": [
-          {
-            "id": "CBME_CBCE_HS_RO_3978",
-            "layerType": "esriFeature",
-            "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer"
-          }
+            {
+                "id": "Nitrates",
+                "name": "Nitrates",
+                "layerType": "esriFeature",
+                "tolerance": 20,
+                "singleEntryCollapse": true,
+                "symbologyExpanded": true,
+                "url": "https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/StoryRAMP/f6f7baf4_cccb_4521_a037_b4691b0f0d49/MapServer/14",
+                "state": {
+                    "opacity": 0.5
+                }
+            },
+            {
+                "id": "Phosphorus",
+                "name": "Phosphore",
+                "layerType": "esriFeature",
+                "tolerance": 20,
+                "singleEntryCollapse": true,
+                "symbologyExpanded": true,
+                "url": "https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/StoryRAMP/f6f7baf4_cccb_4521_a037_b4691b0f0d49/MapServer/15",
+                "state": {
+                    "opacity": 0.5
+                }
+            }
         ],
-        "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
-      },
-      {
-        "id": "baseCBMT_CBCT_GEOM_3978",
-        "name": "Carte de base du Canada - transport (CBCT)",
-        "description": "La carte de base du Canada - transport (CBCT) du Secteur des sciences de la Terre de Ressources naturelles Canada est un service Internet qui s'adresse principalement aux utilisateurs et développeurs d'applications cartographiques en ligne.",
-        "altText": "altText - La carte de base du Canada - transport (CBCT)",
-        "layers": [
-          {
-            "id": "CBMT_CBCT_GEOM_3978",
-            "layerType": "esriFeature",
-            "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer"
-          }
+        "tileSchemas": [
+            {
+                "id": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978",
+                "name": "Lambert Maps",
+                "extentSetId": "EXT_NRCAN_Lambert_3978",
+                "lodSetId": "LOD_NRCAN_Lambert_3978",
+                "hasNorthPole": true
+            },
+            {
+                "id": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857",
+                "name": "Web Mercator Maps",
+                "extentSetId": "EXT_ESRI_World_AuxMerc_3857",
+                "lodSetId": "LOD_ESRI_World_AuxMerc_3857"
+            }
         ],
-        "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
-      },
-      {
-        "id": "baseEsriWorld",
-        "name": "Imagerie mondiale",
-        "description": "L'imagerie mondiale fournit une imagerie satellitaire et aérienne dans de nombreuses régions du monde avec une résolution de 1 mètres et moins et des images satellitaires de résolution inférieure dans le monde entier.",
-        "altText": "altText - L'imagerie mondiale",
-        "layers": [
-          {
-            "id": "World_Imagery",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      },
-      {
-        "id": "baseEsriPhysical",
-        "name": "Monde physique",
-        "description": "La carte du monde physique représente l'aspect physique naturel de la Terre à 1.24 kilomètres par pixel pour le monde et à 500 mètres pour les États-Unis.",
-        "altText": "altText - La carte du monde physique",
-        "layers": [
-          {
-            "id": "World_Physical_Map",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Physical_Map/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      },
-      {
-        "id": "baseEsriRelief",
-        "name": "Monde en relief ombragé",
-        "description": "La carte du monde en relief ombragé représente l'élévation de la surface de la terre comme un relief ombragé. Cette carte est utilisée comme couche de fond afin d'ajouter un relief ombragé à d'autres cartes SIG, comme la carte ArcGIS Online World Street Map.",
-        "altText": "altText - La carte du monde en relief ombragé",
-        "layers": [
-          {
-            "id": "World_Shaded_Relief",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Shaded_Relief/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      },
-      {
-        "id": "baseEsriStreet",
-        "name": "Monde routier",
-        "description": "La carte du monde routier présente des données au niveau des autoroutes pour le monde.",
-        "altText": "altText - La carte du monde routier",
-        "layers": [
-          {
-            "id": "World_Street_Map",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Street_Map/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      },
-      {
-        "id": "baseEsriTerrain",
-        "name": "Monde terrain",
-        "description": "La carte du monde terrain est conçue pour être utilisée comme une carte de base par les professionnels du SIG pour superposer d'autres couches thématiques comme la démographie ou la couverture terrestre.",
-        "altText": "altText - La carte du monde terrain",
-        "layers": [
-          {
-            "id": "World_Terrain_Base",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Terrain_Base/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      },
-      {
-        "id": "baseEsriTopo",
-        "name": "Monde topographique",
-        "description": "La carte du monde topographique est conçue pour être utilisé comme une carte de base par les professionnels du SIG et comme une carte de référence par quiconque.",
-        "altText": "altText - La carte du monde topographique",
-        "layers": [
-          {
-            "id": "World_Topo_Map",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      }
-    ]
-  }
+        "baseMaps": [
+            {
+                "id": "baseNrCan",
+                "name": "Carte de base du Canada – transport (CBCT) avec étiquettes",
+                "description": "La carte de base du Canada – transport (CBCT) du Secteur des sciences de la Terre de Ressources naturelles Canada est un service Internet qui s'adresse principalement aux utilisateurs et développeurs d'applications cartographiques en ligne.",
+                "altText": "altText - La carte de base du Canada – transport (CBCT)",
+                "layers": [
+                    {
+                        "id": "CBCT",
+                        "layerType": "esriFeature",
+                        "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBCT3978/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+            },
+            {
+                "id": "baseSimple",
+                "name": "Carte de base du Canada - simple",
+                "description": "La carte de base du Canada - simple",
+                "altText": "altText - La carte de base du Canada - simple",
+                "layers": [
+                    {
+                        "id": "SMR",
+                        "layerType": "esriFeature",
+                        "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer"
+                    },
+                    {
+                        "id": "SMW",
+                        "layerType": "esriFeature",
+                        "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_TXT_3978/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+            },
+            {
+                "id": "baseCBME_CBCE_HS_RO_3978",
+                "name": "Carte de base du Canada - élevation (CBCE)",
+                "description": "La carte de base du Canada - élevation (CBCE) du Secteur des sciences de la Terre de Ressources naturelles Canada est un service Internet qui s'adresse principalement aux utilisateurs et développeurs d'applications cartographiques en ligne.",
+                "altText": "altText - La carte de base du Canada - élevation (CBCE)",
+                "layers": [
+                    {
+                        "id": "CBME_CBCE_HS_RO_3978",
+                        "layerType": "esriFeature",
+                        "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+            },
+            {
+                "id": "baseCBMT_CBCT_GEOM_3978",
+                "name": "Carte de base du Canada - transport (CBCT)",
+                "description": "La carte de base du Canada - transport (CBCT) du Secteur des sciences de la Terre de Ressources naturelles Canada est un service Internet qui s'adresse principalement aux utilisateurs et développeurs d'applications cartographiques en ligne.",
+                "altText": "altText - La carte de base du Canada - transport (CBCT)",
+                "layers": [
+                    {
+                        "id": "CBMT_CBCT_GEOM_3978",
+                        "layerType": "esriFeature",
+                        "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+            },
+            {
+                "id": "baseEsriWorld",
+                "name": "Imagerie mondiale",
+                "description": "L'imagerie mondiale fournit une imagerie satellitaire et aérienne dans de nombreuses régions du monde avec une résolution de 1 mètres et moins et des images satellitaires de résolution inférieure dans le monde entier.",
+                "altText": "altText - L'imagerie mondiale",
+                "layers": [
+                    {
+                        "id": "World_Imagery",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriPhysical",
+                "name": "Monde physique",
+                "description": "La carte du monde physique représente l'aspect physique naturel de la Terre à 1.24 kilomètres par pixel pour le monde et à 500 mètres pour les États-Unis.",
+                "altText": "altText - La carte du monde physique",
+                "layers": [
+                    {
+                        "id": "World_Physical_Map",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Physical_Map/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriRelief",
+                "name": "Monde en relief ombragé",
+                "description": "La carte du monde en relief ombragé représente l'élévation de la surface de la terre comme un relief ombragé. Cette carte est utilisée comme couche de fond afin d'ajouter un relief ombragé à d'autres cartes SIG, comme la carte ArcGIS Online World Street Map.",
+                "altText": "altText - La carte du monde en relief ombragé",
+                "layers": [
+                    {
+                        "id": "World_Shaded_Relief",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Shaded_Relief/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriStreet",
+                "name": "Monde routier",
+                "description": "La carte du monde routier présente des données au niveau des autoroutes pour le monde.",
+                "altText": "altText - La carte du monde routier",
+                "layers": [
+                    {
+                        "id": "World_Street_Map",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Street_Map/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriTerrain",
+                "name": "Monde terrain",
+                "description": "La carte du monde terrain est conçue pour être utilisée comme une carte de base par les professionnels du SIG pour superposer d'autres couches thématiques comme la démographie ou la couverture terrestre.",
+                "altText": "altText - La carte du monde terrain",
+                "layers": [
+                    {
+                        "id": "World_Terrain_Base",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Terrain_Base/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriTopo",
+                "name": "Monde topographique",
+                "description": "La carte du monde topographique est conçue pour être utilisé comme une carte de base par les professionnels du SIG et comme une carte de référence par quiconque.",
+                "altText": "altText - La carte du monde topographique",
+                "layers": [
+                    {
+                        "id": "World_Topo_Map",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            }
+        ]
+    }
 }

--- a/public/f6f7baf4-cccb-4521-a037-b4691b0f0d49/ramp-config/fr/pollution_prevention_activities.json
+++ b/public/f6f7baf4-cccb-4521-a037-b4691b0f0d49/ramp-config/fr/pollution_prevention_activities.json
@@ -1,512 +1,539 @@
 {
-  "version": "2.0",
-  "language": "fr",
-  "ui": {
-    "title": "Carte interactive",
-    "fullscreen": true,
-    "navBar": {
-      "zoom": "buttons",
-      "extra": [ "fullscreen", "geoLocator", "home", "help" ]
-    },
-    "appBar": {
-      "basemap": true
-
-    },
-    "help": {
-      "folderName": "default"
-    },
-    "sideMenu": {
-      "items": [ [ "fullscreen", "export", "touch", "help", "about" ] ],
-      "logo": false
-    },
-    "legend": {
-      "allowImport": true,
-      "isOpen": {
-        "large": true,
-        "medium": false,
-        "small": false
-      }
-    }
-  },
-  "services": {
-    "proxyUrl": "http://167.40.64.74/wmsproxy/ws/wmsproxy/executeFromProxy",
-    "exportMapUrl": "https://maps-cartes.dev.ec.gc.ca/arcgis/rest/services/Utilities/PrintingTools/GPServer/Export%20Web%20Map%20Task",
-    "export": {
-      "title": {
-        "value": "Activités de prévention de la pollution par les installations de pâtes et papiers déclarant à l’INRP en 2019"
-      },
-      "map": {},
-      "mapElements": {},
-      "legend": {},
-      "footnote": {
-        "value": "Activités de prévention de la pollution par les installations de pâtes et papiers déclarant à l’INRP en 2019"
-      }
-    },
-    "search": {
-      "settings": {
-        "categories": [ "CITY", "HAM", "IR", "LTM", "MUN1", "MUN2", "PROV", "STM", "TERR", "TOWN", "UTM", "VILG", "UNP" ],
-        "sortOrder": [ "CITY", "HAM", "IR", "LTM", "MUN1", "MUN2", "PROV", "STM", "TERR", "TOWN", "UTM", "VILG", "UNP" ],
-        "maxResults": 1000,
-        "officialOnly": true
-      },	
-      "serviceUrls": {
-        "geoNames": "https://geogratis.gc.ca/services/geoname/en/geonames.json",
-        "geoLocation": "https://geogratis.gc.ca/services/geolocation/en/locate?q=",
-        "geoSuggest": "https://geogratis.gc.ca/services/geolocation/en/suggest?q=",
-        "provinces": "https://geogratis.gc.ca/services/geoname/en/codes/province.json",
-        "types": "https://geogratis.gc.ca/services/geoname/en/codes/concise.json"
-      }
-    }
-  },
-  "map": {
-    "initialBasemapId": "baseNrCan",
-    "components": {
-      "geoSearch": {
-        "enabled": true,
-        "showGraphic": true,
-        "showInfo": true
-      },
-      "mouseInfo": {
-        "enabled": true,
-        "spatialReference": {
-          "wkid": 4326
-        }
-      },
-      "northArrow": {
-        "enabled": false
-      },
-      "basemap": {
-        "enabled": true
-      },
-      "overviewMap": {
-        "enabled": true,
-        "layerType": "imagery"
-      },
-      "scaleBar": {
-        "enabled": true
-      }
-    },
-    "extentSets": [
-      {
-        "id": "EXT_NRCAN_Lambert_3978",
-        "default": {
-          "xmax": 2849492,
-          "xmin": -5281457,
-          "ymax": 4482193,
-          "ymin": -983440
+    "version": "2.0",
+    "language": "fr",
+    "ui": {
+        "title": "Carte interactive",
+        "fullscreen": true,
+        "navBar": {
+            "zoom": "buttons",
+            "extra": ["fullscreen", "geoLocator", "home", "help"]
         },
-        "spatialReference": {
-          "wkid": 3978
-        }
-      },
-      {
-        "id": "EXT_ESRI_World_AuxMerc_3857",
-        "default": {
-          "xmax": -5007771.626060756,
-          "xmin": -16632697.354854,
-          "ymax": 10015875.184845109,
-          "ymin": 5022907.964742964
+        "appBar": {
+            "basemap": true
         },
-        "spatialReference": {
-          "wkid": 102100,
-          "latestWkid": 3857
+        "help": {
+            "folderName": "default"
+        },
+        "sideMenu": {
+            "items": [["fullscreen", "export", "touch", "help", "about"]],
+            "logo": false
+        },
+        "legend": {
+            "allowImport": true,
+            "isOpen": {
+                "large": true,
+                "medium": false,
+                "small": false
+            }
         }
-      }
-    ],
-    "lodSets": [
-      {
-        "id": "LOD_NRCAN_Lambert_3978",
-        "lods": [
-          {
-            "level": 0,
-            "resolution": 38364.660062653464,
-            "scale": 145000000
-          },
-          {
-            "level": 1,
-            "resolution": 22489.628312589961,
-            "scale": 85000000
-          },
-          {
-            "level": 2,
-            "resolution": 13229.193125052918,
-            "scale": 50000000
-          },
-          {
-            "level": 3,
-            "resolution": 7937.5158750317505,
-            "scale": 30000000
-          },
-          {
-            "level": 4,
-            "resolution": 4630.2175937685215,
-            "scale": 17500000
-          },
-          {
-            "level": 5,
-            "resolution": 2645.8386250105837,
-            "scale": 10000000
-          },
-          {
-            "level": 6,
-            "resolution": 1587.5031750063501,
-            "scale": 6000000
-          },
-          {
-            "level": 7,
-            "resolution": 926.04351875370423,
-            "scale": 3500000
-          },
-          {
-            "level": 8,
-            "resolution": 529.16772500211675,
-            "scale": 2000000
-          },
-          {
-            "level": 9,
-            "resolution": 317.50063500127004,
-            "scale": 1200000
-          },
-          {
-            "level": 10,
-            "resolution": 185.20870375074085,
-            "scale": 700000
-          },
-          {
-            "level": 11,
-            "resolution": 111.12522225044451,
-            "scale": 420000
-          },
-          {
-            "level": 12,
-            "resolution": 66.1459656252646,
-            "scale": 250000
-          },
-          {
-            "level": 13,
-            "resolution": 38.364660062653464,
-            "scale": 145000
-          },
-          {
-            "level": 14,
-            "resolution": 22.489628312589961,
-            "scale": 85000
-          },
-          {
-            "level": 15,
-            "resolution": 13.229193125052918,
-            "scale": 50000
-          },
-          {
-            "level": 16,
-            "resolution": 7.9375158750317505,
-            "scale": 30000
-          },
-          {
-            "level": 17,
-            "resolution": 4.6302175937685215,
-            "scale": 17500
-          }
-        ]
-      },
-      {
-        "id": "LOD_ESRI_World_AuxMerc_3857",
-        "lods": [
-          {
-            "level": 0,
-            "resolution": 19567.879240999919,
-            "scale": 73957190.948944
-          },
-          {
-            "level": 1,
-            "resolution": 9783.93962049996,
-            "scale": 36978595.474472
-          },
-          {
-            "level": 2,
-            "resolution": 4891.96981024998,
-            "scale": 18489297.737236
-          },
-          {
-            "level": 3,
-            "resolution": 2445.98490512499,
-            "scale": 9244648.868618
-          },
-          {
-            "level": 4,
-            "resolution": 1222.9924525624949,
-            "scale": 4622324.434309
-          },
-          {
-            "level": 5,
-            "resolution": 611.49622628137968,
-            "scale": 2311162.217155
-          },
-          {
-            "level": 6,
-            "resolution": 305.74811314055756,
-            "scale": 1155581.108577
-          },
-          {
-            "level": 7,
-            "resolution": 152.87405657041106,
-            "scale": 577790.554289
-          },
-          {
-            "level": 8,
-            "resolution": 76.437028285073239,
-            "scale": 288895.277144
-          },
-          {
-            "level": 9,
-            "resolution": 38.21851414253662,
-            "scale": 144447.638572
-          },
-          {
-            "level": 10,
-            "resolution": 19.10925707126831,
-            "scale": 72223.819286
-          },
-          {
-            "level": 11,
-            "resolution": 9.5546285356341549,
-            "scale": 36111.909643
-          },
-          {
-            "level": 12,
-            "resolution": 4.77731426794937,
-            "scale": 18055.954822
-          },
-          {
-            "level": 13,
-            "resolution": 2.3886571339746849,
-            "scale": 9027.977411
-          },
-          {
-            "level": 14,
-            "resolution": 1.1943285668550503,
-            "scale": 4513.988705
-          },
-          {
-            "level": 15,
-            "resolution": 0.59716428355981721,
-            "scale": 2256.994353
-          },
-          {
-            "level": 16,
-            "resolution": 0.29858214164761665,
-            "scale": 1128.497176
-          },
-          {
-            "level": 17,
-            "resolution": 0.14929107082380833,
-            "scale": 564.248588
-          },
-          {
-            "level": 18,
-            "resolution": 0.074645535411904163,
-            "scale": 282.124294
-          },
-          {
-            "level": 19,
-            "resolution": 0.037322767705952081,
-            "scale": 141.062147
-          },
-          {
-            "level": 20,
-            "resolution": 0.018661383852976041,
-            "scale": 70.5310735
-          }
-        ]
-      }
-    ],
-    "legend": {
-      "type": "structured",
-      "root": {
-          "name": "root",
-          "children": [
+    },
+    "services": {
+        "proxyUrl": "http://167.40.64.74/wmsproxy/ws/wmsproxy/executeFromProxy",
+        "exportMapUrl": "https://maps-cartes.dev.ec.gc.ca/arcgis/rest/services/Utilities/PrintingTools/GPServer/Export%20Web%20Map%20Task",
+        "export": {
+            "title": {
+                "value": "Activités de prévention de la pollution par les installations de pâtes et papiers déclarant à l’INRP en 2019"
+            },
+            "map": {},
+            "mapElements": {},
+            "legend": {},
+            "footnote": {
+                "value": "Activités de prévention de la pollution par les installations de pâtes et papiers déclarant à l’INRP en 2019"
+            }
+        },
+        "search": {
+            "settings": {
+                "categories": [
+                    "CITY",
+                    "HAM",
+                    "IR",
+                    "LTM",
+                    "MUN1",
+                    "MUN2",
+                    "PROV",
+                    "STM",
+                    "TERR",
+                    "TOWN",
+                    "UTM",
+                    "VILG",
+                    "UNP"
+                ],
+                "sortOrder": [
+                    "CITY",
+                    "HAM",
+                    "IR",
+                    "LTM",
+                    "MUN1",
+                    "MUN2",
+                    "PROV",
+                    "STM",
+                    "TERR",
+                    "TOWN",
+                    "UTM",
+                    "VILG",
+                    "UNP"
+                ],
+                "maxResults": 1000,
+                "officialOnly": true
+            },
+            "serviceUrls": {
+                "geoNames": "https://geogratis.gc.ca/services/geoname/en/geonames.json",
+                "geoLocation": "https://geogratis.gc.ca/services/geolocation/en/locate?q=",
+                "geoSuggest": "https://geogratis.gc.ca/services/geolocation/en/suggest?q=",
+                "provinces": "https://geogratis.gc.ca/services/geoname/en/codes/province.json",
+                "types": "https://geogratis.gc.ca/services/geoname/en/codes/concise.json"
+            }
+        }
+    },
+    "map": {
+        "initialBasemapId": "baseNrCan",
+        "components": {
+            "geoSearch": {
+                "enabled": true,
+                "showGraphic": true,
+                "showInfo": true
+            },
+            "mouseInfo": {
+                "enabled": true,
+                "spatialReference": {
+                    "wkid": 4326
+                }
+            },
+            "northArrow": {
+                "enabled": false
+            },
+            "basemap": {
+                "enabled": true
+            },
+            "overviewMap": {
+                "enabled": true,
+                "layerType": "imagery"
+            },
+            "scaleBar": {
+                "enabled": true
+            }
+        },
+        "extentSets": [
             {
-                "layerId": "PPA",
-                "description": "Activités de prévention de la pollution par les installations de pâtes et papiers déclarant à l’INRP en 2019",                
-                "symbologyExpanded": true
+                "id": "EXT_NRCAN_Lambert_3978",
+                "default": {
+                    "xmax": 2249492,
+                    "xmin": -5881457,
+                    "ymax": 4482193,
+                    "ymin": -983440
+                },
+                "spatialReference": {
+                    "wkid": 3978
+                }
+            },
+            {
+                "id": "EXT_ESRI_World_AuxMerc_3857",
+                "default": {
+                    "xmax": -5007771.626060756,
+                    "xmin": -16632697.354854,
+                    "ymax": 10015875.184845109,
+                    "ymin": 5022907.964742964
+                },
+                "spatialReference": {
+                    "wkid": 102100,
+                    "latestWkid": 3857
+                }
+            }
+        ],
+        "lodSets": [
+            {
+                "id": "LOD_NRCAN_Lambert_3978",
+                "lods": [
+                    {
+                        "level": 0,
+                        "resolution": 38364.660062653464,
+                        "scale": 145000000
+                    },
+                    {
+                        "level": 1,
+                        "resolution": 22489.628312589961,
+                        "scale": 85000000
+                    },
+                    {
+                        "level": 2,
+                        "resolution": 13229.193125052918,
+                        "scale": 50000000
+                    },
+                    {
+                        "level": 3,
+                        "resolution": 7937.5158750317505,
+                        "scale": 30000000
+                    },
+                    {
+                        "level": 4,
+                        "resolution": 4630.2175937685215,
+                        "scale": 17500000
+                    },
+                    {
+                        "level": 5,
+                        "resolution": 2645.8386250105837,
+                        "scale": 10000000
+                    },
+                    {
+                        "level": 6,
+                        "resolution": 1587.5031750063501,
+                        "scale": 6000000
+                    },
+                    {
+                        "level": 7,
+                        "resolution": 926.04351875370423,
+                        "scale": 3500000
+                    },
+                    {
+                        "level": 8,
+                        "resolution": 529.16772500211675,
+                        "scale": 2000000
+                    },
+                    {
+                        "level": 9,
+                        "resolution": 317.50063500127004,
+                        "scale": 1200000
+                    },
+                    {
+                        "level": 10,
+                        "resolution": 185.20870375074085,
+                        "scale": 700000
+                    },
+                    {
+                        "level": 11,
+                        "resolution": 111.12522225044451,
+                        "scale": 420000
+                    },
+                    {
+                        "level": 12,
+                        "resolution": 66.1459656252646,
+                        "scale": 250000
+                    },
+                    {
+                        "level": 13,
+                        "resolution": 38.364660062653464,
+                        "scale": 145000
+                    },
+                    {
+                        "level": 14,
+                        "resolution": 22.489628312589961,
+                        "scale": 85000
+                    },
+                    {
+                        "level": 15,
+                        "resolution": 13.229193125052918,
+                        "scale": 50000
+                    },
+                    {
+                        "level": 16,
+                        "resolution": 7.9375158750317505,
+                        "scale": 30000
+                    },
+                    {
+                        "level": 17,
+                        "resolution": 4.6302175937685215,
+                        "scale": 17500
+                    }
+                ]
+            },
+            {
+                "id": "LOD_ESRI_World_AuxMerc_3857",
+                "lods": [
+                    {
+                        "level": 0,
+                        "resolution": 19567.879240999919,
+                        "scale": 73957190.948944
+                    },
+                    {
+                        "level": 1,
+                        "resolution": 9783.93962049996,
+                        "scale": 36978595.474472
+                    },
+                    {
+                        "level": 2,
+                        "resolution": 4891.96981024998,
+                        "scale": 18489297.737236
+                    },
+                    {
+                        "level": 3,
+                        "resolution": 2445.98490512499,
+                        "scale": 9244648.868618
+                    },
+                    {
+                        "level": 4,
+                        "resolution": 1222.9924525624949,
+                        "scale": 4622324.434309
+                    },
+                    {
+                        "level": 5,
+                        "resolution": 611.49622628137968,
+                        "scale": 2311162.217155
+                    },
+                    {
+                        "level": 6,
+                        "resolution": 305.74811314055756,
+                        "scale": 1155581.108577
+                    },
+                    {
+                        "level": 7,
+                        "resolution": 152.87405657041106,
+                        "scale": 577790.554289
+                    },
+                    {
+                        "level": 8,
+                        "resolution": 76.437028285073239,
+                        "scale": 288895.277144
+                    },
+                    {
+                        "level": 9,
+                        "resolution": 38.21851414253662,
+                        "scale": 144447.638572
+                    },
+                    {
+                        "level": 10,
+                        "resolution": 19.10925707126831,
+                        "scale": 72223.819286
+                    },
+                    {
+                        "level": 11,
+                        "resolution": 9.5546285356341549,
+                        "scale": 36111.909643
+                    },
+                    {
+                        "level": 12,
+                        "resolution": 4.77731426794937,
+                        "scale": 18055.954822
+                    },
+                    {
+                        "level": 13,
+                        "resolution": 2.3886571339746849,
+                        "scale": 9027.977411
+                    },
+                    {
+                        "level": 14,
+                        "resolution": 1.1943285668550503,
+                        "scale": 4513.988705
+                    },
+                    {
+                        "level": 15,
+                        "resolution": 0.59716428355981721,
+                        "scale": 2256.994353
+                    },
+                    {
+                        "level": 16,
+                        "resolution": 0.29858214164761665,
+                        "scale": 1128.497176
+                    },
+                    {
+                        "level": 17,
+                        "resolution": 0.14929107082380833,
+                        "scale": 564.248588
+                    },
+                    {
+                        "level": 18,
+                        "resolution": 0.074645535411904163,
+                        "scale": 282.124294
+                    },
+                    {
+                        "level": 19,
+                        "resolution": 0.037322767705952081,
+                        "scale": 141.062147
+                    },
+                    {
+                        "level": 20,
+                        "resolution": 0.018661383852976041,
+                        "scale": 70.5310735
+                    }
+                ]
+            }
+        ],
+        "legend": {
+            "type": "structured",
+            "root": {
+                "name": "root",
+                "children": [
+                    {
+                        "layerId": "PPA",
+                        "description": "Activités de prévention de la pollution par les installations de pâtes et papiers déclarant à l’INRP en 2019",
+                        "symbologyExpanded": true
+                    }
+                ]
+            }
+        },
+        "layers": [
+            {
+                "id": "PPA",
+                "name": "Activités de prévention de la pollution",
+                "layerType": "esriFeature",
+                "singleEntryCollapse": true,
+                "symbologyExpanded": true,
+                "url": "https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/StoryRAMP/f6f7baf4_cccb_4521_a037_b4691b0f0d49/MapServer/17",
+                "state": {
+                    "opacity": 0.75
+                }
+            }
+        ],
+        "tileSchemas": [
+            {
+                "id": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978",
+                "name": "Lambert Maps",
+                "extentSetId": "EXT_NRCAN_Lambert_3978",
+                "lodSetId": "LOD_NRCAN_Lambert_3978",
+                "hasNorthPole": true
+            },
+            {
+                "id": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857",
+                "name": "Web Mercator Maps",
+                "extentSetId": "EXT_ESRI_World_AuxMerc_3857",
+                "lodSetId": "LOD_ESRI_World_AuxMerc_3857"
+            }
+        ],
+        "baseMaps": [
+            {
+                "id": "baseNrCan",
+                "name": "Carte de base du Canada – transport (CBCT) avec étiquettes",
+                "description": "La carte de base du Canada – transport (CBCT) du Secteur des sciences de la Terre de Ressources naturelles Canada est un service Internet qui s'adresse principalement aux utilisateurs et développeurs d'applications cartographiques en ligne.",
+                "altText": "altText - La carte de base du Canada – transport (CBCT)",
+                "layers": [
+                    {
+                        "id": "CBCT",
+                        "layerType": "esriFeature",
+                        "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBCT3978/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+            },
+            {
+                "id": "baseSimple",
+                "name": "Carte de base du Canada - simple",
+                "description": "La carte de base du Canada - simple",
+                "altText": "altText - La carte de base du Canada - simple",
+                "layers": [
+                    {
+                        "id": "SMR",
+                        "layerType": "esriFeature",
+                        "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer"
+                    },
+                    {
+                        "id": "SMW",
+                        "layerType": "esriFeature",
+                        "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_TXT_3978/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+            },
+            {
+                "id": "baseCBME_CBCE_HS_RO_3978",
+                "name": "Carte de base du Canada - élevation (CBCE)",
+                "description": "La carte de base du Canada - élevation (CBCE) du Secteur des sciences de la Terre de Ressources naturelles Canada est un service Internet qui s'adresse principalement aux utilisateurs et développeurs d'applications cartographiques en ligne.",
+                "altText": "altText - La carte de base du Canada - élevation (CBCE)",
+                "layers": [
+                    {
+                        "id": "CBME_CBCE_HS_RO_3978",
+                        "layerType": "esriFeature",
+                        "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+            },
+            {
+                "id": "baseCBMT_CBCT_GEOM_3978",
+                "name": "Carte de base du Canada - transport (CBCT)",
+                "description": "La carte de base du Canada - transport (CBCT) du Secteur des sciences de la Terre de Ressources naturelles Canada est un service Internet qui s'adresse principalement aux utilisateurs et développeurs d'applications cartographiques en ligne.",
+                "altText": "altText - La carte de base du Canada - transport (CBCT)",
+                "layers": [
+                    {
+                        "id": "CBMT_CBCT_GEOM_3978",
+                        "layerType": "esriFeature",
+                        "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+            },
+            {
+                "id": "baseEsriWorld",
+                "name": "Imagerie mondiale",
+                "description": "L'imagerie mondiale fournit une imagerie satellitaire et aérienne dans de nombreuses régions du monde avec une résolution de 1 mètres et moins et des images satellitaires de résolution inférieure dans le monde entier.",
+                "altText": "altText - L'imagerie mondiale",
+                "layers": [
+                    {
+                        "id": "World_Imagery",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriPhysical",
+                "name": "Monde physique",
+                "description": "La carte du monde physique représente l'aspect physique naturel de la Terre à 1.24 kilomètres par pixel pour le monde et à 500 mètres pour les États-Unis.",
+                "altText": "altText - La carte du monde physique",
+                "layers": [
+                    {
+                        "id": "World_Physical_Map",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Physical_Map/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriRelief",
+                "name": "Monde en relief ombragé",
+                "description": "La carte du monde en relief ombragé représente l'élévation de la surface de la terre comme un relief ombragé. Cette carte est utilisée comme couche de fond afin d'ajouter un relief ombragé à d'autres cartes SIG, comme la carte ArcGIS Online World Street Map.",
+                "altText": "altText - La carte du monde en relief ombragé",
+                "layers": [
+                    {
+                        "id": "World_Shaded_Relief",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Shaded_Relief/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriStreet",
+                "name": "Monde routier",
+                "description": "La carte du monde routier présente des données au niveau des autoroutes pour le monde.",
+                "altText": "altText - La carte du monde routier",
+                "layers": [
+                    {
+                        "id": "World_Street_Map",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Street_Map/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriTerrain",
+                "name": "Monde terrain",
+                "description": "La carte du monde terrain est conçue pour être utilisée comme une carte de base par les professionnels du SIG pour superposer d'autres couches thématiques comme la démographie ou la couverture terrestre.",
+                "altText": "altText - La carte du monde terrain",
+                "layers": [
+                    {
+                        "id": "World_Terrain_Base",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Terrain_Base/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriTopo",
+                "name": "Monde topographique",
+                "description": "La carte du monde topographique est conçue pour être utilisé comme une carte de base par les professionnels du SIG et comme une carte de référence par quiconque.",
+                "altText": "altText - La carte du monde topographique",
+                "layers": [
+                    {
+                        "id": "World_Topo_Map",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
             }
         ]
-      }
-  },
-    "layers": [
-      {
-          "id": "PPA",
-          "name": "Activités de prévention de la pollution",
-          "layerType": "esriFeature",
-          "singleEntryCollapse": true,
-          "symbologyExpanded": true,
-          "url": "https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/StoryRAMP/f6f7baf4_cccb_4521_a037_b4691b0f0d49/MapServer/17",
-          "state": {
-            "opacity": 0.75
-          }
-      }
-    ],
-    "tileSchemas": [
-      {
-        "id": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978",
-        "name": "Lambert Maps",
-        "extentSetId": "EXT_NRCAN_Lambert_3978",
-        "lodSetId": "LOD_NRCAN_Lambert_3978",
-        "hasNorthPole": true
-      },
-      {
-        "id": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857",
-        "name": "Web Mercator Maps",
-        "extentSetId": "EXT_ESRI_World_AuxMerc_3857",
-        "lodSetId": "LOD_ESRI_World_AuxMerc_3857"
-      }
-    ],
-    "baseMaps": [
-      {
-        "id": "baseNrCan",
-        "name": "Carte de base du Canada – transport (CBCT) avec étiquettes",
-        "description": "La carte de base du Canada – transport (CBCT) du Secteur des sciences de la Terre de Ressources naturelles Canada est un service Internet qui s'adresse principalement aux utilisateurs et développeurs d'applications cartographiques en ligne.",
-        "altText": "altText - La carte de base du Canada – transport (CBCT)",
-        "layers": [
-          {
-            "id": "CBCT",
-            "layerType": "esriFeature",
-            "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBCT3978/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
-      },
-      {
-        "id": "baseSimple",
-        "name": "Carte de base du Canada - simple",
-        "description": "La carte de base du Canada - simple",
-        "altText": "altText - La carte de base du Canada - simple",
-        "layers": [
-          {
-            "id": "SMR",
-            "layerType": "esriFeature",
-            "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer"
-          },
-          {
-            "id": "SMW",
-            "layerType": "esriFeature",
-            "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_TXT_3978/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
-      },
-      {
-        "id": "baseCBME_CBCE_HS_RO_3978",
-        "name": "Carte de base du Canada - élevation (CBCE)",
-        "description": "La carte de base du Canada - élevation (CBCE) du Secteur des sciences de la Terre de Ressources naturelles Canada est un service Internet qui s'adresse principalement aux utilisateurs et développeurs d'applications cartographiques en ligne.",
-        "altText": "altText - La carte de base du Canada - élevation (CBCE)",
-        "layers": [
-          {
-            "id": "CBME_CBCE_HS_RO_3978",
-            "layerType": "esriFeature",
-            "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
-      },
-      {
-        "id": "baseCBMT_CBCT_GEOM_3978",
-        "name": "Carte de base du Canada - transport (CBCT)",
-        "description": "La carte de base du Canada - transport (CBCT) du Secteur des sciences de la Terre de Ressources naturelles Canada est un service Internet qui s'adresse principalement aux utilisateurs et développeurs d'applications cartographiques en ligne.",
-        "altText": "altText - La carte de base du Canada - transport (CBCT)",
-        "layers": [
-          {
-            "id": "CBMT_CBCT_GEOM_3978",
-            "layerType": "esriFeature",
-            "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
-      },
-      {
-        "id": "baseEsriWorld",
-        "name": "Imagerie mondiale",
-        "description": "L'imagerie mondiale fournit une imagerie satellitaire et aérienne dans de nombreuses régions du monde avec une résolution de 1 mètres et moins et des images satellitaires de résolution inférieure dans le monde entier.",
-        "altText": "altText - L'imagerie mondiale",
-        "layers": [
-          {
-            "id": "World_Imagery",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      },
-      {
-        "id": "baseEsriPhysical",
-        "name": "Monde physique",
-        "description": "La carte du monde physique représente l'aspect physique naturel de la Terre à 1.24 kilomètres par pixel pour le monde et à 500 mètres pour les États-Unis.",
-        "altText": "altText - La carte du monde physique",
-        "layers": [
-          {
-            "id": "World_Physical_Map",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Physical_Map/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      },
-      {
-        "id": "baseEsriRelief",
-        "name": "Monde en relief ombragé",
-        "description": "La carte du monde en relief ombragé représente l'élévation de la surface de la terre comme un relief ombragé. Cette carte est utilisée comme couche de fond afin d'ajouter un relief ombragé à d'autres cartes SIG, comme la carte ArcGIS Online World Street Map.",
-        "altText": "altText - La carte du monde en relief ombragé",
-        "layers": [
-          {
-            "id": "World_Shaded_Relief",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Shaded_Relief/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      },
-      {
-        "id": "baseEsriStreet",
-        "name": "Monde routier",
-        "description": "La carte du monde routier présente des données au niveau des autoroutes pour le monde.",
-        "altText": "altText - La carte du monde routier",
-        "layers": [
-          {
-            "id": "World_Street_Map",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Street_Map/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      },
-      {
-        "id": "baseEsriTerrain",
-        "name": "Monde terrain",
-        "description": "La carte du monde terrain est conçue pour être utilisée comme une carte de base par les professionnels du SIG pour superposer d'autres couches thématiques comme la démographie ou la couverture terrestre.",
-        "altText": "altText - La carte du monde terrain",
-        "layers": [
-          {
-            "id": "World_Terrain_Base",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Terrain_Base/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      },
-      {
-        "id": "baseEsriTopo",
-        "name": "Monde topographique",
-        "description": "La carte du monde topographique est conçue pour être utilisé comme une carte de base par les professionnels du SIG et comme une carte de référence par quiconque.",
-        "altText": "altText - La carte du monde topographique",
-        "layers": [
-          {
-            "id": "World_Topo_Map",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      }
-    ]
-  }
+    }
 }

--- a/public/f6f7baf4-cccb-4521-a037-b4691b0f0d49/ramp-config/fr/total_criteria_air_contaminants_of_pnp_2010-2019.json
+++ b/public/f6f7baf4-cccb-4521-a037-b4691b0f0d49/ramp-config/fr/total_criteria_air_contaminants_of_pnp_2010-2019.json
@@ -1,513 +1,540 @@
 {
-  "version": "2.0",
-  "language": "fr",
-  "ui": {
-    "title": "Carte interactive",
-    "fullscreen": true,
-    "navBar": {
-      "zoom": "buttons",
-      "extra": [ "fullscreen", "geoLocator", "home", "help" ]
-    },
-    "appBar": {
-      "basemap": true
-
-    },
-    "help": {
-      "folderName": "default"
-    },
-    "sideMenu": {
-      "items": [ [ "fullscreen", "export", "touch", "help", "about" ] ],
-      "logo": false
-    },
-    "legend": {
-      "allowImport": true,
-      "isOpen": {
-        "large": true,
-        "medium": false,
-        "small": false
-      }
-    }
-  },
-  "services": {
-    "proxyUrl": "http://167.40.64.74/wmsproxy/ws/wmsproxy/executeFromProxy",
-    "exportMapUrl": "https://maps-cartes.dev.ec.gc.ca/arcgis/rest/services/Utilities/PrintingTools/GPServer/Export%20Web%20Map%20Task",
-    "export": {
-      "title": {
-        "value": "Principaux contaminants atmosphériques totaux rejetés par les installations de pâtes et papiers déclarant à l’INRP de 2010 à 2019"
-      },
-      "map": {},
-      "mapElements": {},
-      "legend": {},
-      "footnote": {
-        "value": "Principaux contaminants atmosphériques totaux rejetés par les installations de pâtes et papiers déclarant à l’INRP de 2010 à 2019"
-      }
-    },
-    "search": {
-      "settings": {
-        "categories": [ "CITY", "HAM", "IR", "LTM", "MUN1", "MUN2", "PROV", "STM", "TERR", "TOWN", "UTM", "VILG", "UNP" ],
-        "sortOrder": [ "CITY", "HAM", "IR", "LTM", "MUN1", "MUN2", "PROV", "STM", "TERR", "TOWN", "UTM", "VILG", "UNP" ],
-        "maxResults": 1000,
-        "officialOnly": true
-      },	
-      "serviceUrls": {
-        "geoNames": "https://geogratis.gc.ca/services/geoname/fr/geonames.json",
-        "geoLocation": "https://geogratis.gc.ca/services/geolocation/fr/locate?q=",
-        "geoSuggest": "https://geogratis.gc.ca/services/geolocation/fr/suggest?q=",
-        "provinces": "https://geogratis.gc.ca/services/geoname/fr/codes/province.json",
-        "types": "https://geogratis.gc.ca/services/geoname/fr/codes/concise.json"
-      }
-    }
-  },
-  "map": {
-    "initialBasemapId": "baseNrCan",
-    "components": {
-      "geoSearch": {
-        "enabled": true,
-        "showGraphic": true,
-        "showInfo": true
-      },
-      "mouseInfo": {
-        "enabled": true,
-        "spatialReference": {
-          "wkid": 4326
-        }
-      },
-      "northArrow": {
-        "enabled": false
-      },
-      "basemap": {
-        "enabled": true
-      },
-      "overviewMap": {
-        "enabled": true,
-        "layerType": "imagery"
-      },
-      "scaleBar": {
-        "enabled": true
-      }
-    },
-    "extentSets": [
-      {
-        "id": "EXT_NRCAN_Lambert_3978",
-        "default": {
-          "xmax": 2849492,
-          "xmin": -5281457,
-          "ymax": 4482193,
-          "ymin": -983440
+    "version": "2.0",
+    "language": "fr",
+    "ui": {
+        "title": "Carte interactive",
+        "fullscreen": true,
+        "navBar": {
+            "zoom": "buttons",
+            "extra": ["fullscreen", "geoLocator", "home", "help"]
         },
-        "spatialReference": {
-          "wkid": 3978
-        }
-      },
-      {
-        "id": "EXT_ESRI_World_AuxMerc_3857",
-        "default": {
-          "xmax": -5007771.626060756,
-          "xmin": -16632697.354854,
-          "ymax": 10015875.184845109,
-          "ymin": 5022907.964742964
+        "appBar": {
+            "basemap": true
         },
-        "spatialReference": {
-          "wkid": 102100,
-          "latestWkid": 3857
+        "help": {
+            "folderName": "default"
+        },
+        "sideMenu": {
+            "items": [["fullscreen", "export", "touch", "help", "about"]],
+            "logo": false
+        },
+        "legend": {
+            "allowImport": true,
+            "isOpen": {
+                "large": true,
+                "medium": false,
+                "small": false
+            }
         }
-      }
-    ],
-    "lodSets": [
-      {
-        "id": "LOD_NRCAN_Lambert_3978",
-        "lods": [
-          {
-            "level": 0,
-            "resolution": 38364.660062653464,
-            "scale": 145000000
-          },
-          {
-            "level": 1,
-            "resolution": 22489.628312589961,
-            "scale": 85000000
-          },
-          {
-            "level": 2,
-            "resolution": 13229.193125052918,
-            "scale": 50000000
-          },
-          {
-            "level": 3,
-            "resolution": 7937.5158750317505,
-            "scale": 30000000
-          },
-          {
-            "level": 4,
-            "resolution": 4630.2175937685215,
-            "scale": 17500000
-          },
-          {
-            "level": 5,
-            "resolution": 2645.8386250105837,
-            "scale": 10000000
-          },
-          {
-            "level": 6,
-            "resolution": 1587.5031750063501,
-            "scale": 6000000
-          },
-          {
-            "level": 7,
-            "resolution": 926.04351875370423,
-            "scale": 3500000
-          },
-          {
-            "level": 8,
-            "resolution": 529.16772500211675,
-            "scale": 2000000
-          },
-          {
-            "level": 9,
-            "resolution": 317.50063500127004,
-            "scale": 1200000
-          },
-          {
-            "level": 10,
-            "resolution": 185.20870375074085,
-            "scale": 700000
-          },
-          {
-            "level": 11,
-            "resolution": 111.12522225044451,
-            "scale": 420000
-          },
-          {
-            "level": 12,
-            "resolution": 66.1459656252646,
-            "scale": 250000
-          },
-          {
-            "level": 13,
-            "resolution": 38.364660062653464,
-            "scale": 145000
-          },
-          {
-            "level": 14,
-            "resolution": 22.489628312589961,
-            "scale": 85000
-          },
-          {
-            "level": 15,
-            "resolution": 13.229193125052918,
-            "scale": 50000
-          },
-          {
-            "level": 16,
-            "resolution": 7.9375158750317505,
-            "scale": 30000
-          },
-          {
-            "level": 17,
-            "resolution": 4.6302175937685215,
-            "scale": 17500
-          }
-        ]
-      },
-      {
-        "id": "LOD_ESRI_World_AuxMerc_3857",
-        "lods": [
-          {
-            "level": 0,
-            "resolution": 19567.879240999919,
-            "scale": 73957190.948944
-          },
-          {
-            "level": 1,
-            "resolution": 9783.93962049996,
-            "scale": 36978595.474472
-          },
-          {
-            "level": 2,
-            "resolution": 4891.96981024998,
-            "scale": 18489297.737236
-          },
-          {
-            "level": 3,
-            "resolution": 2445.98490512499,
-            "scale": 9244648.868618
-          },
-          {
-            "level": 4,
-            "resolution": 1222.9924525624949,
-            "scale": 4622324.434309
-          },
-          {
-            "level": 5,
-            "resolution": 611.49622628137968,
-            "scale": 2311162.217155
-          },
-          {
-            "level": 6,
-            "resolution": 305.74811314055756,
-            "scale": 1155581.108577
-          },
-          {
-            "level": 7,
-            "resolution": 152.87405657041106,
-            "scale": 577790.554289
-          },
-          {
-            "level": 8,
-            "resolution": 76.437028285073239,
-            "scale": 288895.277144
-          },
-          {
-            "level": 9,
-            "resolution": 38.21851414253662,
-            "scale": 144447.638572
-          },
-          {
-            "level": 10,
-            "resolution": 19.10925707126831,
-            "scale": 72223.819286
-          },
-          {
-            "level": 11,
-            "resolution": 9.5546285356341549,
-            "scale": 36111.909643
-          },
-          {
-            "level": 12,
-            "resolution": 4.77731426794937,
-            "scale": 18055.954822
-          },
-          {
-            "level": 13,
-            "resolution": 2.3886571339746849,
-            "scale": 9027.977411
-          },
-          {
-            "level": 14,
-            "resolution": 1.1943285668550503,
-            "scale": 4513.988705
-          },
-          {
-            "level": 15,
-            "resolution": 0.59716428355981721,
-            "scale": 2256.994353
-          },
-          {
-            "level": 16,
-            "resolution": 0.29858214164761665,
-            "scale": 1128.497176
-          },
-          {
-            "level": 17,
-            "resolution": 0.14929107082380833,
-            "scale": 564.248588
-          },
-          {
-            "level": 18,
-            "resolution": 0.074645535411904163,
-            "scale": 282.124294
-          },
-          {
-            "level": 19,
-            "resolution": 0.037322767705952081,
-            "scale": 141.062147
-          },
-          {
-            "level": 20,
-            "resolution": 0.018661383852976041,
-            "scale": 70.5310735
-          }
-        ]
-      }
-    ],
-    "legend": {
-      "type": "structured",
-      "root": {
-          "name": "root",
-          "children": [
+    },
+    "services": {
+        "proxyUrl": "http://167.40.64.74/wmsproxy/ws/wmsproxy/executeFromProxy",
+        "exportMapUrl": "https://maps-cartes.dev.ec.gc.ca/arcgis/rest/services/Utilities/PrintingTools/GPServer/Export%20Web%20Map%20Task",
+        "export": {
+            "title": {
+                "value": "Principaux contaminants atmosphériques totaux rejetés par les installations de pâtes et papiers déclarant à l’INRP de 2010 à 2019"
+            },
+            "map": {},
+            "mapElements": {},
+            "legend": {},
+            "footnote": {
+                "value": "Principaux contaminants atmosphériques totaux rejetés par les installations de pâtes et papiers déclarant à l’INRP de 2010 à 2019"
+            }
+        },
+        "search": {
+            "settings": {
+                "categories": [
+                    "CITY",
+                    "HAM",
+                    "IR",
+                    "LTM",
+                    "MUN1",
+                    "MUN2",
+                    "PROV",
+                    "STM",
+                    "TERR",
+                    "TOWN",
+                    "UTM",
+                    "VILG",
+                    "UNP"
+                ],
+                "sortOrder": [
+                    "CITY",
+                    "HAM",
+                    "IR",
+                    "LTM",
+                    "MUN1",
+                    "MUN2",
+                    "PROV",
+                    "STM",
+                    "TERR",
+                    "TOWN",
+                    "UTM",
+                    "VILG",
+                    "UNP"
+                ],
+                "maxResults": 1000,
+                "officialOnly": true
+            },
+            "serviceUrls": {
+                "geoNames": "https://geogratis.gc.ca/services/geoname/fr/geonames.json",
+                "geoLocation": "https://geogratis.gc.ca/services/geolocation/fr/locate?q=",
+                "geoSuggest": "https://geogratis.gc.ca/services/geolocation/fr/suggest?q=",
+                "provinces": "https://geogratis.gc.ca/services/geoname/fr/codes/province.json",
+                "types": "https://geogratis.gc.ca/services/geoname/fr/codes/concise.json"
+            }
+        }
+    },
+    "map": {
+        "initialBasemapId": "baseNrCan",
+        "components": {
+            "geoSearch": {
+                "enabled": true,
+                "showGraphic": true,
+                "showInfo": true
+            },
+            "mouseInfo": {
+                "enabled": true,
+                "spatialReference": {
+                    "wkid": 4326
+                }
+            },
+            "northArrow": {
+                "enabled": false
+            },
+            "basemap": {
+                "enabled": true
+            },
+            "overviewMap": {
+                "enabled": true,
+                "layerType": "imagery"
+            },
+            "scaleBar": {
+                "enabled": true
+            }
+        },
+        "extentSets": [
             {
-                "layerId": "Criteria",
-                "description": "Principaux contaminants atmosphériques totaux rejetés par les installations de pâtes et papiers déclarant à l’INRP de 2010 à 2019 (tonnes)",                
-                "symbologyExpanded": true
+                "id": "EXT_NRCAN_Lambert_3978",
+                "default": {
+                    "xmax": 2249492,
+                    "xmin": -5881457,
+                    "ymax": 4482193,
+                    "ymin": -983440
+                },
+                "spatialReference": {
+                    "wkid": 3978
+                }
+            },
+            {
+                "id": "EXT_ESRI_World_AuxMerc_3857",
+                "default": {
+                    "xmax": -5007771.626060756,
+                    "xmin": -16632697.354854,
+                    "ymax": 10015875.184845109,
+                    "ymin": 5022907.964742964
+                },
+                "spatialReference": {
+                    "wkid": 102100,
+                    "latestWkid": 3857
+                }
+            }
+        ],
+        "lodSets": [
+            {
+                "id": "LOD_NRCAN_Lambert_3978",
+                "lods": [
+                    {
+                        "level": 0,
+                        "resolution": 38364.660062653464,
+                        "scale": 145000000
+                    },
+                    {
+                        "level": 1,
+                        "resolution": 22489.628312589961,
+                        "scale": 85000000
+                    },
+                    {
+                        "level": 2,
+                        "resolution": 13229.193125052918,
+                        "scale": 50000000
+                    },
+                    {
+                        "level": 3,
+                        "resolution": 7937.5158750317505,
+                        "scale": 30000000
+                    },
+                    {
+                        "level": 4,
+                        "resolution": 4630.2175937685215,
+                        "scale": 17500000
+                    },
+                    {
+                        "level": 5,
+                        "resolution": 2645.8386250105837,
+                        "scale": 10000000
+                    },
+                    {
+                        "level": 6,
+                        "resolution": 1587.5031750063501,
+                        "scale": 6000000
+                    },
+                    {
+                        "level": 7,
+                        "resolution": 926.04351875370423,
+                        "scale": 3500000
+                    },
+                    {
+                        "level": 8,
+                        "resolution": 529.16772500211675,
+                        "scale": 2000000
+                    },
+                    {
+                        "level": 9,
+                        "resolution": 317.50063500127004,
+                        "scale": 1200000
+                    },
+                    {
+                        "level": 10,
+                        "resolution": 185.20870375074085,
+                        "scale": 700000
+                    },
+                    {
+                        "level": 11,
+                        "resolution": 111.12522225044451,
+                        "scale": 420000
+                    },
+                    {
+                        "level": 12,
+                        "resolution": 66.1459656252646,
+                        "scale": 250000
+                    },
+                    {
+                        "level": 13,
+                        "resolution": 38.364660062653464,
+                        "scale": 145000
+                    },
+                    {
+                        "level": 14,
+                        "resolution": 22.489628312589961,
+                        "scale": 85000
+                    },
+                    {
+                        "level": 15,
+                        "resolution": 13.229193125052918,
+                        "scale": 50000
+                    },
+                    {
+                        "level": 16,
+                        "resolution": 7.9375158750317505,
+                        "scale": 30000
+                    },
+                    {
+                        "level": 17,
+                        "resolution": 4.6302175937685215,
+                        "scale": 17500
+                    }
+                ]
+            },
+            {
+                "id": "LOD_ESRI_World_AuxMerc_3857",
+                "lods": [
+                    {
+                        "level": 0,
+                        "resolution": 19567.879240999919,
+                        "scale": 73957190.948944
+                    },
+                    {
+                        "level": 1,
+                        "resolution": 9783.93962049996,
+                        "scale": 36978595.474472
+                    },
+                    {
+                        "level": 2,
+                        "resolution": 4891.96981024998,
+                        "scale": 18489297.737236
+                    },
+                    {
+                        "level": 3,
+                        "resolution": 2445.98490512499,
+                        "scale": 9244648.868618
+                    },
+                    {
+                        "level": 4,
+                        "resolution": 1222.9924525624949,
+                        "scale": 4622324.434309
+                    },
+                    {
+                        "level": 5,
+                        "resolution": 611.49622628137968,
+                        "scale": 2311162.217155
+                    },
+                    {
+                        "level": 6,
+                        "resolution": 305.74811314055756,
+                        "scale": 1155581.108577
+                    },
+                    {
+                        "level": 7,
+                        "resolution": 152.87405657041106,
+                        "scale": 577790.554289
+                    },
+                    {
+                        "level": 8,
+                        "resolution": 76.437028285073239,
+                        "scale": 288895.277144
+                    },
+                    {
+                        "level": 9,
+                        "resolution": 38.21851414253662,
+                        "scale": 144447.638572
+                    },
+                    {
+                        "level": 10,
+                        "resolution": 19.10925707126831,
+                        "scale": 72223.819286
+                    },
+                    {
+                        "level": 11,
+                        "resolution": 9.5546285356341549,
+                        "scale": 36111.909643
+                    },
+                    {
+                        "level": 12,
+                        "resolution": 4.77731426794937,
+                        "scale": 18055.954822
+                    },
+                    {
+                        "level": 13,
+                        "resolution": 2.3886571339746849,
+                        "scale": 9027.977411
+                    },
+                    {
+                        "level": 14,
+                        "resolution": 1.1943285668550503,
+                        "scale": 4513.988705
+                    },
+                    {
+                        "level": 15,
+                        "resolution": 0.59716428355981721,
+                        "scale": 2256.994353
+                    },
+                    {
+                        "level": 16,
+                        "resolution": 0.29858214164761665,
+                        "scale": 1128.497176
+                    },
+                    {
+                        "level": 17,
+                        "resolution": 0.14929107082380833,
+                        "scale": 564.248588
+                    },
+                    {
+                        "level": 18,
+                        "resolution": 0.074645535411904163,
+                        "scale": 282.124294
+                    },
+                    {
+                        "level": 19,
+                        "resolution": 0.037322767705952081,
+                        "scale": 141.062147
+                    },
+                    {
+                        "level": 20,
+                        "resolution": 0.018661383852976041,
+                        "scale": 70.5310735
+                    }
+                ]
+            }
+        ],
+        "legend": {
+            "type": "structured",
+            "root": {
+                "name": "root",
+                "children": [
+                    {
+                        "layerId": "Criteria",
+                        "description": "Principaux contaminants atmosphériques totaux rejetés par les installations de pâtes et papiers déclarant à l’INRP de 2010 à 2019 (tonnes)",
+                        "symbologyExpanded": true
+                    }
+                ]
+            }
+        },
+        "layers": [
+            {
+                "id": "Criteria",
+                "name": "Principaux contaminants atmosphériques totaux rejetés",
+                "layerType": "esriFeature",
+                "tolerance": 20,
+                "singleEntryCollapse": true,
+                "symbologyExpanded": true,
+                "url": "https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/StoryRAMP/f6f7baf4_cccb_4521_a037_b4691b0f0d49/MapServer/3",
+                "state": {
+                    "opacity": 0.75
+                }
+            }
+        ],
+        "tileSchemas": [
+            {
+                "id": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978",
+                "name": "Lambert Maps",
+                "extentSetId": "EXT_NRCAN_Lambert_3978",
+                "lodSetId": "LOD_NRCAN_Lambert_3978",
+                "hasNorthPole": true
+            },
+            {
+                "id": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857",
+                "name": "Web Mercator Maps",
+                "extentSetId": "EXT_ESRI_World_AuxMerc_3857",
+                "lodSetId": "LOD_ESRI_World_AuxMerc_3857"
+            }
+        ],
+        "baseMaps": [
+            {
+                "id": "baseNrCan",
+                "name": "Carte de base du Canada – transport (CBCT) avec étiquettes",
+                "description": "La carte de base du Canada – transport (CBCT) du Secteur des sciences de la Terre de Ressources naturelles Canada est un service Internet qui s'adresse principalement aux utilisateurs et développeurs d'applications cartographiques en ligne.",
+                "altText": "altText - La carte de base du Canada – transport (CBCT)",
+                "layers": [
+                    {
+                        "id": "CBCT",
+                        "layerType": "esriFeature",
+                        "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBCT3978/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+            },
+            {
+                "id": "baseSimple",
+                "name": "Carte de base du Canada - simple",
+                "description": "La carte de base du Canada - simple",
+                "altText": "altText - La carte de base du Canada - simple",
+                "layers": [
+                    {
+                        "id": "SMR",
+                        "layerType": "esriFeature",
+                        "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer"
+                    },
+                    {
+                        "id": "SMW",
+                        "layerType": "esriFeature",
+                        "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_TXT_3978/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+            },
+            {
+                "id": "baseCBME_CBCE_HS_RO_3978",
+                "name": "Carte de base du Canada - élevation (CBCE)",
+                "description": "La carte de base du Canada - élevation (CBCE) du Secteur des sciences de la Terre de Ressources naturelles Canada est un service Internet qui s'adresse principalement aux utilisateurs et développeurs d'applications cartographiques en ligne.",
+                "altText": "altText - La carte de base du Canada - élevation (CBCE)",
+                "layers": [
+                    {
+                        "id": "CBME_CBCE_HS_RO_3978",
+                        "layerType": "esriFeature",
+                        "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+            },
+            {
+                "id": "baseCBMT_CBCT_GEOM_3978",
+                "name": "Carte de base du Canada - transport (CBCT)",
+                "description": "La carte de base du Canada - transport (CBCT) du Secteur des sciences de la Terre de Ressources naturelles Canada est un service Internet qui s'adresse principalement aux utilisateurs et développeurs d'applications cartographiques en ligne.",
+                "altText": "altText - La carte de base du Canada - transport (CBCT)",
+                "layers": [
+                    {
+                        "id": "CBMT_CBCT_GEOM_3978",
+                        "layerType": "esriFeature",
+                        "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+            },
+            {
+                "id": "baseEsriWorld",
+                "name": "Imagerie mondiale",
+                "description": "L'imagerie mondiale fournit une imagerie satellitaire et aérienne dans de nombreuses régions du monde avec une résolution de 1 mètres et moins et des images satellitaires de résolution inférieure dans le monde entier.",
+                "altText": "altText - L'imagerie mondiale",
+                "layers": [
+                    {
+                        "id": "World_Imagery",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriPhysical",
+                "name": "Monde physique",
+                "description": "La carte du monde physique représente l'aspect physique naturel de la Terre à 1.24 kilomètres par pixel pour le monde et à 500 mètres pour les États-Unis.",
+                "altText": "altText - La carte du monde physique",
+                "layers": [
+                    {
+                        "id": "World_Physical_Map",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Physical_Map/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriRelief",
+                "name": "Monde en relief ombragé",
+                "description": "La carte du monde en relief ombragé représente l'élévation de la surface de la terre comme un relief ombragé. Cette carte est utilisée comme couche de fond afin d'ajouter un relief ombragé à d'autres cartes SIG, comme la carte ArcGIS Online World Street Map.",
+                "altText": "altText - La carte du monde en relief ombragé",
+                "layers": [
+                    {
+                        "id": "World_Shaded_Relief",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Shaded_Relief/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriStreet",
+                "name": "Monde routier",
+                "description": "La carte du monde routier présente des données au niveau des autoroutes pour le monde.",
+                "altText": "altText - La carte du monde routier",
+                "layers": [
+                    {
+                        "id": "World_Street_Map",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Street_Map/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriTerrain",
+                "name": "Monde terrain",
+                "description": "La carte du monde terrain est conçue pour être utilisée comme une carte de base par les professionnels du SIG pour superposer d'autres couches thématiques comme la démographie ou la couverture terrestre.",
+                "altText": "altText - La carte du monde terrain",
+                "layers": [
+                    {
+                        "id": "World_Terrain_Base",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Terrain_Base/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriTopo",
+                "name": "Monde topographique",
+                "description": "La carte du monde topographique est conçue pour être utilisé comme une carte de base par les professionnels du SIG et comme une carte de référence par quiconque.",
+                "altText": "altText - La carte du monde topographique",
+                "layers": [
+                    {
+                        "id": "World_Topo_Map",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
             }
         ]
-      }
-  },
-    "layers": [
-      {
-          "id": "Criteria",
-          "name": "Principaux contaminants atmosphériques totaux rejetés",
-          "layerType": "esriFeature",
-          "tolerance": 20,
-          "singleEntryCollapse": true,
-          "symbologyExpanded": true,
-          "url": "https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/StoryRAMP/f6f7baf4_cccb_4521_a037_b4691b0f0d49/MapServer/3",
-          "state": {
-            "opacity": 0.75
-          }
-      }
-    ],
-    "tileSchemas": [
-      {
-        "id": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978",
-        "name": "Lambert Maps",
-        "extentSetId": "EXT_NRCAN_Lambert_3978",
-        "lodSetId": "LOD_NRCAN_Lambert_3978",
-        "hasNorthPole": true
-      },
-      {
-        "id": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857",
-        "name": "Web Mercator Maps",
-        "extentSetId": "EXT_ESRI_World_AuxMerc_3857",
-        "lodSetId": "LOD_ESRI_World_AuxMerc_3857"
-      }
-    ],
-    "baseMaps": [
-      {
-        "id": "baseNrCan",
-        "name": "Carte de base du Canada – transport (CBCT) avec étiquettes",
-        "description": "La carte de base du Canada – transport (CBCT) du Secteur des sciences de la Terre de Ressources naturelles Canada est un service Internet qui s'adresse principalement aux utilisateurs et développeurs d'applications cartographiques en ligne.",
-        "altText": "altText - La carte de base du Canada – transport (CBCT)",
-        "layers": [
-          {
-            "id": "CBCT",
-            "layerType": "esriFeature",
-            "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBCT3978/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
-      },
-      {
-        "id": "baseSimple",
-        "name": "Carte de base du Canada - simple",
-        "description": "La carte de base du Canada - simple",
-        "altText": "altText - La carte de base du Canada - simple",
-        "layers": [
-          {
-            "id": "SMR",
-            "layerType": "esriFeature",
-            "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer"
-          },
-          {
-            "id": "SMW",
-            "layerType": "esriFeature",
-            "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_TXT_3978/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
-      },
-      {
-        "id": "baseCBME_CBCE_HS_RO_3978",
-        "name": "Carte de base du Canada - élevation (CBCE)",
-        "description": "La carte de base du Canada - élevation (CBCE) du Secteur des sciences de la Terre de Ressources naturelles Canada est un service Internet qui s'adresse principalement aux utilisateurs et développeurs d'applications cartographiques en ligne.",
-        "altText": "altText - La carte de base du Canada - élevation (CBCE)",
-        "layers": [
-          {
-            "id": "CBME_CBCE_HS_RO_3978",
-            "layerType": "esriFeature",
-            "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
-      },
-      {
-        "id": "baseCBMT_CBCT_GEOM_3978",
-        "name": "Carte de base du Canada - transport (CBCT)",
-        "description": "La carte de base du Canada - transport (CBCT) du Secteur des sciences de la Terre de Ressources naturelles Canada est un service Internet qui s'adresse principalement aux utilisateurs et développeurs d'applications cartographiques en ligne.",
-        "altText": "altText - La carte de base du Canada - transport (CBCT)",
-        "layers": [
-          {
-            "id": "CBMT_CBCT_GEOM_3978",
-            "layerType": "esriFeature",
-            "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
-      },
-      {
-        "id": "baseEsriWorld",
-        "name": "Imagerie mondiale",
-        "description": "L'imagerie mondiale fournit une imagerie satellitaire et aérienne dans de nombreuses régions du monde avec une résolution de 1 mètres et moins et des images satellitaires de résolution inférieure dans le monde entier.",
-        "altText": "altText - L'imagerie mondiale",
-        "layers": [
-          {
-            "id": "World_Imagery",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      },
-      {
-        "id": "baseEsriPhysical",
-        "name": "Monde physique",
-        "description": "La carte du monde physique représente l'aspect physique naturel de la Terre à 1.24 kilomètres par pixel pour le monde et à 500 mètres pour les États-Unis.",
-        "altText": "altText - La carte du monde physique",
-        "layers": [
-          {
-            "id": "World_Physical_Map",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Physical_Map/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      },
-      {
-        "id": "baseEsriRelief",
-        "name": "Monde en relief ombragé",
-        "description": "La carte du monde en relief ombragé représente l'élévation de la surface de la terre comme un relief ombragé. Cette carte est utilisée comme couche de fond afin d'ajouter un relief ombragé à d'autres cartes SIG, comme la carte ArcGIS Online World Street Map.",
-        "altText": "altText - La carte du monde en relief ombragé",
-        "layers": [
-          {
-            "id": "World_Shaded_Relief",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Shaded_Relief/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      },
-      {
-        "id": "baseEsriStreet",
-        "name": "Monde routier",
-        "description": "La carte du monde routier présente des données au niveau des autoroutes pour le monde.",
-        "altText": "altText - La carte du monde routier",
-        "layers": [
-          {
-            "id": "World_Street_Map",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Street_Map/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      },
-      {
-        "id": "baseEsriTerrain",
-        "name": "Monde terrain",
-        "description": "La carte du monde terrain est conçue pour être utilisée comme une carte de base par les professionnels du SIG pour superposer d'autres couches thématiques comme la démographie ou la couverture terrestre.",
-        "altText": "altText - La carte du monde terrain",
-        "layers": [
-          {
-            "id": "World_Terrain_Base",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Terrain_Base/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      },
-      {
-        "id": "baseEsriTopo",
-        "name": "Monde topographique",
-        "description": "La carte du monde topographique est conçue pour être utilisé comme une carte de base par les professionnels du SIG et comme une carte de référence par quiconque.",
-        "altText": "altText - La carte du monde topographique",
-        "layers": [
-          {
-            "id": "World_Topo_Map",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      }
-    ]
-  }
+    }
 }

--- a/public/f6f7baf4-cccb-4521-a037-b4691b0f0d49/ramp-config/fr/total_disposals_and_transfers_of_pnp_2010-2019.json
+++ b/public/f6f7baf4-cccb-4521-a037-b4691b0f0d49/ramp-config/fr/total_disposals_and_transfers_of_pnp_2010-2019.json
@@ -1,519 +1,546 @@
 {
-  "version": "2.0",
-  "language": "fr",
-  "ui": {
-    "title": "Carte interactive",
-    "fullscreen": true,
-    "navBar": {
-      "zoom": "buttons",
-      "extra": [ "fullscreen", "geoLocator", "home", "help" ]
+    "version": "2.0",
+    "language": "fr",
+    "ui": {
+        "title": "Carte interactive",
+        "fullscreen": true,
+        "navBar": {
+            "zoom": "buttons",
+            "extra": ["fullscreen", "geoLocator", "home", "help"]
+        },
+        "appBar": {
+            "basemap": true
+        },
+        "help": {
+            "folderName": "default"
+        },
+        "sideMenu": {
+            "items": [["fullscreen", "export", "touch", "help", "about"]],
+            "logo": false
+        },
+        "legend": {
+            "allowImport": true,
+            "isOpen": {
+                "large": true,
+                "medium": false,
+                "small": false
+            }
+        }
     },
-    "appBar": {
-      "basemap": true
+    "services": {
+        "proxyUrl": "http://167.40.64.74/wmsproxy/ws/wmsproxy/executeFromProxy",
+        "exportMapUrl": "https://maps-cartes.dev.ec.gc.ca/arcgis/rest/services/Utilities/PrintingTools/GPServer/Export%20Web%20Map%20Task",
+        "export": {
+            "title": {
+                "value": "Éliminations et transferts totaux par les installations de pâtes et papiers déclarant à l’INRP de 2010 à 2019"
+            },
+            "map": {},
+            "mapElements": {},
+            "legend": {},
+            "footnote": {
+                "value": "Éliminations et transferts totaux par les installations de pâtes et papiers déclarant à l’INRP de 2010 à 2019"
+            }
+        },
+        "search": {
+            "settings": {
+                "categories": [
+                    "CITY",
+                    "HAM",
+                    "IR",
+                    "LTM",
+                    "MUN1",
+                    "MUN2",
+                    "PROV",
+                    "STM",
+                    "TERR",
+                    "TOWN",
+                    "UTM",
+                    "VILG",
+                    "UNP"
+                ],
+                "sortOrder": [
+                    "CITY",
+                    "HAM",
+                    "IR",
+                    "LTM",
+                    "MUN1",
+                    "MUN2",
+                    "PROV",
+                    "STM",
+                    "TERR",
+                    "TOWN",
+                    "UTM",
+                    "VILG",
+                    "UNP"
+                ],
+                "maxResults": 1000,
+                "officialOnly": true
+            },
+            "serviceUrls": {
+                "geoNames": "https://geogratis.gc.ca/services/geoname/fr/geonames.json",
+                "geoLocation": "https://geogratis.gc.ca/services/geolocation/fr/locate?q=",
+                "geoSuggest": "https://geogratis.gc.ca/services/geolocation/fr/suggest?q=",
+                "provinces": "https://geogratis.gc.ca/services/geoname/fr/codes/province.json",
+                "types": "https://geogratis.gc.ca/services/geoname/fr/codes/concise.json"
+            }
+        }
+    },
+    "map": {
+        "initialBasemapId": "baseNrCan",
+        "components": {
+            "geoSearch": {
+                "enabled": true,
+                "showGraphic": true,
+                "showInfo": true
+            },
+            "mouseInfo": {
+                "enabled": true,
+                "spatialReference": {
+                    "wkid": 4326
+                }
+            },
+            "northArrow": {
+                "enabled": false
+            },
+            "basemap": {
+                "enabled": true
+            },
+            "overviewMap": {
+                "enabled": true,
+                "layerType": "imagery"
+            },
+            "scaleBar": {
+                "enabled": true
+            }
+        },
+        "extentSets": [
+            {
+                "id": "EXT_NRCAN_Lambert_3978",
+                "default": {
+                    "xmax": 2249492,
+                    "xmin": -5881457,
+                    "ymax": 4482193,
+                    "ymin": -983440
+                },
+                "spatialReference": {
+                    "wkid": 3978
+                }
+            },
+            {
+                "id": "EXT_ESRI_World_AuxMerc_3857",
+                "default": {
+                    "xmax": -5007771.626060756,
+                    "xmin": -16632697.354854,
+                    "ymax": 10015875.184845109,
+                    "ymin": 5022907.964742964
+                },
+                "spatialReference": {
+                    "wkid": 102100,
+                    "latestWkid": 3857
+                }
+            }
+        ],
+        "lodSets": [
+            {
+                "id": "LOD_NRCAN_Lambert_3978",
+                "lods": [
+                    {
+                        "level": 0,
+                        "resolution": 38364.660062653464,
+                        "scale": 145000000
+                    },
+                    {
+                        "level": 1,
+                        "resolution": 22489.628312589961,
+                        "scale": 85000000
+                    },
+                    {
+                        "level": 2,
+                        "resolution": 13229.193125052918,
+                        "scale": 50000000
+                    },
+                    {
+                        "level": 3,
+                        "resolution": 7937.5158750317505,
+                        "scale": 30000000
+                    },
+                    {
+                        "level": 4,
+                        "resolution": 4630.2175937685215,
+                        "scale": 17500000
+                    },
+                    {
+                        "level": 5,
+                        "resolution": 2645.8386250105837,
+                        "scale": 10000000
+                    },
+                    {
+                        "level": 6,
+                        "resolution": 1587.5031750063501,
+                        "scale": 6000000
+                    },
+                    {
+                        "level": 7,
+                        "resolution": 926.04351875370423,
+                        "scale": 3500000
+                    },
+                    {
+                        "level": 8,
+                        "resolution": 529.16772500211675,
+                        "scale": 2000000
+                    },
+                    {
+                        "level": 9,
+                        "resolution": 317.50063500127004,
+                        "scale": 1200000
+                    },
+                    {
+                        "level": 10,
+                        "resolution": 185.20870375074085,
+                        "scale": 700000
+                    },
+                    {
+                        "level": 11,
+                        "resolution": 111.12522225044451,
+                        "scale": 420000
+                    },
+                    {
+                        "level": 12,
+                        "resolution": 66.1459656252646,
+                        "scale": 250000
+                    },
+                    {
+                        "level": 13,
+                        "resolution": 38.364660062653464,
+                        "scale": 145000
+                    },
+                    {
+                        "level": 14,
+                        "resolution": 22.489628312589961,
+                        "scale": 85000
+                    },
+                    {
+                        "level": 15,
+                        "resolution": 13.229193125052918,
+                        "scale": 50000
+                    },
+                    {
+                        "level": 16,
+                        "resolution": 7.9375158750317505,
+                        "scale": 30000
+                    },
+                    {
+                        "level": 17,
+                        "resolution": 4.6302175937685215,
+                        "scale": 17500
+                    }
+                ]
+            },
+            {
+                "id": "LOD_ESRI_World_AuxMerc_3857",
+                "lods": [
+                    {
+                        "level": 0,
+                        "resolution": 19567.879240999919,
+                        "scale": 73957190.948944
+                    },
+                    {
+                        "level": 1,
+                        "resolution": 9783.93962049996,
+                        "scale": 36978595.474472
+                    },
+                    {
+                        "level": 2,
+                        "resolution": 4891.96981024998,
+                        "scale": 18489297.737236
+                    },
+                    {
+                        "level": 3,
+                        "resolution": 2445.98490512499,
+                        "scale": 9244648.868618
+                    },
+                    {
+                        "level": 4,
+                        "resolution": 1222.9924525624949,
+                        "scale": 4622324.434309
+                    },
+                    {
+                        "level": 5,
+                        "resolution": 611.49622628137968,
+                        "scale": 2311162.217155
+                    },
+                    {
+                        "level": 6,
+                        "resolution": 305.74811314055756,
+                        "scale": 1155581.108577
+                    },
+                    {
+                        "level": 7,
+                        "resolution": 152.87405657041106,
+                        "scale": 577790.554289
+                    },
+                    {
+                        "level": 8,
+                        "resolution": 76.437028285073239,
+                        "scale": 288895.277144
+                    },
+                    {
+                        "level": 9,
+                        "resolution": 38.21851414253662,
+                        "scale": 144447.638572
+                    },
+                    {
+                        "level": 10,
+                        "resolution": 19.10925707126831,
+                        "scale": 72223.819286
+                    },
+                    {
+                        "level": 11,
+                        "resolution": 9.5546285356341549,
+                        "scale": 36111.909643
+                    },
+                    {
+                        "level": 12,
+                        "resolution": 4.77731426794937,
+                        "scale": 18055.954822
+                    },
+                    {
+                        "level": 13,
+                        "resolution": 2.3886571339746849,
+                        "scale": 9027.977411
+                    },
+                    {
+                        "level": 14,
+                        "resolution": 1.1943285668550503,
+                        "scale": 4513.988705
+                    },
+                    {
+                        "level": 15,
+                        "resolution": 0.59716428355981721,
+                        "scale": 2256.994353
+                    },
+                    {
+                        "level": 16,
+                        "resolution": 0.29858214164761665,
+                        "scale": 1128.497176
+                    },
+                    {
+                        "level": 17,
+                        "resolution": 0.14929107082380833,
+                        "scale": 564.248588
+                    },
+                    {
+                        "level": 18,
+                        "resolution": 0.074645535411904163,
+                        "scale": 282.124294
+                    },
+                    {
+                        "level": 19,
+                        "resolution": 0.037322767705952081,
+                        "scale": 141.062147
+                    },
+                    {
+                        "level": 20,
+                        "resolution": 0.018661383852976041,
+                        "scale": 70.5310735
+                    }
+                ]
+            }
+        ],
+        "legend": {
+            "type": "structured",
+            "root": {
+                "name": "root",
+                "children": [
+                    {
+                        "layerId": "Criteria",
+                        "description": "Éliminations et transferts totaux par les installations de pâtes et papiers déclarant à l’INRP de 2010 à 2019 (tonnes)",
+                        "symbologyExpanded": true
+                    }
+                ]
+            }
+        },
+        "layers": [
+            {
+                "id": "Criteria",
 
-    },
-    "help": {
-      "folderName": "default"
-    },
-    "sideMenu": {
-      "items": [ [ "fullscreen", "export", "touch", "help", "about" ] ],
-      "logo": false
-    },
-    "legend": {
-      "allowImport": true,
-      "isOpen": {
-        "large": true,
-        "medium": false,
-        "small": false
-      }
-    }
-  },
-  "services": {
-    "proxyUrl": "http://167.40.64.74/wmsproxy/ws/wmsproxy/executeFromProxy",
-    "exportMapUrl": "https://maps-cartes.dev.ec.gc.ca/arcgis/rest/services/Utilities/PrintingTools/GPServer/Export%20Web%20Map%20Task",
-    "export": {
-      "title": {
-        "value": "Éliminations et transferts totaux par les installations de pâtes et papiers déclarant à l’INRP de 2010 à 2019"
-      },
-      "map": {},
-      "mapElements": {},
-      "legend": {},
-      "footnote": {
-        "value": "Éliminations et transferts totaux par les installations de pâtes et papiers déclarant à l’INRP de 2010 à 2019"
-      }
-    },
-    "search": {
-      "settings": {
-        "categories": [ "CITY", "HAM", "IR", "LTM", "MUN1", "MUN2", "PROV", "STM", "TERR", "TOWN", "UTM", "VILG", "UNP" ],
-        "sortOrder": [ "CITY", "HAM", "IR", "LTM", "MUN1", "MUN2", "PROV", "STM", "TERR", "TOWN", "UTM", "VILG", "UNP" ],
-        "maxResults": 1000,
-        "officialOnly": true
-      },	
-      "serviceUrls": {
-        "geoNames": "https://geogratis.gc.ca/services/geoname/fr/geonames.json",
-        "geoLocation": "https://geogratis.gc.ca/services/geolocation/fr/locate?q=",
-        "geoSuggest": "https://geogratis.gc.ca/services/geolocation/fr/suggest?q=",
-        "provinces": "https://geogratis.gc.ca/services/geoname/fr/codes/province.json",
-        "types": "https://geogratis.gc.ca/services/geoname/fr/codes/concise.json"
-      }
-    }
-  },
-  "map": {
-    "initialBasemapId": "baseNrCan",
-    "components": {
-      "geoSearch": {
-        "enabled": true,
-        "showGraphic": true,
-        "showInfo": true
-      },
-      "mouseInfo": {
-        "enabled": true,
-        "spatialReference": {
-          "wkid": 4326
-        }
-      },
-      "northArrow": {
-        "enabled": false
-      },
-      "basemap": {
-        "enabled": true
-      },
-      "overviewMap": {
-        "enabled": true,
-        "layerType": "imagery"
-      },
-      "scaleBar": {
-        "enabled": true
-      }
-    },
-    "extentSets": [
-      {
-        "id": "EXT_NRCAN_Lambert_3978",
-        "default": {
-          "xmax": 2849492,
-          "xmin": -5281457,
-          "ymax": 4482193,
-          "ymin": -983440
-        },
-        "spatialReference": {
-          "wkid": 3978
-        }
-      },
-      {
-        "id": "EXT_ESRI_World_AuxMerc_3857",
-        "default": {
-          "xmax": -5007771.626060756,
-          "xmin": -16632697.354854,
-          "ymax": 10015875.184845109,
-          "ymin": 5022907.964742964
-        },
-        "spatialReference": {
-          "wkid": 102100,
-          "latestWkid": 3857
-        }
-      }
-    ],
-    "lodSets": [
-      {
-        "id": "LOD_NRCAN_Lambert_3978",
-        "lods": [
-          {
-            "level": 0,
-            "resolution": 38364.660062653464,
-            "scale": 145000000
-          },
-          {
-            "level": 1,
-            "resolution": 22489.628312589961,
-            "scale": 85000000
-          },
-          {
-            "level": 2,
-            "resolution": 13229.193125052918,
-            "scale": 50000000
-          },
-          {
-            "level": 3,
-            "resolution": 7937.5158750317505,
-            "scale": 30000000
-          },
-          {
-            "level": 4,
-            "resolution": 4630.2175937685215,
-            "scale": 17500000
-          },
-          {
-            "level": 5,
-            "resolution": 2645.8386250105837,
-            "scale": 10000000
-          },
-          {
-            "level": 6,
-            "resolution": 1587.5031750063501,
-            "scale": 6000000
-          },
-          {
-            "level": 7,
-            "resolution": 926.04351875370423,
-            "scale": 3500000
-          },
-          {
-            "level": 8,
-            "resolution": 529.16772500211675,
-            "scale": 2000000
-          },
-          {
-            "level": 9,
-            "resolution": 317.50063500127004,
-            "scale": 1200000
-          },
-          {
-            "level": 10,
-            "resolution": 185.20870375074085,
-            "scale": 700000
-          },
-          {
-            "level": 11,
-            "resolution": 111.12522225044451,
-            "scale": 420000
-          },
-          {
-            "level": 12,
-            "resolution": 66.1459656252646,
-            "scale": 250000
-          },
-          {
-            "level": 13,
-            "resolution": 38.364660062653464,
-            "scale": 145000
-          },
-          {
-            "level": 14,
-            "resolution": 22.489628312589961,
-            "scale": 85000
-          },
-          {
-            "level": 15,
-            "resolution": 13.229193125052918,
-            "scale": 50000
-          },
-          {
-            "level": 16,
-            "resolution": 7.9375158750317505,
-            "scale": 30000
-          },
-          {
-            "level": 17,
-            "resolution": 4.6302175937685215,
-            "scale": 17500
-          }
-        ]
-      },
-      {
-        "id": "LOD_ESRI_World_AuxMerc_3857",
-        "lods": [
-          {
-            "level": 0,
-            "resolution": 19567.879240999919,
-            "scale": 73957190.948944
-          },
-          {
-            "level": 1,
-            "resolution": 9783.93962049996,
-            "scale": 36978595.474472
-          },
-          {
-            "level": 2,
-            "resolution": 4891.96981024998,
-            "scale": 18489297.737236
-          },
-          {
-            "level": 3,
-            "resolution": 2445.98490512499,
-            "scale": 9244648.868618
-          },
-          {
-            "level": 4,
-            "resolution": 1222.9924525624949,
-            "scale": 4622324.434309
-          },
-          {
-            "level": 5,
-            "resolution": 611.49622628137968,
-            "scale": 2311162.217155
-          },
-          {
-            "level": 6,
-            "resolution": 305.74811314055756,
-            "scale": 1155581.108577
-          },
-          {
-            "level": 7,
-            "resolution": 152.87405657041106,
-            "scale": 577790.554289
-          },
-          {
-            "level": 8,
-            "resolution": 76.437028285073239,
-            "scale": 288895.277144
-          },
-          {
-            "level": 9,
-            "resolution": 38.21851414253662,
-            "scale": 144447.638572
-          },
-          {
-            "level": 10,
-            "resolution": 19.10925707126831,
-            "scale": 72223.819286
-          },
-          {
-            "level": 11,
-            "resolution": 9.5546285356341549,
-            "scale": 36111.909643
-          },
-          {
-            "level": 12,
-            "resolution": 4.77731426794937,
-            "scale": 18055.954822
-          },
-          {
-            "level": 13,
-            "resolution": 2.3886571339746849,
-            "scale": 9027.977411
-          },
-          {
-            "level": 14,
-            "resolution": 1.1943285668550503,
-            "scale": 4513.988705
-          },
-          {
-            "level": 15,
-            "resolution": 0.59716428355981721,
-            "scale": 2256.994353
-          },
-          {
-            "level": 16,
-            "resolution": 0.29858214164761665,
-            "scale": 1128.497176
-          },
-          {
-            "level": 17,
-            "resolution": 0.14929107082380833,
-            "scale": 564.248588
-          },
-          {
-            "level": 18,
-            "resolution": 0.074645535411904163,
-            "scale": 282.124294
-          },
-          {
-            "level": 19,
-            "resolution": 0.037322767705952081,
-            "scale": 141.062147
-          },
-          {
-            "level": 20,
-            "resolution": 0.018661383852976041,
-            "scale": 70.5310735
-          }
-        ]
-      }
-    ],
-    "legend": {
-      "type": "structured",
-      "root": {
-          "name": "root",
-          "children": [
+                "layerType": "esriDynamic",
+                "tolerance": 20,
+                "singleEntryCollapse": true,
+                "symbologyExpanded": true,
+                "url": "https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/StoryRAMP/f6f7baf4_cccb_4521_a037_b4691b0f0d49/MapServer",
+                "state": {
+                    "opacity": 0.75
+                },
+                "layerEntries": [
+                    {
+                        "index": 16,
+                        "name": "Éliminations et transferts totaux"
+                    }
+                ]
+            }
+        ],
+        "tileSchemas": [
             {
-                "layerId": "Criteria",
-                "description": "Éliminations et transferts totaux par les installations de pâtes et papiers déclarant à l’INRP de 2010 à 2019 (tonnes)",
-                "symbologyExpanded": true
+                "id": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978",
+                "name": "Lambert Maps",
+                "extentSetId": "EXT_NRCAN_Lambert_3978",
+                "lodSetId": "LOD_NRCAN_Lambert_3978",
+                "hasNorthPole": true
+            },
+            {
+                "id": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857",
+                "name": "Web Mercator Maps",
+                "extentSetId": "EXT_ESRI_World_AuxMerc_3857",
+                "lodSetId": "LOD_ESRI_World_AuxMerc_3857"
+            }
+        ],
+        "baseMaps": [
+            {
+                "id": "baseNrCan",
+                "name": "Carte de base du Canada – transport (CBCT) avec étiquettes",
+                "description": "La carte de base du Canada – transport (CBCT) du Secteur des sciences de la Terre de Ressources naturelles Canada est un service Internet qui s'adresse principalement aux utilisateurs et développeurs d'applications cartographiques en ligne.",
+                "altText": "altText - La carte de base du Canada – transport (CBCT)",
+                "layers": [
+                    {
+                        "id": "CBCT",
+                        "layerType": "esriFeature",
+                        "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBCT3978/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+            },
+            {
+                "id": "baseSimple",
+                "name": "Carte de base du Canada - simple",
+                "description": "La carte de base du Canada - simple",
+                "altText": "altText - La carte de base du Canada - simple",
+                "layers": [
+                    {
+                        "id": "SMR",
+                        "layerType": "esriFeature",
+                        "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer"
+                    },
+                    {
+                        "id": "SMW",
+                        "layerType": "esriFeature",
+                        "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_TXT_3978/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+            },
+            {
+                "id": "baseCBME_CBCE_HS_RO_3978",
+                "name": "Carte de base du Canada - élevation (CBCE)",
+                "description": "La carte de base du Canada - élevation (CBCE) du Secteur des sciences de la Terre de Ressources naturelles Canada est un service Internet qui s'adresse principalement aux utilisateurs et développeurs d'applications cartographiques en ligne.",
+                "altText": "altText - La carte de base du Canada - élevation (CBCE)",
+                "layers": [
+                    {
+                        "id": "CBME_CBCE_HS_RO_3978",
+                        "layerType": "esriFeature",
+                        "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+            },
+            {
+                "id": "baseCBMT_CBCT_GEOM_3978",
+                "name": "Carte de base du Canada - transport (CBCT)",
+                "description": "La carte de base du Canada - transport (CBCT) du Secteur des sciences de la Terre de Ressources naturelles Canada est un service Internet qui s'adresse principalement aux utilisateurs et développeurs d'applications cartographiques en ligne.",
+                "altText": "altText - La carte de base du Canada - transport (CBCT)",
+                "layers": [
+                    {
+                        "id": "CBMT_CBCT_GEOM_3978",
+                        "layerType": "esriFeature",
+                        "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+            },
+            {
+                "id": "baseEsriWorld",
+                "name": "Imagerie mondiale",
+                "description": "L'imagerie mondiale fournit une imagerie satellitaire et aérienne dans de nombreuses régions du monde avec une résolution de 1 mètres et moins et des images satellitaires de résolution inférieure dans le monde entier.",
+                "altText": "altText - L'imagerie mondiale",
+                "layers": [
+                    {
+                        "id": "World_Imagery",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriPhysical",
+                "name": "Monde physique",
+                "description": "La carte du monde physique représente l'aspect physique naturel de la Terre à 1.24 kilomètres par pixel pour le monde et à 500 mètres pour les États-Unis.",
+                "altText": "altText - La carte du monde physique",
+                "layers": [
+                    {
+                        "id": "World_Physical_Map",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Physical_Map/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriRelief",
+                "name": "Monde en relief ombragé",
+                "description": "La carte du monde en relief ombragé représente l'élévation de la surface de la terre comme un relief ombragé. Cette carte est utilisée comme couche de fond afin d'ajouter un relief ombragé à d'autres cartes SIG, comme la carte ArcGIS Online World Street Map.",
+                "altText": "altText - La carte du monde en relief ombragé",
+                "layers": [
+                    {
+                        "id": "World_Shaded_Relief",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Shaded_Relief/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriStreet",
+                "name": "Monde routier",
+                "description": "La carte du monde routier présente des données au niveau des autoroutes pour le monde.",
+                "altText": "altText - La carte du monde routier",
+                "layers": [
+                    {
+                        "id": "World_Street_Map",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Street_Map/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriTerrain",
+                "name": "Monde terrain",
+                "description": "La carte du monde terrain est conçue pour être utilisée comme une carte de base par les professionnels du SIG pour superposer d'autres couches thématiques comme la démographie ou la couverture terrestre.",
+                "altText": "altText - La carte du monde terrain",
+                "layers": [
+                    {
+                        "id": "World_Terrain_Base",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Terrain_Base/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriTopo",
+                "name": "Monde topographique",
+                "description": "La carte du monde topographique est conçue pour être utilisé comme une carte de base par les professionnels du SIG et comme une carte de référence par quiconque.",
+                "altText": "altText - La carte du monde topographique",
+                "layers": [
+                    {
+                        "id": "World_Topo_Map",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
             }
         ]
-      }
-  },
-    "layers": [
-      {
-          "id": "Criteria",
-          
-          "layerType": "esriDynamic",
-          "tolerance": 20,
-          "singleEntryCollapse": true,
-          "symbologyExpanded": true,
-          "url": "https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/StoryRAMP/f6f7baf4_cccb_4521_a037_b4691b0f0d49/MapServer",
-          "state": {
-            "opacity": 0.75
-          },
-          "layerEntries": [
-            {
-              "index": 16,
-              "name": "Éliminations et transferts totaux"
-            }
-          ]            
-      }
-    ],
-    "tileSchemas": [
-      {
-        "id": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978",
-        "name": "Lambert Maps",
-        "extentSetId": "EXT_NRCAN_Lambert_3978",
-        "lodSetId": "LOD_NRCAN_Lambert_3978",
-        "hasNorthPole": true
-      },
-      {
-        "id": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857",
-        "name": "Web Mercator Maps",
-        "extentSetId": "EXT_ESRI_World_AuxMerc_3857",
-        "lodSetId": "LOD_ESRI_World_AuxMerc_3857"
-      }
-    ],
-    "baseMaps": [
-      {
-        "id": "baseNrCan",
-        "name": "Carte de base du Canada – transport (CBCT) avec étiquettes",
-        "description": "La carte de base du Canada – transport (CBCT) du Secteur des sciences de la Terre de Ressources naturelles Canada est un service Internet qui s'adresse principalement aux utilisateurs et développeurs d'applications cartographiques en ligne.",
-        "altText": "altText - La carte de base du Canada – transport (CBCT)",
-        "layers": [
-          {
-            "id": "CBCT",
-            "layerType": "esriFeature",
-            "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBCT3978/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
-      },
-      {
-        "id": "baseSimple",
-        "name": "Carte de base du Canada - simple",
-        "description": "La carte de base du Canada - simple",
-        "altText": "altText - La carte de base du Canada - simple",
-        "layers": [
-          {
-            "id": "SMR",
-            "layerType": "esriFeature",
-            "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer"
-          },
-          {
-            "id": "SMW",
-            "layerType": "esriFeature",
-            "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_TXT_3978/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
-      },
-      {
-        "id": "baseCBME_CBCE_HS_RO_3978",
-        "name": "Carte de base du Canada - élevation (CBCE)",
-        "description": "La carte de base du Canada - élevation (CBCE) du Secteur des sciences de la Terre de Ressources naturelles Canada est un service Internet qui s'adresse principalement aux utilisateurs et développeurs d'applications cartographiques en ligne.",
-        "altText": "altText - La carte de base du Canada - élevation (CBCE)",
-        "layers": [
-          {
-            "id": "CBME_CBCE_HS_RO_3978",
-            "layerType": "esriFeature",
-            "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
-      },
-      {
-        "id": "baseCBMT_CBCT_GEOM_3978",
-        "name": "Carte de base du Canada - transport (CBCT)",
-        "description": "La carte de base du Canada - transport (CBCT) du Secteur des sciences de la Terre de Ressources naturelles Canada est un service Internet qui s'adresse principalement aux utilisateurs et développeurs d'applications cartographiques en ligne.",
-        "altText": "altText - La carte de base du Canada - transport (CBCT)",
-        "layers": [
-          {
-            "id": "CBMT_CBCT_GEOM_3978",
-            "layerType": "esriFeature",
-            "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
-      },
-      {
-        "id": "baseEsriWorld",
-        "name": "Imagerie mondiale",
-        "description": "L'imagerie mondiale fournit une imagerie satellitaire et aérienne dans de nombreuses régions du monde avec une résolution de 1 mètres et moins et des images satellitaires de résolution inférieure dans le monde entier.",
-        "altText": "altText - L'imagerie mondiale",
-        "layers": [
-          {
-            "id": "World_Imagery",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      },
-      {
-        "id": "baseEsriPhysical",
-        "name": "Monde physique",
-        "description": "La carte du monde physique représente l'aspect physique naturel de la Terre à 1.24 kilomètres par pixel pour le monde et à 500 mètres pour les États-Unis.",
-        "altText": "altText - La carte du monde physique",
-        "layers": [
-          {
-            "id": "World_Physical_Map",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Physical_Map/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      },
-      {
-        "id": "baseEsriRelief",
-        "name": "Monde en relief ombragé",
-        "description": "La carte du monde en relief ombragé représente l'élévation de la surface de la terre comme un relief ombragé. Cette carte est utilisée comme couche de fond afin d'ajouter un relief ombragé à d'autres cartes SIG, comme la carte ArcGIS Online World Street Map.",
-        "altText": "altText - La carte du monde en relief ombragé",
-        "layers": [
-          {
-            "id": "World_Shaded_Relief",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Shaded_Relief/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      },
-      {
-        "id": "baseEsriStreet",
-        "name": "Monde routier",
-        "description": "La carte du monde routier présente des données au niveau des autoroutes pour le monde.",
-        "altText": "altText - La carte du monde routier",
-        "layers": [
-          {
-            "id": "World_Street_Map",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Street_Map/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      },
-      {
-        "id": "baseEsriTerrain",
-        "name": "Monde terrain",
-        "description": "La carte du monde terrain est conçue pour être utilisée comme une carte de base par les professionnels du SIG pour superposer d'autres couches thématiques comme la démographie ou la couverture terrestre.",
-        "altText": "altText - La carte du monde terrain",
-        "layers": [
-          {
-            "id": "World_Terrain_Base",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Terrain_Base/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      },
-      {
-        "id": "baseEsriTopo",
-        "name": "Monde topographique",
-        "description": "La carte du monde topographique est conçue pour être utilisé comme une carte de base par les professionnels du SIG et comme une carte de référence par quiconque.",
-        "altText": "altText - La carte du monde topographique",
-        "layers": [
-          {
-            "id": "World_Topo_Map",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      }
-    ]
-  }
+    }
 }

--- a/public/f6f7baf4-cccb-4521-a037-b4691b0f0d49/ramp-config/fr/total_reduced_sulphur_of_pnp_2010-2019.json
+++ b/public/f6f7baf4-cccb-4521-a037-b4691b0f0d49/ramp-config/fr/total_reduced_sulphur_of_pnp_2010-2019.json
@@ -1,513 +1,540 @@
 {
-  "version": "2.0",
-  "language": "fr",
-  "ui": {
-    "title": "Carte interactive",
-    "fullscreen": true,
-    "navBar": {
-      "zoom": "buttons",
-      "extra": [ "fullscreen", "geoLocator", "home", "help" ]
-    },
-    "appBar": {
-      "basemap": true
-
-    },
-    "help": {
-      "folderName": "default"
-    },
-    "sideMenu": {
-      "items": [ [ "fullscreen", "export", "touch", "help", "about" ] ],
-      "logo": false
-    },
-    "legend": {
-      "allowImport": true,
-      "isOpen": {
-        "large": true,
-        "medium": false,
-        "small": false
-      }
-    }
-  },
-  "services": {
-    "proxyUrl": "http://167.40.64.74/wmsproxy/ws/wmsproxy/executeFromProxy",
-    "exportMapUrl": "https://maps-cartes.dev.ec.gc.ca/arcgis/rest/services/Utilities/PrintingTools/GPServer/Export%20Web%20Map%20Task",
-    "export": {
-      "title": {
-        "value": "Rejets de soufre réduit total par les installations de pâtes et papiers déclarant à l’INRP de 2010 à 2019"
-      },
-      "map": {},
-      "mapElements": {},
-      "legend": {},
-      "footnote": {
-        "value": "Rejets de soufre réduit total par les installations de pâtes et papiers déclarant à l’INRP de 2010 à 2019"
-      }
-    },
-    "search": {
-      "settings": {
-        "categories": [ "CITY", "HAM", "IR", "LTM", "MUN1", "MUN2", "PROV", "STM", "TERR", "TOWN", "UTM", "VILG", "UNP" ],
-        "sortOrder": [ "CITY", "HAM", "IR", "LTM", "MUN1", "MUN2", "PROV", "STM", "TERR", "TOWN", "UTM", "VILG", "UNP" ],
-        "maxResults": 1000,
-        "officialOnly": true
-      },	
-      "serviceUrls": {
-        "geoNames": "https://geogratis.gc.ca/services/geoname/en/geonames.json",
-        "geoLocation": "https://geogratis.gc.ca/services/geolocation/en/locate?q=",
-        "geoSuggest": "https://geogratis.gc.ca/services/geolocation/en/suggest?q=",
-        "provinces": "https://geogratis.gc.ca/services/geoname/en/codes/province.json",
-        "types": "https://geogratis.gc.ca/services/geoname/en/codes/concise.json"
-      }
-    }
-  },
-  "map": {
-    "initialBasemapId": "baseNrCan",
-    "components": {
-      "geoSearch": {
-        "enabled": true,
-        "showGraphic": true,
-        "showInfo": true
-      },
-      "mouseInfo": {
-        "enabled": true,
-        "spatialReference": {
-          "wkid": 4326
-        }
-      },
-      "northArrow": {
-        "enabled": false
-      },
-      "basemap": {
-        "enabled": true
-      },
-      "overviewMap": {
-        "enabled": true,
-        "layerType": "imagery"
-      },
-      "scaleBar": {
-        "enabled": true
-      }
-    },
-    "extentSets": [
-      {
-        "id": "EXT_NRCAN_Lambert_3978",
-        "default": {
-          "xmax": 2849492,
-          "xmin": -5281457,
-          "ymax": 4482193,
-          "ymin": -983440
+    "version": "2.0",
+    "language": "fr",
+    "ui": {
+        "title": "Carte interactive",
+        "fullscreen": true,
+        "navBar": {
+            "zoom": "buttons",
+            "extra": ["fullscreen", "geoLocator", "home", "help"]
         },
-        "spatialReference": {
-          "wkid": 3978
-        }
-      },
-      {
-        "id": "EXT_ESRI_World_AuxMerc_3857",
-        "default": {
-          "xmax": -5007771.626060756,
-          "xmin": -16632697.354854,
-          "ymax": 10015875.184845109,
-          "ymin": 5022907.964742964
+        "appBar": {
+            "basemap": true
         },
-        "spatialReference": {
-          "wkid": 102100,
-          "latestWkid": 3857
+        "help": {
+            "folderName": "default"
+        },
+        "sideMenu": {
+            "items": [["fullscreen", "export", "touch", "help", "about"]],
+            "logo": false
+        },
+        "legend": {
+            "allowImport": true,
+            "isOpen": {
+                "large": true,
+                "medium": false,
+                "small": false
+            }
         }
-      }
-    ],
-    "lodSets": [
-      {
-        "id": "LOD_NRCAN_Lambert_3978",
-        "lods": [
-          {
-            "level": 0,
-            "resolution": 38364.660062653464,
-            "scale": 145000000
-          },
-          {
-            "level": 1,
-            "resolution": 22489.628312589961,
-            "scale": 85000000
-          },
-          {
-            "level": 2,
-            "resolution": 13229.193125052918,
-            "scale": 50000000
-          },
-          {
-            "level": 3,
-            "resolution": 7937.5158750317505,
-            "scale": 30000000
-          },
-          {
-            "level": 4,
-            "resolution": 4630.2175937685215,
-            "scale": 17500000
-          },
-          {
-            "level": 5,
-            "resolution": 2645.8386250105837,
-            "scale": 10000000
-          },
-          {
-            "level": 6,
-            "resolution": 1587.5031750063501,
-            "scale": 6000000
-          },
-          {
-            "level": 7,
-            "resolution": 926.04351875370423,
-            "scale": 3500000
-          },
-          {
-            "level": 8,
-            "resolution": 529.16772500211675,
-            "scale": 2000000
-          },
-          {
-            "level": 9,
-            "resolution": 317.50063500127004,
-            "scale": 1200000
-          },
-          {
-            "level": 10,
-            "resolution": 185.20870375074085,
-            "scale": 700000
-          },
-          {
-            "level": 11,
-            "resolution": 111.12522225044451,
-            "scale": 420000
-          },
-          {
-            "level": 12,
-            "resolution": 66.1459656252646,
-            "scale": 250000
-          },
-          {
-            "level": 13,
-            "resolution": 38.364660062653464,
-            "scale": 145000
-          },
-          {
-            "level": 14,
-            "resolution": 22.489628312589961,
-            "scale": 85000
-          },
-          {
-            "level": 15,
-            "resolution": 13.229193125052918,
-            "scale": 50000
-          },
-          {
-            "level": 16,
-            "resolution": 7.9375158750317505,
-            "scale": 30000
-          },
-          {
-            "level": 17,
-            "resolution": 4.6302175937685215,
-            "scale": 17500
-          }
-        ]
-      },
-      {
-        "id": "LOD_ESRI_World_AuxMerc_3857",
-        "lods": [
-          {
-            "level": 0,
-            "resolution": 19567.879240999919,
-            "scale": 73957190.948944
-          },
-          {
-            "level": 1,
-            "resolution": 9783.93962049996,
-            "scale": 36978595.474472
-          },
-          {
-            "level": 2,
-            "resolution": 4891.96981024998,
-            "scale": 18489297.737236
-          },
-          {
-            "level": 3,
-            "resolution": 2445.98490512499,
-            "scale": 9244648.868618
-          },
-          {
-            "level": 4,
-            "resolution": 1222.9924525624949,
-            "scale": 4622324.434309
-          },
-          {
-            "level": 5,
-            "resolution": 611.49622628137968,
-            "scale": 2311162.217155
-          },
-          {
-            "level": 6,
-            "resolution": 305.74811314055756,
-            "scale": 1155581.108577
-          },
-          {
-            "level": 7,
-            "resolution": 152.87405657041106,
-            "scale": 577790.554289
-          },
-          {
-            "level": 8,
-            "resolution": 76.437028285073239,
-            "scale": 288895.277144
-          },
-          {
-            "level": 9,
-            "resolution": 38.21851414253662,
-            "scale": 144447.638572
-          },
-          {
-            "level": 10,
-            "resolution": 19.10925707126831,
-            "scale": 72223.819286
-          },
-          {
-            "level": 11,
-            "resolution": 9.5546285356341549,
-            "scale": 36111.909643
-          },
-          {
-            "level": 12,
-            "resolution": 4.77731426794937,
-            "scale": 18055.954822
-          },
-          {
-            "level": 13,
-            "resolution": 2.3886571339746849,
-            "scale": 9027.977411
-          },
-          {
-            "level": 14,
-            "resolution": 1.1943285668550503,
-            "scale": 4513.988705
-          },
-          {
-            "level": 15,
-            "resolution": 0.59716428355981721,
-            "scale": 2256.994353
-          },
-          {
-            "level": 16,
-            "resolution": 0.29858214164761665,
-            "scale": 1128.497176
-          },
-          {
-            "level": 17,
-            "resolution": 0.14929107082380833,
-            "scale": 564.248588
-          },
-          {
-            "level": 18,
-            "resolution": 0.074645535411904163,
-            "scale": 282.124294
-          },
-          {
-            "level": 19,
-            "resolution": 0.037322767705952081,
-            "scale": 141.062147
-          },
-          {
-            "level": 20,
-            "resolution": 0.018661383852976041,
-            "scale": 70.5310735
-          }
-        ]
-      }
-    ],
-    "legend": {
-      "type": "structured",
-      "root": {
-          "name": "root",
-          "children": [
+    },
+    "services": {
+        "proxyUrl": "http://167.40.64.74/wmsproxy/ws/wmsproxy/executeFromProxy",
+        "exportMapUrl": "https://maps-cartes.dev.ec.gc.ca/arcgis/rest/services/Utilities/PrintingTools/GPServer/Export%20Web%20Map%20Task",
+        "export": {
+            "title": {
+                "value": "Rejets de soufre réduit total par les installations de pâtes et papiers déclarant à l’INRP de 2010 à 2019"
+            },
+            "map": {},
+            "mapElements": {},
+            "legend": {},
+            "footnote": {
+                "value": "Rejets de soufre réduit total par les installations de pâtes et papiers déclarant à l’INRP de 2010 à 2019"
+            }
+        },
+        "search": {
+            "settings": {
+                "categories": [
+                    "CITY",
+                    "HAM",
+                    "IR",
+                    "LTM",
+                    "MUN1",
+                    "MUN2",
+                    "PROV",
+                    "STM",
+                    "TERR",
+                    "TOWN",
+                    "UTM",
+                    "VILG",
+                    "UNP"
+                ],
+                "sortOrder": [
+                    "CITY",
+                    "HAM",
+                    "IR",
+                    "LTM",
+                    "MUN1",
+                    "MUN2",
+                    "PROV",
+                    "STM",
+                    "TERR",
+                    "TOWN",
+                    "UTM",
+                    "VILG",
+                    "UNP"
+                ],
+                "maxResults": 1000,
+                "officialOnly": true
+            },
+            "serviceUrls": {
+                "geoNames": "https://geogratis.gc.ca/services/geoname/en/geonames.json",
+                "geoLocation": "https://geogratis.gc.ca/services/geolocation/en/locate?q=",
+                "geoSuggest": "https://geogratis.gc.ca/services/geolocation/en/suggest?q=",
+                "provinces": "https://geogratis.gc.ca/services/geoname/en/codes/province.json",
+                "types": "https://geogratis.gc.ca/services/geoname/en/codes/concise.json"
+            }
+        }
+    },
+    "map": {
+        "initialBasemapId": "baseNrCan",
+        "components": {
+            "geoSearch": {
+                "enabled": true,
+                "showGraphic": true,
+                "showInfo": true
+            },
+            "mouseInfo": {
+                "enabled": true,
+                "spatialReference": {
+                    "wkid": 4326
+                }
+            },
+            "northArrow": {
+                "enabled": false
+            },
+            "basemap": {
+                "enabled": true
+            },
+            "overviewMap": {
+                "enabled": true,
+                "layerType": "imagery"
+            },
+            "scaleBar": {
+                "enabled": true
+            }
+        },
+        "extentSets": [
             {
-                "layerId": "Sulphur",
-                "description": "Rejets de soufre réduit total par les installations de pâtes et papiers déclarant à l’INRP de 2010 à 2019 (tonnes)",                
-                "symbologyExpanded": true
+                "id": "EXT_NRCAN_Lambert_3978",
+                "default": {
+                    "xmax": 2249492,
+                    "xmin": -5881457,
+                    "ymax": 4482193,
+                    "ymin": -983440
+                },
+                "spatialReference": {
+                    "wkid": 3978
+                }
+            },
+            {
+                "id": "EXT_ESRI_World_AuxMerc_3857",
+                "default": {
+                    "xmax": -5007771.626060756,
+                    "xmin": -16632697.354854,
+                    "ymax": 10015875.184845109,
+                    "ymin": 5022907.964742964
+                },
+                "spatialReference": {
+                    "wkid": 102100,
+                    "latestWkid": 3857
+                }
+            }
+        ],
+        "lodSets": [
+            {
+                "id": "LOD_NRCAN_Lambert_3978",
+                "lods": [
+                    {
+                        "level": 0,
+                        "resolution": 38364.660062653464,
+                        "scale": 145000000
+                    },
+                    {
+                        "level": 1,
+                        "resolution": 22489.628312589961,
+                        "scale": 85000000
+                    },
+                    {
+                        "level": 2,
+                        "resolution": 13229.193125052918,
+                        "scale": 50000000
+                    },
+                    {
+                        "level": 3,
+                        "resolution": 7937.5158750317505,
+                        "scale": 30000000
+                    },
+                    {
+                        "level": 4,
+                        "resolution": 4630.2175937685215,
+                        "scale": 17500000
+                    },
+                    {
+                        "level": 5,
+                        "resolution": 2645.8386250105837,
+                        "scale": 10000000
+                    },
+                    {
+                        "level": 6,
+                        "resolution": 1587.5031750063501,
+                        "scale": 6000000
+                    },
+                    {
+                        "level": 7,
+                        "resolution": 926.04351875370423,
+                        "scale": 3500000
+                    },
+                    {
+                        "level": 8,
+                        "resolution": 529.16772500211675,
+                        "scale": 2000000
+                    },
+                    {
+                        "level": 9,
+                        "resolution": 317.50063500127004,
+                        "scale": 1200000
+                    },
+                    {
+                        "level": 10,
+                        "resolution": 185.20870375074085,
+                        "scale": 700000
+                    },
+                    {
+                        "level": 11,
+                        "resolution": 111.12522225044451,
+                        "scale": 420000
+                    },
+                    {
+                        "level": 12,
+                        "resolution": 66.1459656252646,
+                        "scale": 250000
+                    },
+                    {
+                        "level": 13,
+                        "resolution": 38.364660062653464,
+                        "scale": 145000
+                    },
+                    {
+                        "level": 14,
+                        "resolution": 22.489628312589961,
+                        "scale": 85000
+                    },
+                    {
+                        "level": 15,
+                        "resolution": 13.229193125052918,
+                        "scale": 50000
+                    },
+                    {
+                        "level": 16,
+                        "resolution": 7.9375158750317505,
+                        "scale": 30000
+                    },
+                    {
+                        "level": 17,
+                        "resolution": 4.6302175937685215,
+                        "scale": 17500
+                    }
+                ]
+            },
+            {
+                "id": "LOD_ESRI_World_AuxMerc_3857",
+                "lods": [
+                    {
+                        "level": 0,
+                        "resolution": 19567.879240999919,
+                        "scale": 73957190.948944
+                    },
+                    {
+                        "level": 1,
+                        "resolution": 9783.93962049996,
+                        "scale": 36978595.474472
+                    },
+                    {
+                        "level": 2,
+                        "resolution": 4891.96981024998,
+                        "scale": 18489297.737236
+                    },
+                    {
+                        "level": 3,
+                        "resolution": 2445.98490512499,
+                        "scale": 9244648.868618
+                    },
+                    {
+                        "level": 4,
+                        "resolution": 1222.9924525624949,
+                        "scale": 4622324.434309
+                    },
+                    {
+                        "level": 5,
+                        "resolution": 611.49622628137968,
+                        "scale": 2311162.217155
+                    },
+                    {
+                        "level": 6,
+                        "resolution": 305.74811314055756,
+                        "scale": 1155581.108577
+                    },
+                    {
+                        "level": 7,
+                        "resolution": 152.87405657041106,
+                        "scale": 577790.554289
+                    },
+                    {
+                        "level": 8,
+                        "resolution": 76.437028285073239,
+                        "scale": 288895.277144
+                    },
+                    {
+                        "level": 9,
+                        "resolution": 38.21851414253662,
+                        "scale": 144447.638572
+                    },
+                    {
+                        "level": 10,
+                        "resolution": 19.10925707126831,
+                        "scale": 72223.819286
+                    },
+                    {
+                        "level": 11,
+                        "resolution": 9.5546285356341549,
+                        "scale": 36111.909643
+                    },
+                    {
+                        "level": 12,
+                        "resolution": 4.77731426794937,
+                        "scale": 18055.954822
+                    },
+                    {
+                        "level": 13,
+                        "resolution": 2.3886571339746849,
+                        "scale": 9027.977411
+                    },
+                    {
+                        "level": 14,
+                        "resolution": 1.1943285668550503,
+                        "scale": 4513.988705
+                    },
+                    {
+                        "level": 15,
+                        "resolution": 0.59716428355981721,
+                        "scale": 2256.994353
+                    },
+                    {
+                        "level": 16,
+                        "resolution": 0.29858214164761665,
+                        "scale": 1128.497176
+                    },
+                    {
+                        "level": 17,
+                        "resolution": 0.14929107082380833,
+                        "scale": 564.248588
+                    },
+                    {
+                        "level": 18,
+                        "resolution": 0.074645535411904163,
+                        "scale": 282.124294
+                    },
+                    {
+                        "level": 19,
+                        "resolution": 0.037322767705952081,
+                        "scale": 141.062147
+                    },
+                    {
+                        "level": 20,
+                        "resolution": 0.018661383852976041,
+                        "scale": 70.5310735
+                    }
+                ]
+            }
+        ],
+        "legend": {
+            "type": "structured",
+            "root": {
+                "name": "root",
+                "children": [
+                    {
+                        "layerId": "Sulphur",
+                        "description": "Rejets de soufre réduit total par les installations de pâtes et papiers déclarant à l’INRP de 2010 à 2019 (tonnes)",
+                        "symbologyExpanded": true
+                    }
+                ]
+            }
+        },
+        "layers": [
+            {
+                "id": "Sulphur",
+                "name": "Rejets de soufre réduit total",
+                "layerType": "esriFeature",
+                "tolerance": 20,
+                "singleEntryCollapse": true,
+                "symbologyExpanded": true,
+                "url": "https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/StoryRAMP/f6f7baf4_cccb_4521_a037_b4691b0f0d49/MapServer/13",
+                "state": {
+                    "opacity": 0.75
+                }
+            }
+        ],
+        "tileSchemas": [
+            {
+                "id": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978",
+                "name": "Lambert Maps",
+                "extentSetId": "EXT_NRCAN_Lambert_3978",
+                "lodSetId": "LOD_NRCAN_Lambert_3978",
+                "hasNorthPole": true
+            },
+            {
+                "id": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857",
+                "name": "Web Mercator Maps",
+                "extentSetId": "EXT_ESRI_World_AuxMerc_3857",
+                "lodSetId": "LOD_ESRI_World_AuxMerc_3857"
+            }
+        ],
+        "baseMaps": [
+            {
+                "id": "baseNrCan",
+                "name": "Carte de base du Canada – transport (CBCT) avec étiquettes",
+                "description": "La carte de base du Canada – transport (CBCT) du Secteur des sciences de la Terre de Ressources naturelles Canada est un service Internet qui s'adresse principalement aux utilisateurs et développeurs d'applications cartographiques en ligne.",
+                "altText": "altText - La carte de base du Canada – transport (CBCT)",
+                "layers": [
+                    {
+                        "id": "CBCT",
+                        "layerType": "esriFeature",
+                        "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBCT3978/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+            },
+            {
+                "id": "baseSimple",
+                "name": "Carte de base du Canada - simple",
+                "description": "La carte de base du Canada - simple",
+                "altText": "altText - La carte de base du Canada - simple",
+                "layers": [
+                    {
+                        "id": "SMR",
+                        "layerType": "esriFeature",
+                        "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer"
+                    },
+                    {
+                        "id": "SMW",
+                        "layerType": "esriFeature",
+                        "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_TXT_3978/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+            },
+            {
+                "id": "baseCBME_CBCE_HS_RO_3978",
+                "name": "Carte de base du Canada - élevation (CBCE)",
+                "description": "La carte de base du Canada - élevation (CBCE) du Secteur des sciences de la Terre de Ressources naturelles Canada est un service Internet qui s'adresse principalement aux utilisateurs et développeurs d'applications cartographiques en ligne.",
+                "altText": "altText - La carte de base du Canada - élevation (CBCE)",
+                "layers": [
+                    {
+                        "id": "CBME_CBCE_HS_RO_3978",
+                        "layerType": "esriFeature",
+                        "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+            },
+            {
+                "id": "baseCBMT_CBCT_GEOM_3978",
+                "name": "Carte de base du Canada - transport (CBCT)",
+                "description": "La carte de base du Canada - transport (CBCT) du Secteur des sciences de la Terre de Ressources naturelles Canada est un service Internet qui s'adresse principalement aux utilisateurs et développeurs d'applications cartographiques en ligne.",
+                "altText": "altText - La carte de base du Canada - transport (CBCT)",
+                "layers": [
+                    {
+                        "id": "CBMT_CBCT_GEOM_3978",
+                        "layerType": "esriFeature",
+                        "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+            },
+            {
+                "id": "baseEsriWorld",
+                "name": "Imagerie mondiale",
+                "description": "L'imagerie mondiale fournit une imagerie satellitaire et aérienne dans de nombreuses régions du monde avec une résolution de 1 mètres et moins et des images satellitaires de résolution inférieure dans le monde entier.",
+                "altText": "altText - L'imagerie mondiale",
+                "layers": [
+                    {
+                        "id": "World_Imagery",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriPhysical",
+                "name": "Monde physique",
+                "description": "La carte du monde physique représente l'aspect physique naturel de la Terre à 1.24 kilomètres par pixel pour le monde et à 500 mètres pour les États-Unis.",
+                "altText": "altText - La carte du monde physique",
+                "layers": [
+                    {
+                        "id": "World_Physical_Map",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Physical_Map/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriRelief",
+                "name": "Monde en relief ombragé",
+                "description": "La carte du monde en relief ombragé représente l'élévation de la surface de la terre comme un relief ombragé. Cette carte est utilisée comme couche de fond afin d'ajouter un relief ombragé à d'autres cartes SIG, comme la carte ArcGIS Online World Street Map.",
+                "altText": "altText - La carte du monde en relief ombragé",
+                "layers": [
+                    {
+                        "id": "World_Shaded_Relief",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Shaded_Relief/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriStreet",
+                "name": "Monde routier",
+                "description": "La carte du monde routier présente des données au niveau des autoroutes pour le monde.",
+                "altText": "altText - La carte du monde routier",
+                "layers": [
+                    {
+                        "id": "World_Street_Map",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Street_Map/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriTerrain",
+                "name": "Monde terrain",
+                "description": "La carte du monde terrain est conçue pour être utilisée comme une carte de base par les professionnels du SIG pour superposer d'autres couches thématiques comme la démographie ou la couverture terrestre.",
+                "altText": "altText - La carte du monde terrain",
+                "layers": [
+                    {
+                        "id": "World_Terrain_Base",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Terrain_Base/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriTopo",
+                "name": "Monde topographique",
+                "description": "La carte du monde topographique est conçue pour être utilisé comme une carte de base par les professionnels du SIG et comme une carte de référence par quiconque.",
+                "altText": "altText - La carte du monde topographique",
+                "layers": [
+                    {
+                        "id": "World_Topo_Map",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
             }
         ]
-      }
-  },
-    "layers": [
-      {
-          "id": "Sulphur",
-          "name": "Rejets de soufre réduit total",
-          "layerType": "esriFeature",
-          "tolerance": 20,
-          "singleEntryCollapse": true,
-          "symbologyExpanded": true,
-          "url": "https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/StoryRAMP/f6f7baf4_cccb_4521_a037_b4691b0f0d49/MapServer/13",
-          "state": {
-            "opacity": 0.75
-          }
-      }
-    ],
-    "tileSchemas": [
-      {
-        "id": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978",
-        "name": "Lambert Maps",
-        "extentSetId": "EXT_NRCAN_Lambert_3978",
-        "lodSetId": "LOD_NRCAN_Lambert_3978",
-        "hasNorthPole": true
-      },
-      {
-        "id": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857",
-        "name": "Web Mercator Maps",
-        "extentSetId": "EXT_ESRI_World_AuxMerc_3857",
-        "lodSetId": "LOD_ESRI_World_AuxMerc_3857"
-      }
-    ],
-    "baseMaps": [
-      {
-        "id": "baseNrCan",
-        "name": "Carte de base du Canada – transport (CBCT) avec étiquettes",
-        "description": "La carte de base du Canada – transport (CBCT) du Secteur des sciences de la Terre de Ressources naturelles Canada est un service Internet qui s'adresse principalement aux utilisateurs et développeurs d'applications cartographiques en ligne.",
-        "altText": "altText - La carte de base du Canada – transport (CBCT)",
-        "layers": [
-          {
-            "id": "CBCT",
-            "layerType": "esriFeature",
-            "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBCT3978/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
-      },
-      {
-        "id": "baseSimple",
-        "name": "Carte de base du Canada - simple",
-        "description": "La carte de base du Canada - simple",
-        "altText": "altText - La carte de base du Canada - simple",
-        "layers": [
-          {
-            "id": "SMR",
-            "layerType": "esriFeature",
-            "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer"
-          },
-          {
-            "id": "SMW",
-            "layerType": "esriFeature",
-            "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_TXT_3978/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
-      },
-      {
-        "id": "baseCBME_CBCE_HS_RO_3978",
-        "name": "Carte de base du Canada - élevation (CBCE)",
-        "description": "La carte de base du Canada - élevation (CBCE) du Secteur des sciences de la Terre de Ressources naturelles Canada est un service Internet qui s'adresse principalement aux utilisateurs et développeurs d'applications cartographiques en ligne.",
-        "altText": "altText - La carte de base du Canada - élevation (CBCE)",
-        "layers": [
-          {
-            "id": "CBME_CBCE_HS_RO_3978",
-            "layerType": "esriFeature",
-            "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
-      },
-      {
-        "id": "baseCBMT_CBCT_GEOM_3978",
-        "name": "Carte de base du Canada - transport (CBCT)",
-        "description": "La carte de base du Canada - transport (CBCT) du Secteur des sciences de la Terre de Ressources naturelles Canada est un service Internet qui s'adresse principalement aux utilisateurs et développeurs d'applications cartographiques en ligne.",
-        "altText": "altText - La carte de base du Canada - transport (CBCT)",
-        "layers": [
-          {
-            "id": "CBMT_CBCT_GEOM_3978",
-            "layerType": "esriFeature",
-            "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
-      },
-      {
-        "id": "baseEsriWorld",
-        "name": "Imagerie mondiale",
-        "description": "L'imagerie mondiale fournit une imagerie satellitaire et aérienne dans de nombreuses régions du monde avec une résolution de 1 mètres et moins et des images satellitaires de résolution inférieure dans le monde entier.",
-        "altText": "altText - L'imagerie mondiale",
-        "layers": [
-          {
-            "id": "World_Imagery",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      },
-      {
-        "id": "baseEsriPhysical",
-        "name": "Monde physique",
-        "description": "La carte du monde physique représente l'aspect physique naturel de la Terre à 1.24 kilomètres par pixel pour le monde et à 500 mètres pour les États-Unis.",
-        "altText": "altText - La carte du monde physique",
-        "layers": [
-          {
-            "id": "World_Physical_Map",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Physical_Map/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      },
-      {
-        "id": "baseEsriRelief",
-        "name": "Monde en relief ombragé",
-        "description": "La carte du monde en relief ombragé représente l'élévation de la surface de la terre comme un relief ombragé. Cette carte est utilisée comme couche de fond afin d'ajouter un relief ombragé à d'autres cartes SIG, comme la carte ArcGIS Online World Street Map.",
-        "altText": "altText - La carte du monde en relief ombragé",
-        "layers": [
-          {
-            "id": "World_Shaded_Relief",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Shaded_Relief/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      },
-      {
-        "id": "baseEsriStreet",
-        "name": "Monde routier",
-        "description": "La carte du monde routier présente des données au niveau des autoroutes pour le monde.",
-        "altText": "altText - La carte du monde routier",
-        "layers": [
-          {
-            "id": "World_Street_Map",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Street_Map/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      },
-      {
-        "id": "baseEsriTerrain",
-        "name": "Monde terrain",
-        "description": "La carte du monde terrain est conçue pour être utilisée comme une carte de base par les professionnels du SIG pour superposer d'autres couches thématiques comme la démographie ou la couverture terrestre.",
-        "altText": "altText - La carte du monde terrain",
-        "layers": [
-          {
-            "id": "World_Terrain_Base",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Terrain_Base/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      },
-      {
-        "id": "baseEsriTopo",
-        "name": "Monde topographique",
-        "description": "La carte du monde topographique est conçue pour être utilisé comme une carte de base par les professionnels du SIG et comme une carte de référence par quiconque.",
-        "altText": "altText - La carte du monde topographique",
-        "layers": [
-          {
-            "id": "World_Topo_Map",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      }
-    ]
-  }
+    }
 }

--- a/public/f6f7baf4-cccb-4521-a037-b4691b0f0d49/ramp-config/fr/total_releases_and_disposals_of_pnp_2010-2019.json
+++ b/public/f6f7baf4-cccb-4521-a037-b4691b0f0d49/ramp-config/fr/total_releases_and_disposals_of_pnp_2010-2019.json
@@ -1,518 +1,545 @@
 {
-  "version": "2.0",
-  "language": "fr",
-  "ui": {
-    "title": "Carte interactive",
-    "fullscreen": true,
-    "navBar": {
-      "zoom": "buttons",
-      "extra": [ "fullscreen", "geoLocator", "home", "help" ]
-    },
-    "appBar": {
-      "basemap": true
-
-    },
-    "help": {
-      "folderName": "default"
-    },
-    "sideMenu": {
-      "items": [ [ "fullscreen", "export", "touch", "help", "about" ] ],
-      "logo": false
-    },
-    "legend": {
-      "allowImport": true,
-      "isOpen": {
-        "large": true,
-        "medium": true,
-        "small": false
-      }
-    }
-  },
-  "services": {
-    "proxyUrl": "http://167.40.64.74/wmsproxy/ws/wmsproxy/executeFromProxy",
-    "exportMapUrl": "https://maps-cartes.dev.ec.gc.ca/arcgis/rest/services/Utilities/PrintingTools/GPServer/Export%20Web%20Map%20Task",
-    "export": {
-      "title": {
-        "value": "Rejets et éliminations totaux des installations de pâtes et papiers déclarant à l’INRP de 2010 à 2019"
-      },
-      "map": {},
-      "mapElements": {},
-      "legend": {},
-      "footnote": {
-        "value": "Rejets et éliminations totaux des installations de pâtes et papiers déclarant à l’INRP de 2010 à 2019"
-      }
-    },
-    "search": {
-      "settings": {
-        "categories": [ "CITY", "HAM", "IR", "LTM", "MUN1", "MUN2", "PROV", "STM", "TERR", "TOWN", "UTM", "VILG", "UNP" ],
-        "sortOrder": [ "CITY", "HAM", "IR", "LTM", "MUN1", "MUN2", "PROV", "STM", "TERR", "TOWN", "UTM", "VILG", "UNP" ],
-        "maxResults": 1000,
-        "officialOnly": true
-      },	
-      "serviceUrls": {
-        "geoNames": "https://geogratis.gc.ca/services/geoname/fr/geonames.json",
-        "geoLocation": "https://geogratis.gc.ca/services/geolocation/fr/locate?q=",
-        "geoSuggest": "https://geogratis.gc.ca/services/geolocation/fr/suggest?q=",
-        "provinces": "https://geogratis.gc.ca/services/geoname/fr/codes/province.json",
-        "types": "https://geogratis.gc.ca/services/geoname/fr/codes/concise.json"
-      }
-    }
-  },
-  "map": {
-    "initialBasemapId": "baseNrCan",
-    "components": {
-      "geoSearch": {
-        "enabled": true,
-        "showGraphic": true,
-        "showInfo": true
-      },
-      "mouseInfo": {
-        "enabled": true,
-        "spatialReference": {
-          "wkid": 4326
-        }
-      },
-      "northArrow": {
-        "enabled": false
-      },
-      "basemap": {
-        "enabled": true
-      },
-      "overviewMap": {
-        "enabled": true,
-        "layerType": "imagery"
-      },
-      "scaleBar": {
-        "enabled": true
-      }
-    },
-    "extentSets": [
-      {
-        "id": "EXT_NRCAN_Lambert_3978",
-        "default": {
-          "xmax": 2849492,
-          "xmin": -5281457,
-          "ymax": 4482193,
-          "ymin": -983440
+    "version": "2.0",
+    "language": "fr",
+    "ui": {
+        "title": "Carte interactive",
+        "fullscreen": true,
+        "navBar": {
+            "zoom": "buttons",
+            "extra": ["fullscreen", "geoLocator", "home", "help"]
         },
-        "spatialReference": {
-          "wkid": 3978
-        }
-      },
-      {
-        "id": "EXT_ESRI_World_AuxMerc_3857",
-        "default": {
-          "xmax": -5007771.626060756,
-          "xmin": -16632697.354854,
-          "ymax": 10015875.184845109,
-          "ymin": 5022907.964742964
+        "appBar": {
+            "basemap": true
         },
-        "spatialReference": {
-          "wkid": 102100,
-          "latestWkid": 3857
+        "help": {
+            "folderName": "default"
+        },
+        "sideMenu": {
+            "items": [["fullscreen", "export", "touch", "help", "about"]],
+            "logo": false
+        },
+        "legend": {
+            "allowImport": true,
+            "isOpen": {
+                "large": true,
+                "medium": true,
+                "small": false
+            }
         }
-      }
-    ],
-    "lodSets": [
-      {
-        "id": "LOD_NRCAN_Lambert_3978",
-        "lods": [
-          {
-            "level": 0,
-            "resolution": 38364.660062653464,
-            "scale": 145000000
-          },
-          {
-            "level": 1,
-            "resolution": 22489.628312589961,
-            "scale": 85000000
-          },
-          {
-            "level": 2,
-            "resolution": 13229.193125052918,
-            "scale": 50000000
-          },
-          {
-            "level": 3,
-            "resolution": 7937.5158750317505,
-            "scale": 30000000
-          },
-          {
-            "level": 4,
-            "resolution": 4630.2175937685215,
-            "scale": 17500000
-          },
-          {
-            "level": 5,
-            "resolution": 2645.8386250105837,
-            "scale": 10000000
-          },
-          {
-            "level": 6,
-            "resolution": 1587.5031750063501,
-            "scale": 6000000
-          },
-          {
-            "level": 7,
-            "resolution": 926.04351875370423,
-            "scale": 3500000
-          },
-          {
-            "level": 8,
-            "resolution": 529.16772500211675,
-            "scale": 2000000
-          },
-          {
-            "level": 9,
-            "resolution": 317.50063500127004,
-            "scale": 1200000
-          },
-          {
-            "level": 10,
-            "resolution": 185.20870375074085,
-            "scale": 700000
-          },
-          {
-            "level": 11,
-            "resolution": 111.12522225044451,
-            "scale": 420000
-          },
-          {
-            "level": 12,
-            "resolution": 66.1459656252646,
-            "scale": 250000
-          },
-          {
-            "level": 13,
-            "resolution": 38.364660062653464,
-            "scale": 145000
-          },
-          {
-            "level": 14,
-            "resolution": 22.489628312589961,
-            "scale": 85000
-          },
-          {
-            "level": 15,
-            "resolution": 13.229193125052918,
-            "scale": 50000
-          },
-          {
-            "level": 16,
-            "resolution": 7.9375158750317505,
-            "scale": 30000
-          },
-          {
-            "level": 17,
-            "resolution": 4.6302175937685215,
-            "scale": 17500
-          }
-        ]
-      },
-      {
-        "id": "LOD_ESRI_World_AuxMerc_3857",
-        "lods": [
-          {
-            "level": 0,
-            "resolution": 19567.879240999919,
-            "scale": 73957190.948944
-          },
-          {
-            "level": 1,
-            "resolution": 9783.93962049996,
-            "scale": 36978595.474472
-          },
-          {
-            "level": 2,
-            "resolution": 4891.96981024998,
-            "scale": 18489297.737236
-          },
-          {
-            "level": 3,
-            "resolution": 2445.98490512499,
-            "scale": 9244648.868618
-          },
-          {
-            "level": 4,
-            "resolution": 1222.9924525624949,
-            "scale": 4622324.434309
-          },
-          {
-            "level": 5,
-            "resolution": 611.49622628137968,
-            "scale": 2311162.217155
-          },
-          {
-            "level": 6,
-            "resolution": 305.74811314055756,
-            "scale": 1155581.108577
-          },
-          {
-            "level": 7,
-            "resolution": 152.87405657041106,
-            "scale": 577790.554289
-          },
-          {
-            "level": 8,
-            "resolution": 76.437028285073239,
-            "scale": 288895.277144
-          },
-          {
-            "level": 9,
-            "resolution": 38.21851414253662,
-            "scale": 144447.638572
-          },
-          {
-            "level": 10,
-            "resolution": 19.10925707126831,
-            "scale": 72223.819286
-          },
-          {
-            "level": 11,
-            "resolution": 9.5546285356341549,
-            "scale": 36111.909643
-          },
-          {
-            "level": 12,
-            "resolution": 4.77731426794937,
-            "scale": 18055.954822
-          },
-          {
-            "level": 13,
-            "resolution": 2.3886571339746849,
-            "scale": 9027.977411
-          },
-          {
-            "level": 14,
-            "resolution": 1.1943285668550503,
-            "scale": 4513.988705
-          },
-          {
-            "level": 15,
-            "resolution": 0.59716428355981721,
-            "scale": 2256.994353
-          },
-          {
-            "level": 16,
-            "resolution": 0.29858214164761665,
-            "scale": 1128.497176
-          },
-          {
-            "level": 17,
-            "resolution": 0.14929107082380833,
-            "scale": 564.248588
-          },
-          {
-            "level": 18,
-            "resolution": 0.074645535411904163,
-            "scale": 282.124294
-          },
-          {
-            "level": 19,
-            "resolution": 0.037322767705952081,
-            "scale": 141.062147
-          },
-          {
-            "level": 20,
-            "resolution": 0.018661383852976041,
-            "scale": 70.5310735
-          }
-        ]
-      }
-    ],
-    "legend": {
-      "type": "structured",
-      "root": {
-          "name": "root",
-          "children": [
+    },
+    "services": {
+        "proxyUrl": "http://167.40.64.74/wmsproxy/ws/wmsproxy/executeFromProxy",
+        "exportMapUrl": "https://maps-cartes.dev.ec.gc.ca/arcgis/rest/services/Utilities/PrintingTools/GPServer/Export%20Web%20Map%20Task",
+        "export": {
+            "title": {
+                "value": "Rejets et éliminations totaux des installations de pâtes et papiers déclarant à l’INRP de 2010 à 2019"
+            },
+            "map": {},
+            "mapElements": {},
+            "legend": {},
+            "footnote": {
+                "value": "Rejets et éliminations totaux des installations de pâtes et papiers déclarant à l’INRP de 2010 à 2019"
+            }
+        },
+        "search": {
+            "settings": {
+                "categories": [
+                    "CITY",
+                    "HAM",
+                    "IR",
+                    "LTM",
+                    "MUN1",
+                    "MUN2",
+                    "PROV",
+                    "STM",
+                    "TERR",
+                    "TOWN",
+                    "UTM",
+                    "VILG",
+                    "UNP"
+                ],
+                "sortOrder": [
+                    "CITY",
+                    "HAM",
+                    "IR",
+                    "LTM",
+                    "MUN1",
+                    "MUN2",
+                    "PROV",
+                    "STM",
+                    "TERR",
+                    "TOWN",
+                    "UTM",
+                    "VILG",
+                    "UNP"
+                ],
+                "maxResults": 1000,
+                "officialOnly": true
+            },
+            "serviceUrls": {
+                "geoNames": "https://geogratis.gc.ca/services/geoname/fr/geonames.json",
+                "geoLocation": "https://geogratis.gc.ca/services/geolocation/fr/locate?q=",
+                "geoSuggest": "https://geogratis.gc.ca/services/geolocation/fr/suggest?q=",
+                "provinces": "https://geogratis.gc.ca/services/geoname/fr/codes/province.json",
+                "types": "https://geogratis.gc.ca/services/geoname/fr/codes/concise.json"
+            }
+        }
+    },
+    "map": {
+        "initialBasemapId": "baseNrCan",
+        "components": {
+            "geoSearch": {
+                "enabled": true,
+                "showGraphic": true,
+                "showInfo": true
+            },
+            "mouseInfo": {
+                "enabled": true,
+                "spatialReference": {
+                    "wkid": 4326
+                }
+            },
+            "northArrow": {
+                "enabled": false
+            },
+            "basemap": {
+                "enabled": true
+            },
+            "overviewMap": {
+                "enabled": true,
+                "layerType": "imagery"
+            },
+            "scaleBar": {
+                "enabled": true
+            }
+        },
+        "extentSets": [
             {
-                "layerId": "Releases",
-                "description": "Rejets et éliminations totaux des installations de pâtes et papiers déclarant à l’INRP de 2010 à 2019 (tonnes)",                
-                "symbologyExpanded": true
+                "id": "EXT_NRCAN_Lambert_3978",
+                "default": {
+                    "xmax": 2249492,
+                    "xmin": -5881457,
+                    "ymax": 4482193,
+                    "ymin": -983440
+                },
+                "spatialReference": {
+                    "wkid": 3978
+                }
+            },
+            {
+                "id": "EXT_ESRI_World_AuxMerc_3857",
+                "default": {
+                    "xmax": -5007771.626060756,
+                    "xmin": -16632697.354854,
+                    "ymax": 10015875.184845109,
+                    "ymin": 5022907.964742964
+                },
+                "spatialReference": {
+                    "wkid": 102100,
+                    "latestWkid": 3857
+                }
+            }
+        ],
+        "lodSets": [
+            {
+                "id": "LOD_NRCAN_Lambert_3978",
+                "lods": [
+                    {
+                        "level": 0,
+                        "resolution": 38364.660062653464,
+                        "scale": 145000000
+                    },
+                    {
+                        "level": 1,
+                        "resolution": 22489.628312589961,
+                        "scale": 85000000
+                    },
+                    {
+                        "level": 2,
+                        "resolution": 13229.193125052918,
+                        "scale": 50000000
+                    },
+                    {
+                        "level": 3,
+                        "resolution": 7937.5158750317505,
+                        "scale": 30000000
+                    },
+                    {
+                        "level": 4,
+                        "resolution": 4630.2175937685215,
+                        "scale": 17500000
+                    },
+                    {
+                        "level": 5,
+                        "resolution": 2645.8386250105837,
+                        "scale": 10000000
+                    },
+                    {
+                        "level": 6,
+                        "resolution": 1587.5031750063501,
+                        "scale": 6000000
+                    },
+                    {
+                        "level": 7,
+                        "resolution": 926.04351875370423,
+                        "scale": 3500000
+                    },
+                    {
+                        "level": 8,
+                        "resolution": 529.16772500211675,
+                        "scale": 2000000
+                    },
+                    {
+                        "level": 9,
+                        "resolution": 317.50063500127004,
+                        "scale": 1200000
+                    },
+                    {
+                        "level": 10,
+                        "resolution": 185.20870375074085,
+                        "scale": 700000
+                    },
+                    {
+                        "level": 11,
+                        "resolution": 111.12522225044451,
+                        "scale": 420000
+                    },
+                    {
+                        "level": 12,
+                        "resolution": 66.1459656252646,
+                        "scale": 250000
+                    },
+                    {
+                        "level": 13,
+                        "resolution": 38.364660062653464,
+                        "scale": 145000
+                    },
+                    {
+                        "level": 14,
+                        "resolution": 22.489628312589961,
+                        "scale": 85000
+                    },
+                    {
+                        "level": 15,
+                        "resolution": 13.229193125052918,
+                        "scale": 50000
+                    },
+                    {
+                        "level": 16,
+                        "resolution": 7.9375158750317505,
+                        "scale": 30000
+                    },
+                    {
+                        "level": 17,
+                        "resolution": 4.6302175937685215,
+                        "scale": 17500
+                    }
+                ]
+            },
+            {
+                "id": "LOD_ESRI_World_AuxMerc_3857",
+                "lods": [
+                    {
+                        "level": 0,
+                        "resolution": 19567.879240999919,
+                        "scale": 73957190.948944
+                    },
+                    {
+                        "level": 1,
+                        "resolution": 9783.93962049996,
+                        "scale": 36978595.474472
+                    },
+                    {
+                        "level": 2,
+                        "resolution": 4891.96981024998,
+                        "scale": 18489297.737236
+                    },
+                    {
+                        "level": 3,
+                        "resolution": 2445.98490512499,
+                        "scale": 9244648.868618
+                    },
+                    {
+                        "level": 4,
+                        "resolution": 1222.9924525624949,
+                        "scale": 4622324.434309
+                    },
+                    {
+                        "level": 5,
+                        "resolution": 611.49622628137968,
+                        "scale": 2311162.217155
+                    },
+                    {
+                        "level": 6,
+                        "resolution": 305.74811314055756,
+                        "scale": 1155581.108577
+                    },
+                    {
+                        "level": 7,
+                        "resolution": 152.87405657041106,
+                        "scale": 577790.554289
+                    },
+                    {
+                        "level": 8,
+                        "resolution": 76.437028285073239,
+                        "scale": 288895.277144
+                    },
+                    {
+                        "level": 9,
+                        "resolution": 38.21851414253662,
+                        "scale": 144447.638572
+                    },
+                    {
+                        "level": 10,
+                        "resolution": 19.10925707126831,
+                        "scale": 72223.819286
+                    },
+                    {
+                        "level": 11,
+                        "resolution": 9.5546285356341549,
+                        "scale": 36111.909643
+                    },
+                    {
+                        "level": 12,
+                        "resolution": 4.77731426794937,
+                        "scale": 18055.954822
+                    },
+                    {
+                        "level": 13,
+                        "resolution": 2.3886571339746849,
+                        "scale": 9027.977411
+                    },
+                    {
+                        "level": 14,
+                        "resolution": 1.1943285668550503,
+                        "scale": 4513.988705
+                    },
+                    {
+                        "level": 15,
+                        "resolution": 0.59716428355981721,
+                        "scale": 2256.994353
+                    },
+                    {
+                        "level": 16,
+                        "resolution": 0.29858214164761665,
+                        "scale": 1128.497176
+                    },
+                    {
+                        "level": 17,
+                        "resolution": 0.14929107082380833,
+                        "scale": 564.248588
+                    },
+                    {
+                        "level": 18,
+                        "resolution": 0.074645535411904163,
+                        "scale": 282.124294
+                    },
+                    {
+                        "level": 19,
+                        "resolution": 0.037322767705952081,
+                        "scale": 141.062147
+                    },
+                    {
+                        "level": 20,
+                        "resolution": 0.018661383852976041,
+                        "scale": 70.5310735
+                    }
+                ]
+            }
+        ],
+        "legend": {
+            "type": "structured",
+            "root": {
+                "name": "root",
+                "children": [
+                    {
+                        "layerId": "Releases",
+                        "description": "Rejets et éliminations totaux des installations de pâtes et papiers déclarant à l’INRP de 2010 à 2019 (tonnes)",
+                        "symbologyExpanded": true
+                    }
+                ]
+            }
+        },
+        "layers": [
+            {
+                "id": "Releases",
+                "layerType": "esriDynamic",
+                "tolerance": 20,
+                "singleEntryCollapse": true,
+                "symbologyExpanded": true,
+                "url": "https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/StoryRAMP/f6f7baf4_cccb_4521_a037_b4691b0f0d49/MapServer",
+                "state": {
+                    "opacity": 0.75
+                },
+                "layerEntries": [
+                    {
+                        "index": 11,
+                        "name": "Rejets et éliminations totaux"
+                    }
+                ]
+            }
+        ],
+        "tileSchemas": [
+            {
+                "id": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978",
+                "name": "Lambert Maps",
+                "extentSetId": "EXT_NRCAN_Lambert_3978",
+                "lodSetId": "LOD_NRCAN_Lambert_3978",
+                "hasNorthPole": true
+            },
+            {
+                "id": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857",
+                "name": "Web Mercator Maps",
+                "extentSetId": "EXT_ESRI_World_AuxMerc_3857",
+                "lodSetId": "LOD_ESRI_World_AuxMerc_3857"
+            }
+        ],
+        "baseMaps": [
+            {
+                "id": "baseNrCan",
+                "name": "Carte de base du Canada – transport (CBCT) avec étiquettes",
+                "description": "La carte de base du Canada – transport (CBCT) du Secteur des sciences de la Terre de Ressources naturelles Canada est un service Internet qui s'adresse principalement aux utilisateurs et développeurs d'applications cartographiques en ligne.",
+                "altText": "altText - La carte de base du Canada – transport (CBCT)",
+                "layers": [
+                    {
+                        "id": "CBCT",
+                        "layerType": "esriFeature",
+                        "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBCT3978/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+            },
+            {
+                "id": "baseSimple",
+                "name": "Carte de base du Canada - simple",
+                "description": "La carte de base du Canada - simple",
+                "altText": "altText - La carte de base du Canada - simple",
+                "layers": [
+                    {
+                        "id": "SMR",
+                        "layerType": "esriFeature",
+                        "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer"
+                    },
+                    {
+                        "id": "SMW",
+                        "layerType": "esriFeature",
+                        "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_TXT_3978/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+            },
+            {
+                "id": "baseCBME_CBCE_HS_RO_3978",
+                "name": "Carte de base du Canada - élevation (CBCE)",
+                "description": "La carte de base du Canada - élevation (CBCE) du Secteur des sciences de la Terre de Ressources naturelles Canada est un service Internet qui s'adresse principalement aux utilisateurs et développeurs d'applications cartographiques en ligne.",
+                "altText": "altText - La carte de base du Canada - élevation (CBCE)",
+                "layers": [
+                    {
+                        "id": "CBME_CBCE_HS_RO_3978",
+                        "layerType": "esriFeature",
+                        "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+            },
+            {
+                "id": "baseCBMT_CBCT_GEOM_3978",
+                "name": "Carte de base du Canada - transport (CBCT)",
+                "description": "La carte de base du Canada - transport (CBCT) du Secteur des sciences de la Terre de Ressources naturelles Canada est un service Internet qui s'adresse principalement aux utilisateurs et développeurs d'applications cartographiques en ligne.",
+                "altText": "altText - La carte de base du Canada - transport (CBCT)",
+                "layers": [
+                    {
+                        "id": "CBMT_CBCT_GEOM_3978",
+                        "layerType": "esriFeature",
+                        "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+            },
+            {
+                "id": "baseEsriWorld",
+                "name": "Imagerie mondiale",
+                "description": "L'imagerie mondiale fournit une imagerie satellitaire et aérienne dans de nombreuses régions du monde avec une résolution de 1 mètres et moins et des images satellitaires de résolution inférieure dans le monde entier.",
+                "altText": "altText - L'imagerie mondiale",
+                "layers": [
+                    {
+                        "id": "World_Imagery",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriPhysical",
+                "name": "Monde physique",
+                "description": "La carte du monde physique représente l'aspect physique naturel de la Terre à 1.24 kilomètres par pixel pour le monde et à 500 mètres pour les États-Unis.",
+                "altText": "altText - La carte du monde physique",
+                "layers": [
+                    {
+                        "id": "World_Physical_Map",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Physical_Map/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriRelief",
+                "name": "Monde en relief ombragé",
+                "description": "La carte du monde en relief ombragé représente l'élévation de la surface de la terre comme un relief ombragé. Cette carte est utilisée comme couche de fond afin d'ajouter un relief ombragé à d'autres cartes SIG, comme la carte ArcGIS Online World Street Map.",
+                "altText": "altText - La carte du monde en relief ombragé",
+                "layers": [
+                    {
+                        "id": "World_Shaded_Relief",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Shaded_Relief/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriStreet",
+                "name": "Monde routier",
+                "description": "La carte du monde routier présente des données au niveau des autoroutes pour le monde.",
+                "altText": "altText - La carte du monde routier",
+                "layers": [
+                    {
+                        "id": "World_Street_Map",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Street_Map/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriTerrain",
+                "name": "Monde terrain",
+                "description": "La carte du monde terrain est conçue pour être utilisée comme une carte de base par les professionnels du SIG pour superposer d'autres couches thématiques comme la démographie ou la couverture terrestre.",
+                "altText": "altText - La carte du monde terrain",
+                "layers": [
+                    {
+                        "id": "World_Terrain_Base",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Terrain_Base/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriTopo",
+                "name": "Monde topographique",
+                "description": "La carte du monde topographique est conçue pour être utilisé comme une carte de base par les professionnels du SIG et comme une carte de référence par quiconque.",
+                "altText": "altText - La carte du monde topographique",
+                "layers": [
+                    {
+                        "id": "World_Topo_Map",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
             }
         ]
-      }
-  },
-    "layers": [
-      {
-          "id": "Releases",
-          "layerType": "esriDynamic",
-          "tolerance": 20,
-          "singleEntryCollapse": true,
-          "symbologyExpanded": true,
-          "url": "https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/StoryRAMP/f6f7baf4_cccb_4521_a037_b4691b0f0d49/MapServer",
-          "state": {
-            "opacity": 0.75
-          },
-          "layerEntries": [
-            {
-              "index": 11,
-              "name": "Rejets et éliminations totaux"              
-            }
-          ]  
-      }
-    ],
-    "tileSchemas": [
-      {
-        "id": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978",
-        "name": "Lambert Maps",
-        "extentSetId": "EXT_NRCAN_Lambert_3978",
-        "lodSetId": "LOD_NRCAN_Lambert_3978",
-        "hasNorthPole": true
-      },
-      {
-        "id": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857",
-        "name": "Web Mercator Maps",
-        "extentSetId": "EXT_ESRI_World_AuxMerc_3857",
-        "lodSetId": "LOD_ESRI_World_AuxMerc_3857"
-      }
-    ],
-    "baseMaps": [
-      {
-        "id": "baseNrCan",
-        "name": "Carte de base du Canada – transport (CBCT) avec étiquettes",
-        "description": "La carte de base du Canada – transport (CBCT) du Secteur des sciences de la Terre de Ressources naturelles Canada est un service Internet qui s'adresse principalement aux utilisateurs et développeurs d'applications cartographiques en ligne.",
-        "altText": "altText - La carte de base du Canada – transport (CBCT)",
-        "layers": [
-          {
-            "id": "CBCT",
-            "layerType": "esriFeature",
-            "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBCT3978/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
-      },
-      {
-        "id": "baseSimple",
-        "name": "Carte de base du Canada - simple",
-        "description": "La carte de base du Canada - simple",
-        "altText": "altText - La carte de base du Canada - simple",
-        "layers": [
-          {
-            "id": "SMR",
-            "layerType": "esriFeature",
-            "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer"
-          },
-          {
-            "id": "SMW",
-            "layerType": "esriFeature",
-            "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_TXT_3978/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
-      },
-      {
-        "id": "baseCBME_CBCE_HS_RO_3978",
-        "name": "Carte de base du Canada - élevation (CBCE)",
-        "description": "La carte de base du Canada - élevation (CBCE) du Secteur des sciences de la Terre de Ressources naturelles Canada est un service Internet qui s'adresse principalement aux utilisateurs et développeurs d'applications cartographiques en ligne.",
-        "altText": "altText - La carte de base du Canada - élevation (CBCE)",
-        "layers": [
-          {
-            "id": "CBME_CBCE_HS_RO_3978",
-            "layerType": "esriFeature",
-            "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
-      },
-      {
-        "id": "baseCBMT_CBCT_GEOM_3978",
-        "name": "Carte de base du Canada - transport (CBCT)",
-        "description": "La carte de base du Canada - transport (CBCT) du Secteur des sciences de la Terre de Ressources naturelles Canada est un service Internet qui s'adresse principalement aux utilisateurs et développeurs d'applications cartographiques en ligne.",
-        "altText": "altText - La carte de base du Canada - transport (CBCT)",
-        "layers": [
-          {
-            "id": "CBMT_CBCT_GEOM_3978",
-            "layerType": "esriFeature",
-            "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
-      },
-      {
-        "id": "baseEsriWorld",
-        "name": "Imagerie mondiale",
-        "description": "L'imagerie mondiale fournit une imagerie satellitaire et aérienne dans de nombreuses régions du monde avec une résolution de 1 mètres et moins et des images satellitaires de résolution inférieure dans le monde entier.",
-        "altText": "altText - L'imagerie mondiale",
-        "layers": [
-          {
-            "id": "World_Imagery",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      },
-      {
-        "id": "baseEsriPhysical",
-        "name": "Monde physique",
-        "description": "La carte du monde physique représente l'aspect physique naturel de la Terre à 1.24 kilomètres par pixel pour le monde et à 500 mètres pour les États-Unis.",
-        "altText": "altText - La carte du monde physique",
-        "layers": [
-          {
-            "id": "World_Physical_Map",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Physical_Map/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      },
-      {
-        "id": "baseEsriRelief",
-        "name": "Monde en relief ombragé",
-        "description": "La carte du monde en relief ombragé représente l'élévation de la surface de la terre comme un relief ombragé. Cette carte est utilisée comme couche de fond afin d'ajouter un relief ombragé à d'autres cartes SIG, comme la carte ArcGIS Online World Street Map.",
-        "altText": "altText - La carte du monde en relief ombragé",
-        "layers": [
-          {
-            "id": "World_Shaded_Relief",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Shaded_Relief/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      },
-      {
-        "id": "baseEsriStreet",
-        "name": "Monde routier",
-        "description": "La carte du monde routier présente des données au niveau des autoroutes pour le monde.",
-        "altText": "altText - La carte du monde routier",
-        "layers": [
-          {
-            "id": "World_Street_Map",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Street_Map/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      },
-      {
-        "id": "baseEsriTerrain",
-        "name": "Monde terrain",
-        "description": "La carte du monde terrain est conçue pour être utilisée comme une carte de base par les professionnels du SIG pour superposer d'autres couches thématiques comme la démographie ou la couverture terrestre.",
-        "altText": "altText - La carte du monde terrain",
-        "layers": [
-          {
-            "id": "World_Terrain_Base",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Terrain_Base/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      },
-      {
-        "id": "baseEsriTopo",
-        "name": "Monde topographique",
-        "description": "La carte du monde topographique est conçue pour être utilisé comme une carte de base par les professionnels du SIG et comme une carte de référence par quiconque.",
-        "altText": "altText - La carte du monde topographique",
-        "layers": [
-          {
-            "id": "World_Topo_Map",
-            "layerType": "esriFeature",
-            "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer"
-          }
-        ],
-        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-      }
-    ]
-  }
+    }
 }


### PR DESCRIPTION
Closes #145 

In this PR, I've modified the starting extents for each of the RAMP3 configs that default to having the legend open so that as little data as possible is covered by the legend on small resolutions.

None of the map extents should have changed significantly. I tried my best to make sure the modifications were all *just* enough so that most of the points could appear without being blocked.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/177)
<!-- Reviewable:end -->
