### PR TITLE
fix map titles cutting off text on mobile

### DIFF
--- a/src/components/panels/map-panel.vue
+++ b/src/components/panels/map-panel.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="rv-map">
+    <div class="rv-map flex flex-col h-full align-middle w-full">
         <div class="px-10 mb-0 chapter-title top-20 map-title text-center">
             {{ config.title }}
         </div>


### PR DESCRIPTION
Closes #185 

On mobile, maps with a title section will no longer cut off the text below.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/193)
<!-- Reviewable:end -->
