### PR TITLE
Fix paginator mobile issues

### DIFF
--- a/src/components/panels/slideshow-panel.vue
+++ b/src/components/panels/slideshow-panel.vue
@@ -1,13 +1,7 @@
 <template>
     <div class="carousel self-start px-10 my-8 bg-gray-200_ h-28_" :style="{ width: `${width}px` }">
         <full-screen :expandable="config.fullscreen" :type="config.type">
-            <hooper
-                ref="carousel"
-                v-if="width !== -1"
-                class="h-full bg-white"
-                style="max-height: 45vh"
-                :infiniteScroll="config.loop"
-            >
+            <hooper ref="carousel" v-if="width !== -1" class="h-full bg-white" :infiniteScroll="config.loop">
                 <slide v-for="(image, index) in config.images" :key="index" :index="index" class="self-center">
                     <img
                         :src="image.src"

--- a/src/components/story/mobile-menu.vue
+++ b/src/components/story/mobile-menu.vue
@@ -18,23 +18,24 @@
             </button>
         </div>
 
-        <ul v-show="isMenuOpen" class="dropdown-nav-content bg-white my-3 w-72 z-10 border-r border-gray-200">
-            <div class="flex py-4">
-                <span class="flex-2 pl-2 ml-4 leading-normal">{{ lang === 'en' ? 'Chapters' : 'Chapitres' }}</span>
-                <button @click="isMenuOpen = !isMenuOpen">
-                    <svg
-                        class="flex-shrink-0 mr-4"
-                        width="24"
-                        height="24"
-                        viewBox="0 0 24 24"
-                        xmlns="http://www.w3.org/2000/svg"
-                        fill="#c0c0c0"
-                        stroke="#c0c0c0"
-                    >
-                        <path d="M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z"></path>
-                    </svg>
-                </button>
-            </div>
+        <div v-show="isMenuOpen" class="flex items-center mt-3 py-4 w-72 bg-white">
+            <span class="flex-2 pl-2 ml-4 leading-normal">{{ lang === 'en' ? 'Chapters' : 'Chapitres' }}</span>
+            <button @click="isMenuOpen = !isMenuOpen">
+                <svg
+                    class="flex-shrink-0 mr-4"
+                    width="24"
+                    height="24"
+                    viewBox="0 0 24 24"
+                    xmlns="http://www.w3.org/2000/svg"
+                    fill="#c0c0c0"
+                    stroke="#c0c0c0"
+                >
+                    <path d="M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z"></path>
+                </svg>
+            </button>
+        </div>
+
+        <ul v-show="isMenuOpen" class="dropdown-nav-content bg-white pb-10 w-72 z-10 border-r border-gray-200">
             <li>
                 <router-link :to="{ hash: '#intro' }" class="flex py-1 px-3" target>
                     <svg
@@ -101,6 +102,7 @@ export default class SideMenuV extends Vue {
 
 <style lang="scss" scoped>
 .dropdown-nav-content {
+    height: calc(100vh - 4rem);
     overflow-y: auto;
     -ms-overflow-style: none; /* Internet Explorer 10+ */
     scrollbar-width: none; /* Firefox */


### PR DESCRIPTION
Closes #181 

Fixes paginator issues on mobile - header is fixed while main chapter list content is scrollable and takes up full screen height. Also removes a `max-height` style property for slideshow images. 