### PR TITLE
fix text overlapping maps and images

### DIFF
--- a/src/components/panels/image-panel.vue
+++ b/src/components/panels/image-panel.vue
@@ -5,11 +5,15 @@
                 :src="config.src"
                 :class="config.class"
                 :alt="config.altText"
-                class="graphic px-10 mx-auto my-6 block flex object-contain sm:max-w-screen sm:max-h-screen"
+                class="graphic-image px-10 mx-auto my-6 block flex object-contain sm:max-w-screen sm:max-h-screen"
             />
         </full-screen>
 
-        <div v-if="config.caption" class="text-center mt-5 text-sm max-w-full" v-html="md.render(config.caption)"></div>
+        <div
+            v-if="config.caption"
+            class="text-center text-sm max-w-full graphic-caption"
+            v-html="md.render(config.caption)"
+        ></div>
     </div>
 </template>
 
@@ -36,8 +40,10 @@ export default class ImagePanelV extends Vue {
 @media screen and (max-width: 640px) {
     .graphic {
         max-width: 100vw;
-        max-height: 40vh;
         background-color: white;
+    }
+    .graphic-image {
+        max-height: 38vh;
     }
 }
 </style>

--- a/src/components/panels/panel.vue
+++ b/src/components/panels/panel.vue
@@ -2,7 +2,7 @@
     <div
         :class="
             config.type !== 'text'
-                ? `sticky ${config.type === 'map' ? 'top-16' : 'top-8'} sm:self-start flex-2 order-1 sm:order-2`
+                ? `sticky ${config.type === 'map' ? 'top-16' : 'top-8'} sm:self-start flex-2 order-1 sm:order-2 z-40`
                 : 'flex order-2 sm:order-1'
         "
         class="flex-col"

--- a/src/components/panels/slideshow-panel.vue
+++ b/src/components/panels/slideshow-panel.vue
@@ -1,14 +1,20 @@
 <template>
     <div class="carousel self-start px-10 my-8 bg-gray-200_ h-28_" :style="{ width: `${width}px` }">
         <full-screen :expandable="config.fullscreen" :type="config.type">
-            <hooper ref="carousel" v-if="width !== -1" class="h-full" :infiniteScroll="config.loop">
+            <hooper
+                ref="carousel"
+                v-if="width !== -1"
+                class="h-full bg-white"
+                style="max-height: 45vh"
+                :infiniteScroll="config.loop"
+            >
                 <slide v-for="(image, index) in config.images" :key="index" :index="index" class="self-center">
                     <img
                         :src="image.src"
                         :height="image.height"
                         :width="image.width"
                         :alt="image.altText"
-                        class="m-auto story-graphic"
+                        class="m-auto story-graphic carousel-image"
                     />
                 </slide>
 
@@ -86,8 +92,10 @@ export default class SlideshowPanelV extends Vue {
 @media screen and (max-width: 640px) {
     .carousel {
         max-width: 100vw;
-        max-height: 50vh;
         background-color: white;
+    }
+    .carousel-image {
+        max-height: 48vh;
     }
 }
 </style>


### PR DESCRIPTION
Closes #180 

This PR fixes an issue where text would overlap with captions for images and slideshows. It also fixes another Firefox-exclusive issue where markdown text would appear on top of images, maps and charts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/184)
<!-- Reviewable:end -->
