### PR TITLE
Make charts fully responsive and fix dynamic panels on mobile

### DIFF
--- a/src/components/panels/chart-panel.vue
+++ b/src/components/panels/chart-panel.vue
@@ -1,9 +1,9 @@
 <template>
-    <div class="self-start w-full px-10 my-8 bg-gray-200_ h-28_" :style="{ width: `${width}px` }">
+    <div class="carousel self-start px-10 my-8 bg-gray-200_" :style="{ width: `${width}px` }">
         <hooper
             ref="carousel"
             v-if="width !== -1 && config.charts.length > 1"
-            class="h-auto"
+            class="h-full"
             :infiniteScroll="config.loop"
         >
             <slide
@@ -52,17 +52,6 @@ export default class ChartPanelV extends Vue {
         setTimeout(() => {
             this.width = this.$el.clientWidth;
         }, 100);
-
-        // window.addEventListener('resize', () => {
-        //     // adjust width for mobile resolutions
-        //     if (window.innerWidth > 640) {
-        //         this.width = 1121;
-        //         console.log('NORMAL SCREEN: ', this.width);
-        //     } else {
-        //         this.width = 0.97 * window.innerWidth;
-        //         console.log('MOBILE SCREEN: ', this.width);
-        //     }
-        // });
     }
 }
 </script>
@@ -92,6 +81,14 @@ export default class ChartPanelV extends Vue {
             // background-color: lighten(#00d2d3, 20%);
             border-color: var(--sr-accent-colour);
         }
+    }
+}
+
+@media screen and (max-width: 640px) {
+    .carousel {
+        max-width: 100vw;
+        max-height: 50vh;
+        background-color: white;
     }
 }
 </style>

--- a/src/components/panels/dynamic-panel.vue
+++ b/src/components/panels/dynamic-panel.vue
@@ -1,13 +1,13 @@
 <template>
-    <div :id="this.$vnode.key" class="story-slide w-full h-full flex flex-row">
-        <Scrollama class="flex-1 prose max-w-none my-5">
+    <div :id="this.$vnode.key" class="story-slide w-full h-full flex sm:flex-row flex-col">
+        <Scrollama class="flex-1 order-2 sm:order-1 prose max-w-none my-5">
             <h2 class="px-10 mb-0 chapter-title top-20">
                 {{ config.title }}
             </h2>
 
             <div class="px-10 md-content" v-html="md.render(config.content)"></div>
         </Scrollama>
-        <panel class="flex-2" :config="activeConfig" :ratio="false"></panel>
+        <panel class="dynamic-content flex-2" :config="activeConfig" :ratio="false"></panel>
     </div>
 </template>
 
@@ -62,4 +62,10 @@ export default class DynamicPanelV extends Vue {
 }
 </script>
 
-<style scoped lang="scss"></style>
+<style scoped lang="scss">
+@media screen and (max-width: 640px) {
+    .dynamic-content {
+        max-height: 40vh;
+    }
+}
+</style>

--- a/src/components/panels/helpers/chart.vue
+++ b/src/components/panels/helpers/chart.vue
@@ -61,6 +61,17 @@ export default class ChartV extends Vue {
         }
     }
 
+    mounted(): void {
+        setTimeout(() => {
+            (this.$refs.chart as any).chart.reflow();
+        }, 100);
+
+        window.addEventListener('resize', () => {
+            // adjust width for mobile resolutions
+            (this.$refs.chart as any).chart.reflow();
+        });
+    }
+
     /**
      * Parse and process CSV file contents and return a properly configured highcharts options object.
      */
@@ -81,9 +92,11 @@ export default class ChartV extends Vue {
             // extract general chart options that applies to all chart types
             const defaultOptions = {
                 chart: {
+                    renderTo: 'dv-chart-container',
                     type: dqvOptions?.type,
-                    ...(dqvOptions?.height && { height: dqvOptions?.height }),
-                    ...(dqvOptions?.width && { width: dqvOptions?.width })
+                    ...(dqvOptions?.height &&
+                        this.$el.clientHeight > dqvOptions?.height && { height: dqvOptions?.height }),
+                    ...(dqvOptions?.width && this.$el.clientWidth > dqvOptions?.width && { width: dqvOptions?.width })
                 },
                 ...(dqvOptions?.title && { title: { text: dqvOptions?.title } }),
                 ...(dqvOptions?.subtitle && { subtitle: { text: dqvOptions?.subtitle } }),
@@ -193,14 +206,12 @@ export default class ChartV extends Vue {
 
 @media screen and (max-width: 640px) {
     .dv-chart {
-        max-width: 100vw;
-        max-height: 40vh;
         background-color: white;
     }
 
     .dv-chart-container {
-        // height: 100%;
-        width: 100%;
+        width: 100% !important;
+        height: 100% !important;
     }
 }
 </style>

--- a/src/components/panels/slideshow-panel.vue
+++ b/src/components/panels/slideshow-panel.vue
@@ -51,19 +51,6 @@ export default class SlideshowPanelV extends Vue {
         setTimeout(() => {
             this.width = this.$el.clientWidth;
         }, 100);
-
-        // window.addEventListener('resize', () => {
-        //     setTimeout(() => {
-        //         // adjust width for mobile resolutions
-        //         if (window.innerWidth > 640) {
-        //             this.width = 1121;
-        //             console.log('NORMAL SCREEN: ', this.width);
-        //         } else {
-        //             this.width = 0.97 * window.innerWidth;
-        //             console.log('MOBILE SCREEN: ', this.width);
-        //         }
-        //     }, 100);
-        // });
     }
 }
 </script>
@@ -99,7 +86,7 @@ export default class SlideshowPanelV extends Vue {
 @media screen and (max-width: 640px) {
     .carousel {
         max-width: 100vw;
-        max-height: 40vh;
+        max-height: 50vh;
         background-color: white;
     }
 }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -173,5 +173,3 @@ export interface ChartConfig {
     src: string;
     options?: DQVOptions;
 }
-
-// TODO: add more definitions here as needed


### PR DESCRIPTION
Closes #154 
Closes #99 

Modifies styling for dynamic panels to display properly on mobile resolutions. Made adjustments to make dqv charts responsive to resizing screen. Charts and chart carousels should no longer be cut-off on mobile screens nor overflow its parent container. 

A minor issue is that some of the longer labels will be cut-off. My thought for this is to consider removing some of the less essential labels altogether on mobile (e.g. y-axis titles, subtitles for bar/line charts, section labels for pie charts) as a way to conserve space to display the data, but we can wait and see what results from the mobile testing #29.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/179)
<!-- Reviewable:end -->
