### PR TITLE
Fix time slider display on mobile

### DIFF
--- a/src/components/panels/helpers/time-slider.vue
+++ b/src/components/panels/helpers/time-slider.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="time-slider">
-        <button class="absolute top-1 left-4" @click="intervalID >= 0 ? endLoop() : startLoop()">
+        <button class="absolute top-1 left-4 play-button" @click="intervalID >= 0 ? endLoop() : startLoop()">
             <svg
                 v-if="intervalID === -1"
                 xmlns="http://www.w3.org/2000/svg"
@@ -24,7 +24,7 @@
                 <path d="M6 19h4V5H6v14zm8-14v14h4V5h-4z" />
             </svg>
         </button>
-        <span class="my-2.5 text-base"
+        <span class="my-2.5 text-base range-display"
             ><span class="">{{ range[0] }}</span
             ><span class="" v-if="range[1]"> - {{ range[1] }}</span></span
         >
@@ -157,6 +157,25 @@ export default class TimeSlider extends Vue {
 
     .noUi-target {
         @apply w-4/5;
+    }
+
+    // MEDIA QUERY
+    @media screen and (max-width: 640px) {
+        .noUi-value:nth-of-type(4n) {
+            display: none;
+        }
+
+        .range-display {
+            @apply m-0;
+        }
+
+        .noUi-marker-large {
+            height: 9px !important;
+        }
+
+        .play-button {
+            @apply left-2 top-0;
+        }
     }
 
     // hide the slider rail

--- a/src/components/panels/map-panel.vue
+++ b/src/components/panels/map-panel.vue
@@ -161,6 +161,14 @@ export default class MapPanelV extends Vue {
 @media screen and (max-width: 640px) {
     .rv-map {
         max-height: 40vh;
+
+        ::v-deep .time-slider-container {
+            left: 0px !important;
+            right: 38px !important;
+            bottom: 29px !important;
+            min-height: 90px !important;
+            width: auto !important;
+        }
     }
 
     .map-title {


### PR DESCRIPTION
Closes #178

![image](https://user-images.githubusercontent.com/8732588/156009368-aea01c85-aeae-4882-8bc0-2839f9724fba.png)

- Removed some margins and shrunk the height of the panel
- Hid every other label as they would overlap eachother
- Made the time slider take available width
- Moved play button out of the way of the slider handles

Non-mobile styles left alone

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/191)
<!-- Reviewable:end -->
