### PR TITLE
fix missing carousel arrows on firefox

### DIFF
--- a/src/components/panels/slideshow-panel.vue
+++ b/src/components/panels/slideshow-panel.vue
@@ -61,6 +61,7 @@ export default class SlideshowPanelV extends Vue {
 
     ::v-deep .hooper-navigation svg {
         overflow: visible;
+        padding-left: initial !important;
     }
 
     ::v-deep .hooper-indicator {


### PR DESCRIPTION
Closes #189 

Arrows were missing in Firefox and not Chrome, WET styles added padding to the arrows' svgs sending them out of the box they were visible in.