### PR TITLE
Use html history mode for vue router

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2044,122 +2044,6 @@
                 "tslint": "^5.20.1",
                 "webpack": "^4.0.0",
                 "yorkie": "^2.0.0"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "4.3.0",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "color-convert": "^2.0.1"
-                    }
-                },
-                "chalk": {
-                    "version": "4.1.2",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-                    "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "ansi-styles": "^4.1.0",
-                        "supports-color": "^7.1.0"
-                    }
-                },
-                "color-convert": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "color-name": "~1.1.4"
-                    }
-                },
-                "color-name": {
-                    "version": "1.1.4",
-                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-                    "dev": true,
-                    "optional": true
-                },
-                "fork-ts-checker-webpack-plugin-v5": {
-                    "version": "npm:fork-ts-checker-webpack-plugin@5.2.1",
-                    "resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-5.2.1.tgz",
-                    "integrity": "sha512-SVi+ZAQOGbtAsUWrZvGzz38ga2YqjWvca1pXQFUArIVXqli0lLoDQ8uS0wg0kSpcwpZmaW5jVCZXQebkyUQSsw==",
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "@babel/code-frame": "^7.8.3",
-                        "@types/json-schema": "^7.0.5",
-                        "chalk": "^4.1.0",
-                        "cosmiconfig": "^6.0.0",
-                        "deepmerge": "^4.2.2",
-                        "fs-extra": "^9.0.0",
-                        "memfs": "^3.1.2",
-                        "minimatch": "^3.0.4",
-                        "schema-utils": "2.7.0",
-                        "semver": "^7.3.2",
-                        "tapable": "^1.0.0"
-                    }
-                },
-                "has-flag": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-                    "dev": true,
-                    "optional": true
-                },
-                "lru-cache": {
-                    "version": "6.0.0",
-                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-                    "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "yallist": "^4.0.0"
-                    }
-                },
-                "schema-utils": {
-                    "version": "2.7.0",
-                    "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.0.tgz",
-                    "integrity": "sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==",
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "@types/json-schema": "^7.0.4",
-                        "ajv": "^6.12.2",
-                        "ajv-keywords": "^3.4.1"
-                    }
-                },
-                "semver": {
-                    "version": "7.3.5",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-                    "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "lru-cache": "^6.0.0"
-                    }
-                },
-                "supports-color": {
-                    "version": "7.2.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "has-flag": "^4.0.0"
-                    }
-                },
-                "yallist": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-                    "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-                    "dev": true,
-                    "optional": true
-                }
             }
         },
         "@vue/cli-plugin-vuex": {
@@ -2423,60 +2307,6 @@
                     "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
                     "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
                     "dev": true
-                },
-                "vue-loader-v16": {
-                    "version": "npm:vue-loader@16.8.3",
-                    "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-16.8.3.tgz",
-                    "integrity": "sha512-7vKN45IxsKxe5GcVCbc2qFU5aWzyiLrYJyUuMz4BQLKctCj/fmCa0w6fGiiQ2cLFetNcek1ppGJQDCup0c1hpA==",
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "chalk": "^4.1.0",
-                        "hash-sum": "^2.0.0",
-                        "loader-utils": "^2.0.0"
-                    },
-                    "dependencies": {
-                        "chalk": {
-                            "version": "4.1.2",
-                            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-                            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-                            "dev": true,
-                            "optional": true,
-                            "requires": {
-                                "ansi-styles": "^4.1.0",
-                                "supports-color": "^7.1.0"
-                            }
-                        },
-                        "has-flag": {
-                            "version": "4.0.0",
-                            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-                            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-                            "dev": true,
-                            "optional": true
-                        },
-                        "loader-utils": {
-                            "version": "2.0.2",
-                            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
-                            "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
-                            "dev": true,
-                            "optional": true,
-                            "requires": {
-                                "big.js": "^5.2.2",
-                                "emojis-list": "^3.0.0",
-                                "json5": "^2.1.2"
-                            }
-                        },
-                        "supports-color": {
-                            "version": "7.2.0",
-                            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-                            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-                            "dev": true,
-                            "optional": true,
-                            "requires": {
-                                "has-flag": "^4.0.0"
-                            }
-                        }
-                    }
                 },
                 "wrap-ansi": {
                     "version": "6.2.0",
@@ -6649,6 +6479,122 @@
                     "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
                     "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
                     "dev": true
+                }
+            }
+        },
+        "fork-ts-checker-webpack-plugin-v5": {
+            "version": "npm:fork-ts-checker-webpack-plugin@5.2.1",
+            "resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-5.2.1.tgz",
+            "integrity": "sha512-SVi+ZAQOGbtAsUWrZvGzz38ga2YqjWvca1pXQFUArIVXqli0lLoDQ8uS0wg0kSpcwpZmaW5jVCZXQebkyUQSsw==",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "@babel/code-frame": "^7.8.3",
+                "@types/json-schema": "^7.0.5",
+                "chalk": "^4.1.0",
+                "cosmiconfig": "^6.0.0",
+                "deepmerge": "^4.2.2",
+                "fs-extra": "^9.0.0",
+                "memfs": "^3.1.2",
+                "minimatch": "^3.0.4",
+                "schema-utils": "2.7.0",
+                "semver": "^7.3.2",
+                "tapable": "^1.0.0"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "4.1.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+                    "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true,
+                    "optional": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true,
+                    "optional": true
+                },
+                "lru-cache": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+                    "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "yallist": "^4.0.0"
+                    }
+                },
+                "schema-utils": {
+                    "version": "2.7.0",
+                    "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.0.tgz",
+                    "integrity": "sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "@types/json-schema": "^7.0.4",
+                        "ajv": "^6.12.2",
+                        "ajv-keywords": "^3.4.1"
+                    }
+                },
+                "semver": {
+                    "version": "7.3.5",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+                    "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "lru-cache": "^6.0.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                },
+                "yallist": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+                    "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+                    "dev": true,
+                    "optional": true
                 }
             }
         },
@@ -14520,6 +14466,94 @@
                 "loader-utils": "^1.1.0",
                 "vue-hot-reload-api": "^2.3.0",
                 "vue-style-loader": "^4.1.0"
+            }
+        },
+        "vue-loader-v16": {
+            "version": "npm:vue-loader@16.8.3",
+            "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-16.8.3.tgz",
+            "integrity": "sha512-7vKN45IxsKxe5GcVCbc2qFU5aWzyiLrYJyUuMz4BQLKctCj/fmCa0w6fGiiQ2cLFetNcek1ppGJQDCup0c1hpA==",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "chalk": "^4.1.0",
+                "hash-sum": "^2.0.0",
+                "loader-utils": "^2.0.0"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "4.1.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+                    "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true,
+                    "optional": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true,
+                    "optional": true
+                },
+                "hash-sum": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/hash-sum/-/hash-sum-2.0.0.tgz",
+                    "integrity": "sha512-WdZTbAByD+pHfl/g9QSsBIIwy8IT+EsPiKDs0KNX+zSHhdDLFKdZu0BQHljvO+0QI/BasbMSUa8wYNCZTvhslg==",
+                    "dev": true,
+                    "optional": true
+                },
+                "loader-utils": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
+                    "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "big.js": "^5.2.2",
+                        "emojis-list": "^3.0.0",
+                        "json5": "^2.1.2"
+                    }
+                },
+                "supports-color": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
             }
         },
         "vue-loading-spinner": {

--- a/public/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000_en.ts
+++ b/public/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000_en.ts
@@ -21,7 +21,7 @@ Businesses, institutions and other facilities across Canada must report their re
                 },
                 {
                     src:
-                        '00000000-0000-0000-0000-000000000000/assets/en/NPRIpictogramme-2016data-EN__1553797637582__w1430.jpg',
+                        '/00000000-0000-0000-0000-000000000000/assets/en/NPRIpictogramme-2016data-EN__1553797637582__w1430.jpg',
                     type: 'image',
                     caption: 'This is a caption for the image.'
                 }
@@ -53,7 +53,7 @@ Fun stuff.`,
                             id: 'panel-2',
                             panel: {
                                 src:
-                                    '00000000-0000-0000-0000-000000000000/assets/en/GettyImages-187242601__1554821467033__w1920.jpg',
+                                    '/00000000-0000-0000-0000-000000000000/assets/en/GettyImages-187242601__1554821467033__w1920.jpg',
                                 type: 'image'
                             }
                         },
@@ -61,7 +61,7 @@ Fun stuff.`,
                             id: 'panel-3',
                             panel: {
                                 config:
-                                    '00000000-0000-0000-0000-000000000000/ramp-config/en/OilSandsFacilityLocations2019.json',
+                                    '/00000000-0000-0000-0000-000000000000/ramp-config/en/OilSandsFacilityLocations2019.json',
                                 type: 'map',
                                 scrollguard: true
                             }
@@ -89,7 +89,7 @@ This map shows a generalized potential extent of the three oil sands areas. The 
                     type: 'text'
                 },
                 {
-                    config: '00000000-0000-0000-0000-000000000000/ramp-config/en/OilSandsDeposits.json',
+                    config: '/00000000-0000-0000-0000-000000000000/ramp-config/en/OilSandsDeposits.json',
                     type: 'map',
                     scrollguard: true
                 }
@@ -109,7 +109,7 @@ Surface mining involves digging up large areas with large excavators. The result
                 },
                 {
                     src:
-                        '00000000-0000-0000-0000-000000000000/assets/en/GettyImages-187242601__1554821467033__w1920.jpg',
+                        '/00000000-0000-0000-0000-000000000000/assets/en/GettyImages-187242601__1554821467033__w1920.jpg',
                     type: 'image',
                     fullscreen: false
                 }
@@ -126,7 +126,7 @@ Thermal in-situ facilities have a much smaller physical footprint than surface m
                     type: 'text'
                 },
                 {
-                    src: '00000000-0000-0000-0000-000000000000/assets/en/Slide 3 - mine vs insitu.jpg',
+                    src: '/00000000-0000-0000-0000-000000000000/assets/en/Slide 3 - mine vs insitu.jpg',
                     type: 'image'
                 }
             ]
@@ -149,7 +149,7 @@ Thermal in-situ facilities have a much smaller physical footprint than surface m
                     type: 'text'
                 },
                 {
-                    config: '00000000-0000-0000-0000-000000000000/ramp-config/en/OilSandsFacilityLocations2019.json',
+                    config: '/00000000-0000-0000-0000-000000000000/ramp-config/en/OilSandsFacilityLocations2019.json',
                     type: 'map',
                     title: 'Map Title Test'
                 }
@@ -175,32 +175,32 @@ The seven oil sands surface mining facilities that reported to the NPRI are list
                 {
                     images: [
                         {
-                            src: '00000000-0000-0000-0000-000000000000/assets/en/substances/1_AuroraNorth_RelDisp.PNG',
+                            src: '/00000000-0000-0000-0000-000000000000/assets/en/substances/1_AuroraNorth_RelDisp.PNG',
                             type: 'image'
                         },
                         {
-                            src: '00000000-0000-0000-0000-000000000000/assets/en/substances/2_FortHills_RelDisp.PNG',
+                            src: '/00000000-0000-0000-0000-000000000000/assets/en/substances/2_FortHills_RelDisp.PNG',
                             type: 'image'
                         },
                         {
-                            src: '00000000-0000-0000-0000-000000000000/assets/en/substances/3_Horizon_RelDisp.PNG',
+                            src: '/00000000-0000-0000-0000-000000000000/assets/en/substances/3_Horizon_RelDisp.PNG',
                             type: 'image'
                         },
                         {
-                            src: '00000000-0000-0000-0000-000000000000/assets/en/substances/4_Kearl_RelDisp.PNG',
+                            src: '/00000000-0000-0000-0000-000000000000/assets/en/substances/4_Kearl_RelDisp.PNG',
                             type: 'image'
                         },
                         {
                             src:
-                                '00000000-0000-0000-0000-000000000000/assets/en/substances/5_MuskegJackpine_R5_RelDisp.PNG',
+                                '/00000000-0000-0000-0000-000000000000/assets/en/substances/5_MuskegJackpine_R5_RelDisp.PNG',
                             type: 'image'
                         },
                         {
-                            src: '00000000-0000-0000-0000-000000000000/assets/en/substances/6_Suncor_RelDisp.PNG',
+                            src: '/00000000-0000-0000-0000-000000000000/assets/en/substances/6_Suncor_RelDisp.PNG',
                             type: 'image'
                         },
                         {
-                            src: '00000000-0000-0000-0000-000000000000/assets/en/substances/7_Syncrude_RelDisp.PNG',
+                            src: '/00000000-0000-0000-0000-000000000000/assets/en/substances/7_Syncrude_RelDisp.PNG',
                             type: 'image'
                         }
                     ],
@@ -273,7 +273,7 @@ You can explore each facility using satellite imagery.`,
                 },
                 {
                     config:
-                        '00000000-0000-0000-0000-000000000000/ramp-config/en/ReleasesandDisposalsbyMiningFacilitiesin2019(satellite).json',
+                        '/00000000-0000-0000-0000-000000000000/ramp-config/en/ReleasesandDisposalsbyMiningFacilitiesin2019(satellite).json',
                     type: 'map'
                 }
             ]
@@ -287,7 +287,7 @@ You can explore each facility using satellite imagery.`,
                     type: 'text'
                 },
                 {
-                    src: '00000000-0000-0000-0000-000000000000/assets/en/slide 6 - mining trends.jpg',
+                    src: '/00000000-0000-0000-0000-000000000000/assets/en/slide 6 - mining trends.jpg',
                     type: 'image'
                 }
             ]
@@ -312,7 +312,7 @@ While the tailings reported by these mines have large amounts of manganese, ammo
                     type: 'text'
                 },
                 {
-                    src: '00000000-0000-0000-0000-000000000000/assets/en/Top10SubstancesTailings2019.png',
+                    src: '/00000000-0000-0000-0000-000000000000/assets/en/Top10SubstancesTailings2019.png',
                     type: 'image'
                 }
             ]
@@ -334,31 +334,31 @@ While the tailings reported by these mines have large amounts of manganese, ammo
                 {
                     images: [
                         {
-                            src: '00000000-0000-0000-0000-000000000000/assets/en/tailings/AuroraNorth_Tailings.PNG',
+                            src: '/00000000-0000-0000-0000-000000000000/assets/en/tailings/AuroraNorth_Tailings.PNG',
                             type: 'image'
                         },
                         {
-                            src: '00000000-0000-0000-0000-000000000000/assets/en/tailings/FortHills_Tailings.PNG',
+                            src: '/00000000-0000-0000-0000-000000000000/assets/en/tailings/FortHills_Tailings.PNG',
                             type: 'image'
                         },
                         {
-                            src: '00000000-0000-0000-0000-000000000000/assets/en/tailings/Horizon_Tailings.PNG',
+                            src: '/00000000-0000-0000-0000-000000000000/assets/en/tailings/Horizon_Tailings.PNG',
                             type: 'image'
                         },
                         {
-                            src: '00000000-0000-0000-0000-000000000000/assets/en/tailings/Kearl_Tailings.PNG',
+                            src: '/00000000-0000-0000-0000-000000000000/assets/en/tailings/Kearl_Tailings.PNG',
                             type: 'image'
                         },
                         {
-                            src: '00000000-0000-0000-0000-000000000000/assets/en/tailings/Muskeg_Tailings.PNG',
+                            src: '/00000000-0000-0000-0000-000000000000/assets/en/tailings/Muskeg_Tailings.PNG',
                             type: 'image'
                         },
                         {
-                            src: '00000000-0000-0000-0000-000000000000/assets/en/tailings/Suncor_Tailings.PNG',
+                            src: '/00000000-0000-0000-0000-000000000000/assets/en/tailings/Suncor_Tailings.PNG',
                             type: 'image'
                         },
                         {
-                            src: '00000000-0000-0000-0000-000000000000/assets/en/tailings/Syncrude_Tailings.PNG',
+                            src: '/00000000-0000-0000-0000-000000000000/assets/en/tailings/Syncrude_Tailings.PNG',
                             type: 'image'
                         }
                     ],
@@ -380,7 +380,7 @@ You can explore each facility using satellite imagery.`,
                 },
                 {
                     config:
-                        '00000000-0000-0000-0000-000000000000/ramp-config/en/ReleasesandDisposalsbyMiningFacilitiesin2019(satellite).json',
+                        '/00000000-0000-0000-0000-000000000000/ramp-config/en/ReleasesandDisposalsbyMiningFacilitiesin2019(satellite).json',
                     type: 'map'
                 }
             ]
@@ -395,7 +395,7 @@ You can explore each facility using satellite imagery.`,
                 },
                 {
                     config:
-                        '00000000-0000-0000-0000-000000000000/ramp-config/en/TailingsfromMiningFacilities2010to2019(timeslider).json',
+                        '/00000000-0000-0000-0000-000000000000/ramp-config/en/TailingsfromMiningFacilities2010to2019(timeslider).json',
                     type: 'map'
                 }
             ]
@@ -413,7 +413,7 @@ Compared to surface mining, in-situ operations are much more energy intensive, a
                     type: 'text'
                 },
                 {
-                    src: '00000000-0000-0000-0000-000000000000/assets/en/Slide 10 - SAGD vs CSS.jpg',
+                    src: '/00000000-0000-0000-0000-000000000000/assets/en/Slide 10 - SAGD vs CSS.jpg',
                     type: 'image'
                 }
             ]
@@ -437,7 +437,7 @@ The air releases reported by in-situ facilities is almost entirely (98%) criteri
                 },
                 {
                     config:
-                        '00000000-0000-0000-0000-000000000000/ramp-config/en/ReleasestoAirbyInSituFacilitiesforAllSubstancesin2019.json',
+                        '/00000000-0000-0000-0000-000000000000/ramp-config/en/ReleasestoAirbyInSituFacilitiesforAllSubstancesin2019.json',
                     type: 'map'
                 }
             ]
@@ -454,7 +454,7 @@ This change in the number of facilities reporting over time follows changes in t
                 },
                 {
                     config:
-                        '00000000-0000-0000-0000-000000000000/ramp-config/en/ReleasestoAirbyInSituFacilitiesforAllSubstances2010to2019(timeslider).json',
+                        '/00000000-0000-0000-0000-000000000000/ramp-config/en/ReleasestoAirbyInSituFacilitiesforAllSubstances2010to2019(timeslider).json',
                     type: 'map'
                 }
             ]
@@ -473,7 +473,7 @@ While in-situ facilities have reported an increase in reported CAC emissions, th
                 },
                 {
                     src:
-                        '00000000-0000-0000-0000-000000000000/assets/en/Slide%2013%20-%20InSitu%20Trends__1554406944277__w594.jpg',
+                        '/00000000-0000-0000-0000-000000000000/assets/en/Slide%2013%20-%20InSitu%20Trends__1554406944277__w594.jpg',
                     type: 'image'
                 }
             ]
@@ -494,7 +494,7 @@ Oil sands surface mining facilities in Alberta take much of their water from the
                 },
                 {
                     src:
-                        '00000000-0000-0000-0000-000000000000/assets/en/GettyImages-516166467__1554821531978__w1920.jpg',
+                        '/00000000-0000-0000-0000-000000000000/assets/en/GettyImages-516166467__1554821531978__w1920.jpg',
                     type: 'image'
                 }
             ]
@@ -542,7 +542,7 @@ These easy-to-use files let you dig deeper into the data in a variety of ways
                 },
                 {
                     type: 'chart',
-                    charts: [{ src: '00000000-0000-0000-0000-000000000000/charts/en/chartConfig.json' }]
+                    charts: [{ src: '/00000000-0000-0000-0000-000000000000/charts/en/chartConfig.json' }]
                 }
             ]
         },

--- a/public/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000_fr.ts
+++ b/public/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000_fr.ts
@@ -21,7 +21,7 @@ Les entreprises, les établissements et d’autres entités partout au Canada do
                 },
                 {
                     src:
-                        '00000000-0000-0000-0000-000000000000/assets/fr/NPRIpictogramme-2016data-FR__1552505700147__w975.jpg',
+                        '/00000000-0000-0000-0000-000000000000/assets/fr/NPRIpictogramme-2016data-FR__1552505700147__w975.jpg',
                     type: 'image'
                 }
             ]
@@ -46,7 +46,7 @@ Cette carte montre une étendue potentielle généralisée des trois zones de sa
                     type: 'text'
                 },
                 {
-                    config: '00000000-0000-0000-0000-000000000000/ramp-config/fr/OilSandsDeposits.json',
+                    config: '/00000000-0000-0000-0000-000000000000/ramp-config/fr/OilSandsDeposits.json',
                     type: 'map',
                     scrollguard: true
                 }
@@ -66,7 +66,7 @@ L’exploitation à ciel ouvert consiste à creuser de grandes surfaces à l’a
                 },
                 {
                     src:
-                        '00000000-0000-0000-0000-000000000000/assets/fr/GettyImages-187242601__1554821412825__w1920.jpg',
+                        '/00000000-0000-0000-0000-000000000000/assets/fr/GettyImages-187242601__1554821412825__w1920.jpg',
                     type: 'image'
                 }
             ]
@@ -82,7 +82,7 @@ Les installations in situ ont une empreinte physique beaucoup plus petite que le
                     type: 'text'
                 },
                 {
-                    src: '00000000-0000-0000-0000-000000000000/assets/fr/Slide 3 - mine vs insitu.jpg',
+                    src: '/00000000-0000-0000-0000-000000000000/assets/fr/Slide 3 - mine vs insitu.jpg',
                     type: 'image'
                 }
             ]
@@ -105,7 +105,7 @@ Les installations in situ ont une empreinte physique beaucoup plus petite que le
                     type: 'text'
                 },
                 {
-                    config: '00000000-0000-0000-0000-000000000000/ramp-config/fr/OilSandsFacilityLocations2019.json',
+                    config: '/00000000-0000-0000-0000-000000000000/ramp-config/fr/OilSandsFacilityLocations2019.json',
                     type: 'map'
                 }
             ]
@@ -130,32 +130,33 @@ Les sept installations d’exploitation minière à ciel ouvert des sables bitum
                 {
                     images: [
                         {
-                            src: '00000000-0000-0000-0000-000000000000/assets/fr/substances/AuroraNorth_RelDisp_FR.PNG',
+                            src:
+                                '/00000000-0000-0000-0000-000000000000/assets/fr/substances/AuroraNorth_RelDisp_FR.PNG',
                             type: 'image'
                         },
                         {
-                            src: '00000000-0000-0000-0000-000000000000/assets/fr/substances/FortHills_RelDisp_FR.PNG',
+                            src: '/00000000-0000-0000-0000-000000000000/assets/fr/substances/FortHills_RelDisp_FR.PNG',
                             type: 'image'
                         },
                         {
-                            src: '00000000-0000-0000-0000-000000000000/assets/fr/substances/Horizon_RelDisp_FR.PNG',
+                            src: '/00000000-0000-0000-0000-000000000000/assets/fr/substances/Horizon_RelDisp_FR.PNG',
                             type: 'image'
                         },
                         {
-                            src: '00000000-0000-0000-0000-000000000000/assets/fr/substances/Kearl_RelDisp_FR.PNG',
+                            src: '/00000000-0000-0000-0000-000000000000/assets/fr/substances/Kearl_RelDisp_FR.PNG',
                             type: 'image'
                         },
                         {
                             src:
-                                '00000000-0000-0000-0000-000000000000/assets/fr/substances/MuskegJackpine_RelDisp_FR.PNG',
+                                '/00000000-0000-0000-0000-000000000000/assets/fr/substances/MuskegJackpine_RelDisp_FR.PNG',
                             type: 'image'
                         },
                         {
-                            src: '00000000-0000-0000-0000-000000000000/assets/fr/substances/Suncor_RelDisp_FR.PNG',
+                            src: '/00000000-0000-0000-0000-000000000000/assets/fr/substances/Suncor_RelDisp_FR.PNG',
                             type: 'image'
                         },
                         {
-                            src: '00000000-0000-0000-0000-000000000000/assets/fr/substances/Syncrude_RelDisp_FR.PNG',
+                            src: '/00000000-0000-0000-0000-000000000000/assets/fr/substances/Syncrude_RelDisp_FR.PNG',
                             type: 'image'
                         }
                     ],
@@ -232,7 +233,7 @@ Explorez chaque installation avec l’imagerie par satellite.`,
                 },
                 {
                     config:
-                        '00000000-0000-0000-0000-000000000000/ramp-config/en/ReleasesandDisposalsbyMiningFacilitiesin2019(satellite).json',
+                        '/00000000-0000-0000-0000-000000000000/ramp-config/en/ReleasesandDisposalsbyMiningFacilitiesin2019(satellite).json',
                     type: 'map'
                 }
             ]
@@ -246,7 +247,7 @@ Explorez chaque installation avec l’imagerie par satellite.`,
                     type: 'text'
                 },
                 {
-                    src: '00000000-0000-0000-0000-000000000000/assets/fr/slide 6 trends in mining.jpg',
+                    src: '/00000000-0000-0000-0000-000000000000/assets/fr/slide 6 trends in mining.jpg',
                     type: 'image'
                 }
             ]
@@ -272,7 +273,7 @@ Bien que les résidus déclarés par ces mines contiennent de grandes quantités
                     type: 'text'
                 },
                 {
-                    src: '00000000-0000-0000-0000-000000000000/assets/fr/Top10SubstancesTailings2019.png',
+                    src: '/00000000-0000-0000-0000-000000000000/assets/fr/Top10SubstancesTailings2019.png',
                     type: 'image'
                 }
             ]
@@ -296,31 +297,31 @@ Bien que les résidus déclarés par ces mines contiennent de grandes quantités
                 {
                     images: [
                         {
-                            src: '00000000-0000-0000-0000-000000000000/assets/fr/tailings/AuroraNorth_Tailings_FR.PNG',
+                            src: '/00000000-0000-0000-0000-000000000000/assets/fr/tailings/AuroraNorth_Tailings_FR.PNG',
                             type: 'image'
                         },
                         {
-                            src: '00000000-0000-0000-0000-000000000000/assets/fr/tailings/FortHills_Tailings_FR.PNG',
+                            src: '/00000000-0000-0000-0000-000000000000/assets/fr/tailings/FortHills_Tailings_FR.PNG',
                             type: 'image'
                         },
                         {
-                            src: '00000000-0000-0000-0000-000000000000/assets/fr/tailings/Horizon_Tailings_FR.PNG',
+                            src: '/00000000-0000-0000-0000-000000000000/assets/fr/tailings/Horizon_Tailings_FR.PNG',
                             type: 'image'
                         },
                         {
-                            src: '00000000-0000-0000-0000-000000000000/assets/fr/tailings/Kearl_Tailings_FR.PNG',
+                            src: '/00000000-0000-0000-0000-000000000000/assets/fr/tailings/Kearl_Tailings_FR.PNG',
                             type: 'image'
                         },
                         {
-                            src: '00000000-0000-0000-0000-000000000000/assets/fr/tailings/Muskeg_Tailings_FR.PNG',
+                            src: '/00000000-0000-0000-0000-000000000000/assets/fr/tailings/Muskeg_Tailings_FR.PNG',
                             type: 'image'
                         },
                         {
-                            src: '00000000-0000-0000-0000-000000000000/assets/fr/tailings/Suncor_Tailings_FR.PNG',
+                            src: '/00000000-0000-0000-0000-000000000000/assets/fr/tailings/Suncor_Tailings_FR.PNG',
                             type: 'image'
                         },
                         {
-                            src: '00000000-0000-0000-0000-000000000000/assets/fr/tailings/Syncrude_Tailings_FR.PNG',
+                            src: '/00000000-0000-0000-0000-000000000000/assets/fr/tailings/Syncrude_Tailings_FR.PNG',
                             type: 'image'
                         }
                     ],
@@ -343,7 +344,7 @@ Explorez chaque installation avec l’imagerie par satellite.`,
                 },
                 {
                     config:
-                        '00000000-0000-0000-0000-000000000000/ramp-config/fr/ReleasesandDisposalsbyMiningFacilitiesin2019(satellite).json',
+                        '/00000000-0000-0000-0000-000000000000/ramp-config/fr/ReleasesandDisposalsbyMiningFacilitiesin2019(satellite).json',
                     type: 'map'
                 }
             ]
@@ -360,7 +361,7 @@ Explorez chaque installation avec l’imagerie par satellite.`,
                 },
                 {
                     config:
-                        '00000000-0000-0000-0000-000000000000/ramp-config/en/TailingsfromMiningFacilities2010to2019(timeslider).json',
+                        '/00000000-0000-0000-0000-000000000000/ramp-config/en/TailingsfromMiningFacilities2010to2019(timeslider).json',
                     type: 'map'
                 }
             ]
@@ -378,7 +379,7 @@ En comparaison avec l’exploitation minière à ciel ouvert, l’exploitation i
                     type: 'text'
                 },
                 {
-                    src: '00000000-0000-0000-0000-000000000000/assets/fr/Slide 10 - SAGD vs CSS.jpg',
+                    src: '/00000000-0000-0000-0000-000000000000/assets/fr/Slide 10 - SAGD vs CSS.jpg',
                     type: 'image'
                 }
             ]
@@ -402,7 +403,7 @@ Les rejets atmosphériques déclarés par les installations in situ sont presque
                 },
                 {
                     config:
-                        '00000000-0000-0000-0000-000000000000/ramp-config/fr/ReleasestoAirbyInSituFacilitiesforAllSubstancesin2019.json',
+                        '/00000000-0000-0000-0000-000000000000/ramp-config/fr/ReleasestoAirbyInSituFacilitiesforAllSubstancesin2019.json',
                     type: 'map'
                 }
             ]
@@ -419,7 +420,7 @@ Ce changement dans le nombre d’installations déclarantes au fil du temps suit
                 },
                 {
                     config:
-                        '00000000-0000-0000-0000-000000000000/ramp-config/fr/ReleasestoAirbyInSituFacilitiesforAllSubstances2010to2019(timeslider).json',
+                        '/00000000-0000-0000-0000-000000000000/ramp-config/fr/ReleasestoAirbyInSituFacilitiesforAllSubstances2010to2019(timeslider).json',
                     type: 'map'
                 }
             ]
@@ -438,7 +439,7 @@ Bien que les installations in situ aient signalé un accroissement des émission
                 },
                 {
                     src:
-                        '00000000-0000-0000-0000-000000000000/assets/fr/Slide%2013%20Insitu%20trends%20-%20French__1554407015712__w628.jpg',
+                        '/00000000-0000-0000-0000-000000000000/assets/fr/Slide%2013%20Insitu%20trends%20-%20French__1554407015712__w628.jpg',
                     type: 'image'
                 }
             ]
@@ -458,7 +459,7 @@ Les installations d’exploitation minière à ciel ouvert des sables bitumineux
                     type: 'text'
                 },
                 {
-                    src: '00000000-0000-0000-0000-000000000000/assets/fr/slide%2014%20-%20athabasca.jpg',
+                    src: '/00000000-0000-0000-0000-000000000000/assets/fr/slide%2014%20-%20athabasca.jpg',
                     type: 'image'
                 }
             ]

--- a/public/410b88da-0ed1-4749-903f-5e76c24e2e5f/410b88da-0ed1-4749-903f-5e76c24e2e5f_en.ts
+++ b/public/410b88da-0ed1-4749-903f-5e76c24e2e5f/410b88da-0ed1-4749-903f-5e76c24e2e5f_en.ts
@@ -21,7 +21,7 @@ Businesses, institutions and other facilities across Canada must report their re
                 },
                 {
                     src:
-                        '410b88da-0ed1-4749-903f-5e76c24e2e5f/assets/en/NPRIpictogramme-2016data-EN__1553797637582__w1430.jpg',
+                        '/410b88da-0ed1-4749-903f-5e76c24e2e5f/assets/en/NPRIpictogramme-2016data-EN__1553797637582__w1430.jpg',
                     type: 'image',
                     altText:
                         'An image describing the flow from industry of on-site releases to air, water, and land, on-site disposals, off-site disposals, and off-site transfers.'
@@ -47,7 +47,7 @@ This map shows a generalized overview of the three oil sands areas. The actual g
                     type: 'text'
                 },
                 {
-                    config: '410b88da-0ed1-4749-903f-5e76c24e2e5f/ramp-config/en/OilSandsDeposits.json',
+                    config: '/410b88da-0ed1-4749-903f-5e76c24e2e5f/ramp-config/en/OilSandsDeposits.json',
                     type: 'map'
                 }
             ]
@@ -66,7 +66,7 @@ Surface mining involves digging up large areas with large excavators. The result
                 },
                 {
                     src:
-                        '410b88da-0ed1-4749-903f-5e76c24e2e5f/assets/en/GettyImages-187242601__1554821467033__w1920.jpg',
+                        '/410b88da-0ed1-4749-903f-5e76c24e2e5f/assets/en/GettyImages-187242601__1554821467033__w1920.jpg',
                     type: 'image',
                     altText: 'An image showing an aerial view of an oil sands extraction facility.'
                 }
@@ -83,7 +83,7 @@ Thermal in-situ facilities have a much smaller physical footprint than surface m
                     type: 'text'
                 },
                 {
-                    src: '410b88da-0ed1-4749-903f-5e76c24e2e5f/assets/en/Slide 3 - mine vs insitu.jpg',
+                    src: '/410b88da-0ed1-4749-903f-5e76c24e2e5f/assets/en/Slide 3 - mine vs insitu.jpg',
                     type: 'image',
                     altText:
                         'A diagram showing the extraction process involving pumping high-pressure steam deep underground.'
@@ -109,7 +109,7 @@ Thermal in-situ facilities have a much smaller physical footprint than surface m
                     type: 'text'
                 },
                 {
-                    config: '410b88da-0ed1-4749-903f-5e76c24e2e5f/ramp-config/en/OilSandsFacilityLocations2019.json',
+                    config: '/410b88da-0ed1-4749-903f-5e76c24e2e5f/ramp-config/en/OilSandsFacilityLocations2019.json',
                     type: 'map'
                 }
             ]
@@ -136,7 +136,7 @@ The seven oil sands surface mining facilities that reported to the NPRI are list
                     charts: [
                         {
                             src:
-                                '410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/en/substances/1.Imperial Oil Resources Limited-Kearl Oil Sands Processing Plant and Mine.csv',
+                                '/410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/en/substances/1.Imperial Oil Resources Limited-Kearl Oil Sands Processing Plant and Mine.csv',
                             options: {
                                 title: `Imperial Oil Resources Limited, Kearl Oil Sands Processing Plant and Mine 2019 Releases and Disposals (Tonnes)`,
                                 subtitle: '',
@@ -145,7 +145,7 @@ The seven oil sands surface mining facilities that reported to the NPRI are list
                         },
                         {
                             src:
-                                '410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/en/substances/2.Suncor Energy Oil Sands Limited Partnership-Suncor Energy Inc. Oil Sands.csv',
+                                '/410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/en/substances/2.Suncor Energy Oil Sands Limited Partnership-Suncor Energy Inc. Oil Sands.csv',
                             options: {
                                 title: `Suncor Energy Oil Sands Limited Partnership, Suncor Energy Inc. Oil Sands 2019 Releases and Disposals (Tonnes)`,
                                 subtitle: '',
@@ -154,7 +154,7 @@ The seven oil sands surface mining facilities that reported to the NPRI are list
                         },
                         {
                             src:
-                                '410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/en/substances/3.Syncrude Canada Ltd.-Syncrude Canada Ltd.csv',
+                                '/410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/en/substances/3.Syncrude Canada Ltd.-Syncrude Canada Ltd.csv',
                             options: {
                                 title: `Syncrude Canada Ltd., Syncrude Canada Ltd 2019 Releases and Disposals (Tonnes)`,
                                 subtitle: '',
@@ -163,7 +163,7 @@ The seven oil sands surface mining facilities that reported to the NPRI are list
                         },
                         {
                             src:
-                                '410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/en/substances/4.Syncrude Canada Ltd.-Aurora North Mine Site.csv',
+                                '/410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/en/substances/4.Syncrude Canada Ltd.-Aurora North Mine Site.csv',
                             options: {
                                 title: `Syncrude Canada Ltd., Aurora North Mine Site 2019 Releases and Disposals (Tonnes)`,
                                 subtitle: '',
@@ -172,7 +172,7 @@ The seven oil sands surface mining facilities that reported to the NPRI are list
                         },
                         {
                             src:
-                                '410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/en/substances/5.Canadian Natural Upgrading Limited Muskeg River Mine and Jackpine Mine 2019 Tailings.csv',
+                                '/410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/en/substances/5.Canadian Natural Upgrading Limited Muskeg River Mine and Jackpine Mine 2019 Tailings.csv',
                             options: {
                                 title: `Canadian Natural Upgrading Ltd., Canadian Natural Upgrading Limited Muskeg River Mine and Jackpine Mine 2019 Releases and Disposals (Tonnes)`,
                                 subtitle: '',
@@ -181,7 +181,7 @@ The seven oil sands surface mining facilities that reported to the NPRI are list
                         },
                         {
                             src:
-                                '410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/en/substances/6.Canadian Natural Resources Limited-Horizon Oil Sands Processing Plant and Mine.csv',
+                                '/410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/en/substances/6.Canadian Natural Resources Limited-Horizon Oil Sands Processing Plant and Mine.csv',
                             options: {
                                 title: `Canadian Natural Resources Limited, Horizon Oil Sands Processing Plant and Mine 2019 Releases and Dispostals (Tonnes)`,
                                 subtitle: '',
@@ -190,7 +190,7 @@ The seven oil sands surface mining facilities that reported to the NPRI are list
                         },
                         {
                             src:
-                                '410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/en/substances/7.Fort Hills Energy L.P.-Fort Hills Oil Sands.csv',
+                                '/410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/en/substances/7.Fort Hills Energy L.P.-Fort Hills Oil Sands.csv',
                             options: {
                                 title: `Fort Hills Energy L.P., Fort Hills Oil Sands, 2019 Releases and Dispostals (Tonnes)`,
                                 subtitle: '',
@@ -216,7 +216,7 @@ You can explore each facility using satellite imagery.`,
                 },
                 {
                     config:
-                        '410b88da-0ed1-4749-903f-5e76c24e2e5f/ramp-config/en/ReleasesandDisposalsbyMiningFacilitiesin2019(satellite).json',
+                        '/410b88da-0ed1-4749-903f-5e76c24e2e5f/ramp-config/en/ReleasesandDisposalsbyMiningFacilitiesin2019(satellite).json',
                     type: 'map'
                 }
             ]
@@ -234,7 +234,7 @@ You can explore each facility using satellite imagery.`,
                     charts: [
                         {
                             src:
-                                '410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/en/Criteria air contaminant releases from oil sands mines_1.csv',
+                                '/410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/en/Criteria air contaminant releases from oil sands mines_1.csv',
 
                             options: {
                                 xAxisLabel: 'Year',
@@ -246,7 +246,7 @@ You can explore each facility using satellite imagery.`,
                         },
                         {
                             src:
-                                '410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/en/Criteria air contaminant releases from oil sands mines_2.csv',
+                                '/410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/en/Criteria air contaminant releases from oil sands mines_2.csv',
                             options: {
                                 xAxisLabel: 'Year',
                                 yAxisLabel: 'Barrels per year (thousands)',
@@ -258,7 +258,7 @@ You can explore each facility using satellite imagery.`,
                         },
                         {
                             src:
-                                '410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/en/Criteria air contaminant releases from oil sands mines_3.csv',
+                                '/410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/en/Criteria air contaminant releases from oil sands mines_3.csv',
                             options: {
                                 xAxisLabel: 'Year',
                                 yAxisLabel: 'Releases per 1000 barrels',
@@ -295,7 +295,7 @@ While the tailings reported by these mines have large amounts of manganese, ammo
                     type: 'chart',
                     charts: [
                         {
-                            src: '410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/en/Mine tailings reported.csv',
+                            src: '/410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/en/Mine tailings reported.csv',
                             options: {
                                 xAxisLabel: 'Substances',
                                 yAxisLabel: 'Releases (thousands tonnes)',
@@ -327,7 +327,7 @@ While the tailings reported by these mines have large amounts of manganese, ammo
                     charts: [
                         {
                             src:
-                                '410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/en/tailings/1.Syncrude Canada Ltd., Aurora North Mine Site 2019 Tailings.csv',
+                                '/410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/en/tailings/1.Syncrude Canada Ltd., Aurora North Mine Site 2019 Tailings.csv',
                             options: {
                                 title: `Syncrude Canada Ltd., Aurora North Mine Site 2019 Tailings (Tonnes)`,
                                 subtitle: '',
@@ -336,7 +336,7 @@ While the tailings reported by these mines have large amounts of manganese, ammo
                         },
                         {
                             src:
-                                '410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/en/tailings/2.Fort Hill Energy L.P., Fort Hills Oil Sands 2019 Tailings.csv',
+                                '/410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/en/tailings/2.Fort Hill Energy L.P., Fort Hills Oil Sands 2019 Tailings.csv',
                             options: {
                                 title: `Fort Hill Energy L.P., Fort Hills Oil Sands 2019 Tailings (Tonnes)`,
                                 subtitle: '',
@@ -345,7 +345,7 @@ While the tailings reported by these mines have large amounts of manganese, ammo
                         },
                         {
                             src:
-                                '410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/en/tailings/3.Canadian Natural Resources Limited, Horizon Oil Sands Processing Plant and Mine 2019 Tailings.csv',
+                                '/410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/en/tailings/3.Canadian Natural Resources Limited, Horizon Oil Sands Processing Plant and Mine 2019 Tailings.csv',
                             options: {
                                 title: `Canadian Natural Resources Limited, Horizon Oil Sands Processing Plant and Mine 2019 Tailings (Tonnes)`,
                                 subtitle: '',
@@ -354,7 +354,7 @@ While the tailings reported by these mines have large amounts of manganese, ammo
                         },
                         {
                             src:
-                                '410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/en/tailings/4.Imperial Oil Resources Limited, Kearl Oil Sands Processing Plant and Mine 2019 Tailings.csv',
+                                '/410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/en/tailings/4.Imperial Oil Resources Limited, Kearl Oil Sands Processing Plant and Mine 2019 Tailings.csv',
                             options: {
                                 title: `Imperial Oil Resources Limited, Kearl Oil Sands Processing Plant and Mine 2019 Tailings (Tonnes)`,
                                 subtitle: '',
@@ -363,7 +363,7 @@ While the tailings reported by these mines have large amounts of manganese, ammo
                         },
                         {
                             src:
-                                '410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/en/tailings/5.Canadian Natural Upgrading Limited Muskeg River Mine and Jackpine Mine 2019 Tailings.csv',
+                                '/410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/en/tailings/5.Canadian Natural Upgrading Limited Muskeg River Mine and Jackpine Mine 2019 Tailings.csv',
                             options: {
                                 title: `Canadian Natural Upgrading Ltd., Canadian Natural Upgrading Limited Muskeg River Mine and Jackpine Mine 2019 Tailings (Tonnes)`,
                                 subtitle: '',
@@ -372,7 +372,7 @@ While the tailings reported by these mines have large amounts of manganese, ammo
                         },
                         {
                             src:
-                                '410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/en/tailings/6.Suncor Energy Oil Sands Limited Partnership, Suncor Energy Inc. Oil Sands Tailings.csv',
+                                '/410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/en/tailings/6.Suncor Energy Oil Sands Limited Partnership, Suncor Energy Inc. Oil Sands Tailings.csv',
                             options: {
                                 title: `Suncor Energy Oil Sands Limited Partnership, Suncor Energy Inc. Oil Sands Tailings (Tonnes)`,
                                 subtitle: '',
@@ -381,7 +381,7 @@ While the tailings reported by these mines have large amounts of manganese, ammo
                         },
                         {
                             src:
-                                '410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/en/tailings/7.Syncrude Canada Ltd., Syncrude Canada Ltd. 2019 Tailings.csv',
+                                '/410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/en/tailings/7.Syncrude Canada Ltd., Syncrude Canada Ltd. 2019 Tailings.csv',
                             options: {
                                 title: `Syncrude Canada Ltd., Syncrude Canada Ltd. 2019 Tailings (Tonnes)`,
                                 subtitle: '',
@@ -404,7 +404,7 @@ You can explore each facility using satellite imagery.`,
                 },
                 {
                     config:
-                        '410b88da-0ed1-4749-903f-5e76c24e2e5f/ramp-config/en/ReleasesandDisposalsbyMiningFacilitiesin2019(satellite).json',
+                        '/410b88da-0ed1-4749-903f-5e76c24e2e5f/ramp-config/en/ReleasesandDisposalsbyMiningFacilitiesin2019(satellite).json',
                     type: 'map'
                 }
             ]
@@ -419,7 +419,7 @@ You can explore each facility using satellite imagery.`,
                 },
                 {
                     config:
-                        '410b88da-0ed1-4749-903f-5e76c24e2e5f/ramp-config/en/TailingsfromMiningFacilities2010to2019(timeslider).json',
+                        '/410b88da-0ed1-4749-903f-5e76c24e2e5f/ramp-config/en/TailingsfromMiningFacilities2010to2019(timeslider).json',
                     type: 'map',
                     timeSlider: {
                         range: [2010, 2019],
@@ -442,7 +442,7 @@ Compared to surface mining, in-situ operations are much more energy intensive, a
                     type: 'text'
                 },
                 {
-                    src: '410b88da-0ed1-4749-903f-5e76c24e2e5f/assets/en/Slide 10 - SAGD vs CSS.jpg',
+                    src: '/410b88da-0ed1-4749-903f-5e76c24e2e5f/assets/en/Slide 10 - SAGD vs CSS.jpg',
                     type: 'image',
                     altText:
                         'A diagram demonstrating steam assisted gravity drainage and cyclic steam stimulation processes in oil sands extraction.'
@@ -468,7 +468,7 @@ The air releases reported by in-situ facilities is almost entirely (98%) criteri
                 },
                 {
                     config:
-                        '410b88da-0ed1-4749-903f-5e76c24e2e5f/ramp-config/en/ReleasestoAirbyInSituFacilitiesforAllSubstancesin2019.json',
+                        '/410b88da-0ed1-4749-903f-5e76c24e2e5f/ramp-config/en/ReleasestoAirbyInSituFacilitiesforAllSubstancesin2019.json',
                     type: 'map'
                 }
             ]
@@ -485,7 +485,7 @@ This change in the number of facilities reporting over time follows changes in t
                 },
                 {
                     config:
-                        '410b88da-0ed1-4749-903f-5e76c24e2e5f/ramp-config/en/ReleasestoAirbyInSituFacilitiesforAllSubstances2010to2019(timeslider).json',
+                        '/410b88da-0ed1-4749-903f-5e76c24e2e5f/ramp-config/en/ReleasestoAirbyInSituFacilitiesforAllSubstances2010to2019(timeslider).json',
                     type: 'map',
                     timeSlider: {
                         range: [2010, 2019],
@@ -512,7 +512,7 @@ While in-situ facilities have reported an increase in reported CAC emissions, th
                     charts: [
                         {
                             src:
-                                '410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/en/NPRI releases from thermal in-situ facilities_1.csv',
+                                '/410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/en/NPRI releases from thermal in-situ facilities_1.csv',
 
                             options: {
                                 xAxisLabel: 'Year',
@@ -524,7 +524,7 @@ While in-situ facilities have reported an increase in reported CAC emissions, th
                         },
                         {
                             src:
-                                '410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/en/NPRI releases from thermal in-situ facilities_2.csv',
+                                '/410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/en/NPRI releases from thermal in-situ facilities_2.csv',
                             options: {
                                 xAxisLabel: 'Year',
                                 yAxisLabel: 'Barrels per year',
@@ -554,7 +554,7 @@ Oil sands surface mining facilities in Alberta take much of their water from the
                 },
                 {
                     src:
-                        '410b88da-0ed1-4749-903f-5e76c24e2e5f/assets/en/GettyImages-516166467__1554821531978__w1920.jpg',
+                        '/410b88da-0ed1-4749-903f-5e76c24e2e5f/assets/en/GettyImages-516166467__1554821531978__w1920.jpg',
                     type: 'image',
                     altText: 'An aerial view of the Athabasca River.'
                 }

--- a/public/410b88da-0ed1-4749-903f-5e76c24e2e5f/410b88da-0ed1-4749-903f-5e76c24e2e5f_fr.ts
+++ b/public/410b88da-0ed1-4749-903f-5e76c24e2e5f/410b88da-0ed1-4749-903f-5e76c24e2e5f_fr.ts
@@ -21,7 +21,7 @@ Les entreprises, les établissements et d’autres entités partout au Canada do
                 },
                 {
                     src:
-                        '410b88da-0ed1-4749-903f-5e76c24e2e5f/assets/fr/NPRIpictogramme-2016data-FR__1552505700147__w975.jpg',
+                        '/410b88da-0ed1-4749-903f-5e76c24e2e5f/assets/fr/NPRIpictogramme-2016data-FR__1552505700147__w975.jpg',
                     type: 'image',
                     altText: `Image décrivant le flux industriel des rejets sur place dans l'air, l'eau et le sol, des éliminations sur place, des éliminations hors site et des transferts hors site.`
                 }
@@ -47,7 +47,7 @@ Cette carte montre une étendue potentielle généralisée des trois zones de sa
                     type: 'text'
                 },
                 {
-                    config: '410b88da-0ed1-4749-903f-5e76c24e2e5f/ramp-config/fr/OilSandsDeposits.json',
+                    config: '/410b88da-0ed1-4749-903f-5e76c24e2e5f/ramp-config/fr/OilSandsDeposits.json',
                     type: 'map'
                 }
             ]
@@ -66,7 +66,7 @@ L’exploitation à ciel ouvert consiste à creuser de grandes surfaces à l’a
                 },
                 {
                     src:
-                        '410b88da-0ed1-4749-903f-5e76c24e2e5f/assets/fr/GettyImages-187242601__1554821412825__w1920.jpg',
+                        '/410b88da-0ed1-4749-903f-5e76c24e2e5f/assets/fr/GettyImages-187242601__1554821412825__w1920.jpg',
                     type: 'image',
                     altText: `Image montrant une vue aérienne d'une installation d'extraction de sables bitumineux.`
                 }
@@ -83,7 +83,7 @@ Les installations in situ ont une empreinte physique beaucoup plus petite que le
                     type: 'text'
                 },
                 {
-                    src: '410b88da-0ed1-4749-903f-5e76c24e2e5f/assets/fr/Slide 3 - mine vs insitu.jpg',
+                    src: '/410b88da-0ed1-4749-903f-5e76c24e2e5f/assets/fr/Slide 3 - mine vs insitu.jpg',
                     type: 'image',
                     altText: `Schéma montrant le processus d'extraction impliquant le pompage de vapeur à haute pression dans les profondeurs souterraines.`
                 }
@@ -107,7 +107,7 @@ Les installations in situ ont une empreinte physique beaucoup plus petite que le
                     type: 'text'
                 },
                 {
-                    config: '410b88da-0ed1-4749-903f-5e76c24e2e5f/ramp-config/fr/OilSandsFacilityLocations2019.json',
+                    config: '/410b88da-0ed1-4749-903f-5e76c24e2e5f/ramp-config/fr/OilSandsFacilityLocations2019.json',
                     type: 'map'
                 }
             ]
@@ -134,7 +134,7 @@ Les sept installations d’exploitation minière à ciel ouvert des sables bitum
                     charts: [
                         {
                             src:
-                                '410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/fr/substances/1.Imperial Oil Resources Limited-Kearl Oil Sands Processing Plant and Mine.csv',
+                                '/410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/fr/substances/1.Imperial Oil Resources Limited-Kearl Oil Sands Processing Plant and Mine.csv',
                             options: {
                                 title: `Usine de Transformation e Mine Kearl D'imperial 2019 Rejets et Éliminations (tonnes)`,
                                 subtitle: '',
@@ -143,7 +143,7 @@ Les sept installations d’exploitation minière à ciel ouvert des sables bitum
                         },
                         {
                             src:
-                                '410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/fr/substances/2.Suncor Energy Oil Sands Limited Partnership-Suncor Energy Inc. Oil Sands.csv',
+                                '/410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/fr/substances/2.Suncor Energy Oil Sands Limited Partnership-Suncor Energy Inc. Oil Sands.csv',
                             options: {
                                 title: `Sables bitumineux de Suncor Energy Inc. 2019 Rejets et Éliminations (tonnes)`,
                                 subtitle: '',
@@ -152,7 +152,7 @@ Les sept installations d’exploitation minière à ciel ouvert des sables bitum
                         },
                         {
                             src:
-                                '410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/fr/substances/3.Syncrude Canada Ltd.-Syncrude Canada Ltd.csv',
+                                '/410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/fr/substances/3.Syncrude Canada Ltd.-Syncrude Canada Ltd.csv',
                             options: {
                                 title: `Site de la Mine Syncrude Canada Ltd. 2019 Rejets et Éliminations (tonnes)`,
                                 subtitle: '',
@@ -161,7 +161,7 @@ Les sept installations d’exploitation minière à ciel ouvert des sables bitum
                         },
                         {
                             src:
-                                '410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/fr/substances/4.Syncrude Canada Ltd.-Aurora North Mine Site.csv',
+                                '/410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/fr/substances/4.Syncrude Canada Ltd.-Aurora North Mine Site.csv',
                             options: {
                                 title: `Site de la Mine Aurora Nord de Syncrude Canada 2019 Rejets et Éliminations (tonnes)`,
                                 subtitle: '',
@@ -170,7 +170,7 @@ Les sept installations d’exploitation minière à ciel ouvert des sables bitum
                         },
                         {
                             src:
-                                '410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/fr/substances/5.Canadian Natural Upgrading Limited Muskeg River Mine and Jackpine Mine.csv',
+                                '/410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/fr/substances/5.Canadian Natural Upgrading Limited Muskeg River Mine and Jackpine Mine.csv',
                             options: {
                                 title: `Canadian Natural Upgrading Mine de la Rivière Muskeg et Mine Jackpine 2019 Rejets et Éliminations (tonnes)`,
                                 subtitle: '',
@@ -179,7 +179,7 @@ Les sept installations d’exploitation minière à ciel ouvert des sables bitum
                         },
                         {
                             src:
-                                '410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/fr/substances/6.Canadian Natural Resources Limited-Horizon Oil Sands Processing Plant and Mine.csv',
+                                '/410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/fr/substances/6.Canadian Natural Resources Limited-Horizon Oil Sands Processing Plant and Mine.csv',
                             options: {
                                 title: `Canadian Natural Resources Usine de Transformations et Mine Horizon 2019 Rejets et Éliminations (tonnes)`,
                                 subtitle: '',
@@ -188,7 +188,7 @@ Les sept installations d’exploitation minière à ciel ouvert des sables bitum
                         },
                         {
                             src:
-                                '410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/fr/substances/7.Fort Hills Energy L.P.-Fort Hills Oil Sands.csv',
+                                '/410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/fr/substances/7.Fort Hills Energy L.P.-Fort Hills Oil Sands.csv',
                             options: {
                                 title: `Mine de sables bitumineux Fort Hills 2019 Rejets et Éliminations (tonnes)`,
                                 subtitle: '',
@@ -215,7 +215,7 @@ Explorez chaque installation avec l’imagerie par satellite.`,
                 },
                 {
                     config:
-                        '410b88da-0ed1-4749-903f-5e76c24e2e5f/ramp-config/fr/ReleasesandDisposalsbyMiningFacilitiesin2019(satellite).json',
+                        '/410b88da-0ed1-4749-903f-5e76c24e2e5f/ramp-config/fr/ReleasesandDisposalsbyMiningFacilitiesin2019(satellite).json',
                     type: 'map'
                 }
             ]
@@ -233,7 +233,7 @@ Explorez chaque installation avec l’imagerie par satellite.`,
                     charts: [
                         {
                             src:
-                                '410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/fr/Criteria air contaminant releases from oil sands mines_1.csv',
+                                '/410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/fr/Criteria air contaminant releases from oil sands mines_1.csv',
                             options: {
                                 xAxisLabel: '',
                                 yAxisLabel: 'Rejets de PCA (mille tonnes)',
@@ -245,7 +245,7 @@ Explorez chaque installation avec l’imagerie par satellite.`,
                         },
                         {
                             src:
-                                '410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/fr/Criteria air contaminant releases from oil sands mines_2.csv',
+                                '/410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/fr/Criteria air contaminant releases from oil sands mines_2.csv',
                             options: {
                                 xAxisLabel: '',
                                 yAxisLabel: 'Nombre de barils par année',
@@ -257,7 +257,7 @@ Explorez chaque installation avec l’imagerie par satellite.`,
                         },
                         {
                             src:
-                                '410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/fr/Criteria air contaminant releases from oil sands mines_3.csv',
+                                '/410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/fr/Criteria air contaminant releases from oil sands mines_3.csv',
                             options: {
                                 xAxisLabel: '',
                                 yAxisLabel: 'Rejets de PCA par 1000 barils',
@@ -295,7 +295,7 @@ Bien que les résidus déclarés par ces mines contiennent de grandes quantités
                     type: 'chart',
                     charts: [
                         {
-                            src: '410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/fr/Mine tailings reported.csv',
+                            src: '/410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/fr/Mine tailings reported.csv',
 
                             options: {
                                 xAxisLabel: 'Substances',
@@ -330,7 +330,7 @@ Bien que les résidus déclarés par ces mines contiennent de grandes quantités
                     charts: [
                         {
                             src:
-                                '410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/fr/tailings/1.Syncrude Canada Ltd., Aurora North Mine Site 2019 Tailings.csv',
+                                '/410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/fr/tailings/1.Syncrude Canada Ltd., Aurora North Mine Site 2019 Tailings.csv',
                             options: {
                                 title: `Syncrude Canada Ltd., Aurora North Mine Site 2019 Résidus miniers (tonnes)`,
                                 subtitle: '',
@@ -339,7 +339,7 @@ Bien que les résidus déclarés par ces mines contiennent de grandes quantités
                         },
                         {
                             src:
-                                '410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/fr/tailings/2.Fort Hill Energy L.P., Fort Hills Oil Sands 2019 Tailings.csv',
+                                '/410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/fr/tailings/2.Fort Hill Energy L.P., Fort Hills Oil Sands 2019 Tailings.csv',
                             options: {
                                 title: `Mine de sables bitumineux Fort Hills 2019 Résidus miniers (tonnes)`,
                                 subtitle: '',
@@ -348,7 +348,7 @@ Bien que les résidus déclarés par ces mines contiennent de grandes quantités
                         },
                         {
                             src:
-                                '410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/fr/tailings/3.Canadian Natural Resources Limited, Horizon Oil Sands Processing Plant and Mine 2019 Tailings.csv',
+                                '/410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/fr/tailings/3.Canadian Natural Resources Limited, Horizon Oil Sands Processing Plant and Mine 2019 Tailings.csv',
                             options: {
                                 title: `Canadian Natural Resources usine de transformation et Mine Horizon 2019 Résidus miniers (tonnes)`,
                                 subtitle: '',
@@ -357,7 +357,7 @@ Bien que les résidus déclarés par ces mines contiennent de grandes quantités
                         },
                         {
                             src:
-                                '410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/fr/tailings/4.Imperial Oil Resources Limited, Kearl Oil Sands Processing Plant and Mine 2019 Tailings.csv',
+                                '/410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/fr/tailings/4.Imperial Oil Resources Limited, Kearl Oil Sands Processing Plant and Mine 2019 Tailings.csv',
                             options: {
                                 title: `Usine de transformation et Mine Kearl D'Imperial Oil 2019 Résidus miniers (tonnes)`,
                                 subtitle: '',
@@ -366,7 +366,7 @@ Bien que les résidus déclarés par ces mines contiennent de grandes quantités
                         },
                         {
                             src:
-                                '410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/fr/tailings/5.Canadian Natural Upgrading Limited Muskeg River Mine and Jackpine Mine 2019 Tailings.csv',
+                                '/410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/fr/tailings/5.Canadian Natural Upgrading Limited Muskeg River Mine and Jackpine Mine 2019 Tailings.csv',
                             options: {
                                 title: `Canadian Natural Upgrading Mine de la Rivière Muskeg et Mine Jackpine 2019 Résidus miniers (tonnes)`,
                                 subtitle: '',
@@ -375,7 +375,7 @@ Bien que les résidus déclarés par ces mines contiennent de grandes quantités
                         },
                         {
                             src:
-                                '410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/fr/tailings/6.Suncor Energy Oil Sands Limited Partnership, Suncor Energy Inc. Oil Sands Tailings.csv',
+                                '/410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/fr/tailings/6.Suncor Energy Oil Sands Limited Partnership, Suncor Energy Inc. Oil Sands Tailings.csv',
                             options: {
                                 title: `Sables bitumineux de Suncor Energy Inc. 2019 Résidus miniers (tonnes)`,
                                 subtitle: '',
@@ -384,7 +384,7 @@ Bien que les résidus déclarés par ces mines contiennent de grandes quantités
                         },
                         {
                             src:
-                                '410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/fr/tailings/7.Syncrude Canada Ltd., Syncrude Canada Ltd. 2019 Tailings.csv',
+                                '/410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/fr/tailings/7.Syncrude Canada Ltd., Syncrude Canada Ltd. 2019 Tailings.csv',
                             options: {
                                 title: `Syncrude Canada Ltd., Syncrude Canada Ltd. 2019 Résidus miniers (tonnes)`,
                                 subtitle: '',
@@ -407,7 +407,7 @@ Explorez chaque installation avec l’imagerie par satellite.`,
                 },
                 {
                     config:
-                        '410b88da-0ed1-4749-903f-5e76c24e2e5f/ramp-config/fr/ReleasesandDisposalsbyMiningFacilitiesin2019(satellite).json',
+                        '/410b88da-0ed1-4749-903f-5e76c24e2e5f/ramp-config/fr/ReleasesandDisposalsbyMiningFacilitiesin2019(satellite).json',
                     type: 'map'
                 }
             ]
@@ -424,7 +424,7 @@ Explorez chaque installation avec l’imagerie par satellite.`,
                 },
                 {
                     config:
-                        '410b88da-0ed1-4749-903f-5e76c24e2e5f/ramp-config/fr/TailingsfromMiningFacilities2010to2019(timeslider).json',
+                        '/410b88da-0ed1-4749-903f-5e76c24e2e5f/ramp-config/fr/TailingsfromMiningFacilities2010to2019(timeslider).json',
                     type: 'map',
                     timeSlider: {
                         range: [2010, 2019],
@@ -447,7 +447,7 @@ En comparaison avec l’exploitation minière à ciel ouvert, l’exploitation i
                     type: 'text'
                 },
                 {
-                    src: '410b88da-0ed1-4749-903f-5e76c24e2e5f/assets/fr/Slide 10 - SAGD vs CSS.jpg',
+                    src: '/410b88da-0ed1-4749-903f-5e76c24e2e5f/assets/fr/Slide 10 - SAGD vs CSS.jpg',
                     type: 'image',
                     altText: `Schéma illustrant les processus de drainage par gravité au moyen de vapeur et de stimulation cyclique par la vapeur dans l'extraction des sables bitumineux.`
                 }
@@ -472,7 +472,7 @@ Les rejets atmosphériques déclarés par les installations in situ sont presque
                 },
                 {
                     config:
-                        '410b88da-0ed1-4749-903f-5e76c24e2e5f/ramp-config/fr/ReleasestoAirbyInSituFacilitiesforAllSubstancesin2019.json',
+                        '/410b88da-0ed1-4749-903f-5e76c24e2e5f/ramp-config/fr/ReleasestoAirbyInSituFacilitiesforAllSubstancesin2019.json',
                     type: 'map'
                 }
             ]
@@ -489,7 +489,7 @@ Ce changement dans le nombre d’installations déclarantes au fil du temps suit
                 },
                 {
                     config:
-                        '410b88da-0ed1-4749-903f-5e76c24e2e5f/ramp-config/fr/ReleasestoAirbyInSituFacilitiesforAllSubstances2010to2019(timeslider).json',
+                        '/410b88da-0ed1-4749-903f-5e76c24e2e5f/ramp-config/fr/ReleasestoAirbyInSituFacilitiesforAllSubstances2010to2019(timeslider).json',
                     type: 'map',
                     timeSlider: {
                         range: [2010, 2019],
@@ -516,7 +516,7 @@ Bien que les installations in situ aient signalé un accroissement des émission
                     charts: [
                         {
                             src:
-                                '410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/fr/NPRI releases from thermal in-situ facilities_1.csv',
+                                '/410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/fr/NPRI releases from thermal in-situ facilities_1.csv',
 
                             options: {
                                 //xAxisLabel: 'Year',
@@ -528,7 +528,7 @@ Bien que les installations in situ aient signalé un accroissement des émission
                         },
                         {
                             src:
-                                '410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/fr/NPRI releases from thermal in-situ facilities_2.csv',
+                                '/410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/fr/NPRI releases from thermal in-situ facilities_2.csv',
                             options: {
                                 //xAxisLabel: 'Year',
                                 yAxisLabel: 'Nombre de barils par année',
@@ -558,7 +558,7 @@ Les installations d’exploitation minière à ciel ouvert des sables bitumineux
                     type: 'text'
                 },
                 {
-                    src: '410b88da-0ed1-4749-903f-5e76c24e2e5f/assets/fr/slide%2014%20-%20athabasca.jpg',
+                    src: '/410b88da-0ed1-4749-903f-5e76c24e2e5f/assets/fr/slide%2014%20-%20athabasca.jpg',
                     type: 'image',
                     altText: 'Vue aérienne de la rivière Athabasca.'
                 }

--- a/public/ea24000c-7dc3-49a9-baac-c55d28dcaeb9/ea24000c-7dc3-49a9-baac-c55d28dcaeb9_en.ts
+++ b/public/ea24000c-7dc3-49a9-baac-c55d28dcaeb9/ea24000c-7dc3-49a9-baac-c55d28dcaeb9_en.ts
@@ -22,7 +22,7 @@ This substance overview explores the total quantities of Ethylene Glycol reporte
                     type: 'text'
                 },
                 {
-                    src: 'ea24000c-7dc3-49a9-baac-c55d28dcaeb9/assets/en/1-Plane deiced.jpg',
+                    src: '/ea24000c-7dc3-49a9-baac-c55d28dcaeb9/assets/en/1-Plane deiced.jpg',
                     type: 'image',
                     caption:
                         'Source: Gettyimages, Richard Goerge (2021), a [passenger plane being deiced prior a takeoff](https://www.gettyimages.ca/detail/photo/plane-deicing-royalty-free-image/547930075?adppopup=true)',
@@ -104,7 +104,7 @@ The rapid degradation, low concentrations in terms of toxicity, seasonality of r
                 {
                     scrollguard: true,
                     title: 'Location of NPRI facilities that reported ethylene glycol releases in 2019 by sector',
-                    config: 'ea24000c-7dc3-49a9-baac-c55d28dcaeb9/ramp-config/en/locations.json',
+                    config: '/ea24000c-7dc3-49a9-baac-c55d28dcaeb9/ramp-config/en/locations.json',
                     type: 'map'
                 }
             ]
@@ -121,7 +121,7 @@ The rapid degradation, low concentrations in terms of toxicity, seasonality of r
                     type: 'chart',
                     charts: [
                         {
-                            src: 'ea24000c-7dc3-49a9-baac-c55d28dcaeb9/charts/en/EG_releases_2019_en.csv',
+                            src: '/ea24000c-7dc3-49a9-baac-c55d28dcaeb9/charts/en/EG_releases_2019_en.csv',
 
                             options: {
                                 title: 'Figure 1: Percentage of total ethylene glycol releases for 2019, by sector',
@@ -146,7 +146,7 @@ The rapid degradation, low concentrations in terms of toxicity, seasonality of r
                     charts: [
                         {
                             src:
-                                'ea24000c-7dc3-49a9-baac-c55d28dcaeb9/charts/en/Total releases of ethylene glycol for 2019, by province_en.csv',
+                                '/ea24000c-7dc3-49a9-baac-c55d28dcaeb9/charts/en/Total releases of ethylene glycol for 2019, by province_en.csv',
 
                             options: {
                                 title: 'Figure 2: Total releases of ethylene glycol for 2019, by province',
@@ -170,7 +170,7 @@ Overall, total releases of ethylene glycol have increased between 2010 and 2019,
                     type: 'text'
                 },
                 {
-                    config: 'ea24000c-7dc3-49a9-baac-c55d28dcaeb9/ramp-config/en/total_releases2019.json',
+                    config: '/ea24000c-7dc3-49a9-baac-c55d28dcaeb9/ramp-config/en/total_releases2019.json',
                     type: 'map'
                 }
             ]
@@ -190,7 +190,7 @@ As for water releases, we are seeing an overall decreasing trend, driven by decr
                     charts: [
                         {
                             src:
-                                'ea24000c-7dc3-49a9-baac-c55d28dcaeb9/charts/en/Ethlyene glycol release trends, by sector 2010-2019 (tonnes)_en.csv',
+                                '/ea24000c-7dc3-49a9-baac-c55d28dcaeb9/charts/en/Ethlyene glycol release trends, by sector 2010-2019 (tonnes)_en.csv',
 
                             options: {
                                 title: 'Figure 3: Ethylene glycol release trends, by sector 2010-2019 (tonnes)',
@@ -215,7 +215,7 @@ As for water releases, we are seeing an overall decreasing trend, driven by decr
                     charts: [
                         {
                             src:
-                                'ea24000c-7dc3-49a9-baac-c55d28dcaeb9/charts/en/Percentage of ethylene glycol disposal and recycling, by sector (2019).csv',
+                                '/ea24000c-7dc3-49a9-baac-c55d28dcaeb9/charts/en/Percentage of ethylene glycol disposal and recycling, by sector (2019).csv',
 
                             options: {
                                 title: `Figure 4: Percentage of ethylene glycol disposal and recycling, by sector (2019)`,
@@ -236,7 +236,7 @@ As for water releases, we are seeing an overall decreasing trend, driven by decr
                     type: 'text'
                 },
                 {
-                    config: 'ea24000c-7dc3-49a9-baac-c55d28dcaeb9/ramp-config/en/total_quantities2019.json',
+                    config: '/ea24000c-7dc3-49a9-baac-c55d28dcaeb9/ramp-config/en/total_quantities2019.json',
                     type: 'map'
                 }
             ]
@@ -258,7 +258,7 @@ You can read more on [Air Transportation](https://tc.canada.ca/en/corporate-serv
                     charts: [
                         {
                             src:
-                                'ea24000c-7dc3-49a9-baac-c55d28dcaeb9/charts/en/Ethlyene glycol disposal and recycling trends, by sector 2010-2019 (tonnes)_en.csv',
+                                '/ea24000c-7dc3-49a9-baac-c55d28dcaeb9/charts/en/Ethlyene glycol disposal and recycling trends, by sector 2010-2019 (tonnes)_en.csv',
 
                             options: {
                                 title:

--- a/public/ea24000c-7dc3-49a9-baac-c55d28dcaeb9/ea24000c-7dc3-49a9-baac-c55d28dcaeb9_fr.ts
+++ b/public/ea24000c-7dc3-49a9-baac-c55d28dcaeb9/ea24000c-7dc3-49a9-baac-c55d28dcaeb9_fr.ts
@@ -24,7 +24,7 @@ Le présent aperçu de substance analyse les quantités totales d’éthylène g
                 {
                     caption:
                         'Source: Gettyimages, Richard Goerge (2021), a [dégivrage d’un avion avant le décollage](https://www.gettyimages.ca/detail/photo/plane-deicing-royalty-free-image/547930075?adppopup=true)',
-                    src: 'ea24000c-7dc3-49a9-baac-c55d28dcaeb9/assets/fr/1-Plane deiced.jpg',
+                    src: '/ea24000c-7dc3-49a9-baac-c55d28dcaeb9/assets/fr/1-Plane deiced.jpg',
                     type: 'image',
                     altText: 'Dégivrage d’un avion avant le décollage'
                 }
@@ -114,7 +114,7 @@ En 2019, la province comptant le plus grand nombre d’installations ayant décl
                     type: 'text'
                 },
                 {
-                    config: 'ea24000c-7dc3-49a9-baac-c55d28dcaeb9/ramp-config/fr/locations.json',
+                    config: '/ea24000c-7dc3-49a9-baac-c55d28dcaeb9/ramp-config/fr/locations.json',
                     type: 'map'
                 }
             ]
@@ -131,7 +131,7 @@ En 2019, la province comptant le plus grand nombre d’installations ayant décl
                     type: 'chart',
                     charts: [
                         {
-                            src: 'ea24000c-7dc3-49a9-baac-c55d28dcaeb9/charts/fr/EG_releases_2019_fr.csv',
+                            src: '/ea24000c-7dc3-49a9-baac-c55d28dcaeb9/charts/fr/EG_releases_2019_fr.csv',
 
                             options: {
                                 title: `Figure 1 : Pourcentage des rejets totaux d'éthylène glycol pour 2019, par secteur`,
@@ -156,7 +156,7 @@ En 2019, la province comptant le plus grand nombre d’installations ayant décl
                     charts: [
                         {
                             src:
-                                'ea24000c-7dc3-49a9-baac-c55d28dcaeb9/charts/fr/Total releases of ethylene glycol for 2019, by province_fr.csv',
+                                '/ea24000c-7dc3-49a9-baac-c55d28dcaeb9/charts/fr/Total releases of ethylene glycol for 2019, by province_fr.csv',
 
                             options: {
                                 title: `Figure 2: Rejets totaux d'éthylène glycol pour 2019, par province`,
@@ -180,7 +180,7 @@ Dans l’ensemble, les rejets totaux d’éthylène glycol ont augmenté entre 2
                     type: 'text'
                 },
                 {
-                    config: 'ea24000c-7dc3-49a9-baac-c55d28dcaeb9/ramp-config/fr/total_releases2019.json',
+                    config: '/ea24000c-7dc3-49a9-baac-c55d28dcaeb9/ramp-config/fr/total_releases2019.json',
                     type: 'map'
                 }
             ]
@@ -200,7 +200,7 @@ Pour ce qui est des rejets dans l’eau, nous observons une tendance générale 
                     charts: [
                         {
                             src:
-                                'ea24000c-7dc3-49a9-baac-c55d28dcaeb9/charts/fr/Ethlyene glycol release trends, by sector 2010-2019 (tonnes)_fr.csv',
+                                '/ea24000c-7dc3-49a9-baac-c55d28dcaeb9/charts/fr/Ethlyene glycol release trends, by sector 2010-2019 (tonnes)_fr.csv',
 
                             options: {
                                 title: `Figure 3: Tendances des rejets d'éthylène glycol, par secteur 2010-2019 (tonnes)`,
@@ -225,7 +225,7 @@ Pour ce qui est des rejets dans l’eau, nous observons une tendance générale 
                     charts: [
                         {
                             src:
-                                'ea24000c-7dc3-49a9-baac-c55d28dcaeb9/charts/fr/Percentage of ethylene glycol disposal and recycling, by sector (2019).csv',
+                                '/ea24000c-7dc3-49a9-baac-c55d28dcaeb9/charts/fr/Percentage of ethylene glycol disposal and recycling, by sector (2019).csv',
 
                             options: {
                                 title: `Figure 4: Pourcentage des éliminations et du recyclage d'éthylène glycol, par secteur (2019)`,
@@ -246,7 +246,7 @@ Pour ce qui est des rejets dans l’eau, nous observons une tendance générale 
                     type: 'text'
                 },
                 {
-                    config: 'ea24000c-7dc3-49a9-baac-c55d28dcaeb9/ramp-config/fr/total_quantities2019.json',
+                    config: '/ea24000c-7dc3-49a9-baac-c55d28dcaeb9/ramp-config/fr/total_quantities2019.json',
                     type: 'map'
                 }
             ]
@@ -268,7 +268,7 @@ Obtenez plus de détails sur le [transport aérien](https://tc.canada.ca/fr/serv
                     charts: [
                         {
                             src:
-                                'ea24000c-7dc3-49a9-baac-c55d28dcaeb9/charts/fr/Ethlyene glycol disposal and recycling trends, by sector 2010-2019 (tonnes)_fr.csv',
+                                '/ea24000c-7dc3-49a9-baac-c55d28dcaeb9/charts/fr/Ethlyene glycol disposal and recycling trends, by sector 2010-2019 (tonnes)_fr.csv',
 
                             options: {
                                 title: `Figure 5 : Tendances des élimination et du recyclage d'éthylène glycol, par secteur 2010-2019 (tonnes)`,

--- a/public/f6f7baf4-cccb-4521-a037-b4691b0f0d49/f6f7baf4-cccb-4521-a037-b4691b0f0d49_en.ts
+++ b/public/f6f7baf4-cccb-4521-a037-b4691b0f0d49/f6f7baf4-cccb-4521-a037-b4691b0f0d49_en.ts
@@ -39,7 +39,7 @@ This overview of the pulp and paper sector reproduces the key points presented i
                     type: 'text'
                 },
                 {
-                    src: 'f6f7baf4-cccb-4521-a037-b4691b0f0d49/assets/en/PP_sector.jpg',
+                    src: '/f6f7baf4-cccb-4521-a037-b4691b0f0d49/assets/en/PP_sector.jpg',
                     altText: 'A stock image of a pulp and paper facility.',
                     type: 'image'
                 }
@@ -54,7 +54,7 @@ This overview of the pulp and paper sector reproduces the key points presented i
                     type: 'text'
                 },
                 {
-                    config: 'f6f7baf4-cccb-4521-a037-b4691b0f0d49/ramp-config/en/locations.json',
+                    config: '/f6f7baf4-cccb-4521-a037-b4691b0f0d49/ramp-config/en/locations.json',
                     type: 'map'
                 }
             ]
@@ -84,7 +84,7 @@ Several pollutants reportable under NPRI are released to the environment as by-p
                 {
                     caption:
                         'Source: Gettyimages, Dorling Kindersley (2021), [Diagram of a paper making factory](https://www.gettyimages.ca/detail/illustration/diagram-of-a-paper-making-factory-royalty-free-illustration/75488548?adppopup=true)',
-                    src: 'f6f7baf4-cccb-4521-a037-b4691b0f0d49/assets/en/Mechanical_process_EN.png',
+                    src: '/f6f7baf4-cccb-4521-a037-b4691b0f0d49/assets/en/Mechanical_process_EN.png',
                     type: 'image',
                     altText:
                         'Step 1. Preparation of raw material: wood chips are mechanically shredded. Step 2. Pulping and bleaching. Step 3. Pulp is finished in the paper machine. Step 4. Shipping of the final product.'
@@ -106,7 +106,7 @@ Some of the wood fibre that is traditionally used for making pulp and paper can 
                 {
                     caption:
                         'Source: Gettyimages, Dorling Kindersley (2021), [Diagram of a paper making factory](https://www.gettyimages.ca/detail/illustration/diagram-of-a-paper-making-factory-royalty-free-illustration/75488548?adppopup=true)',
-                    src: 'f6f7baf4-cccb-4521-a037-b4691b0f0d49/assets/en/Chemical_process_EN.png',
+                    src: '/f6f7baf4-cccb-4521-a037-b4691b0f0d49/assets/en/Chemical_process_EN.png',
                     type: 'image',
                     altText:
                         'Step 1. Preparation of raw material: wood fibres are separated using chemical and high temperature treatments. Step 2. Pulping and bleaching. Step 3. Pulp is finished in the paper machine. Step 4. Shipping of the final product.'
@@ -127,7 +127,7 @@ Some pulp and paper industry facilities include a wastewater treatment system an
                     type: 'text'
                 },
                 {
-                    src: 'f6f7baf4-cccb-4521-a037-b4691b0f0d49/assets/en/Subprocess.jpg',
+                    src: '/f6f7baf4-cccb-4521-a037-b4691b0f0d49/assets/en/Subprocess.jpg',
                     altText: 'A stock image of a pulp and paper facility, aerial view.',
                     type: 'image'
                 }
@@ -155,7 +155,7 @@ Some pulp and paper industry facilities include a wastewater treatment system an
                     title:
                         'Total releases and disposals of pulp and paper facilities that reported to the NPRI from 2010 to 2019',
                     config:
-                        'f6f7baf4-cccb-4521-a037-b4691b0f0d49/ramp-config/en/total_releases_and_disposals_of_pnp_2010-2019.json',
+                        '/f6f7baf4-cccb-4521-a037-b4691b0f0d49/ramp-config/en/total_releases_and_disposals_of_pnp_2010-2019.json',
                     type: 'map',
                     timeSlider: {
                         range: [2010, 2019],
@@ -177,7 +177,7 @@ Some pulp and paper industry facilities include a wastewater treatment system an
                     title:
                         'Total criteria air contaminants released by pulp and paper facilities that reported to the NPRI from 2010 to 2019',
                     config:
-                        'f6f7baf4-cccb-4521-a037-b4691b0f0d49/ramp-config/en/total_criteria_air_contaminants_of_pnp_2010-2019.json',
+                        '/f6f7baf4-cccb-4521-a037-b4691b0f0d49/ramp-config/en/total_criteria_air_contaminants_of_pnp_2010-2019.json',
                     type: 'map',
                     timeSlider: {
                         range: [2010, 2019],
@@ -205,7 +205,7 @@ In pulp and paper mills, ammonia (NH<sub>3</sub>) is generally neither manufactu
                     type: 'chart',
                     charts: [
                         {
-                            src: 'f6f7baf4-cccb-4521-a037-b4691b0f0d49/charts/en/CAC_en.csv',
+                            src: '/f6f7baf4-cccb-4521-a037-b4691b0f0d49/charts/en/CAC_en.csv',
 
                             options: {
                                 xAxisLabel: '',
@@ -240,7 +240,7 @@ TRS is generally neither manufactured nor processed in high quantity. However, t
                     title:
                         'Total reduced sulphur released by pulp and paper facilities that reported to the NPRI from 2010 to 2019',
                     config:
-                        'f6f7baf4-cccb-4521-a037-b4691b0f0d49/ramp-config/en/total_reduced_sulphur_of_pnp_2010-2019.json',
+                        '/f6f7baf4-cccb-4521-a037-b4691b0f0d49/ramp-config/en/total_reduced_sulphur_of_pnp_2010-2019.json',
                     type: 'map',
                     timeSlider: {
                         range: [2010, 2019],
@@ -272,7 +272,7 @@ TRS is generally neither manufactured nor processed in high quantity. However, t
                     type: 'text'
                 },
                 {
-                    src: 'f6f7baf4-cccb-4521-a037-b4691b0f0d49/assets/en/trs_en.png',
+                    src: '/f6f7baf4-cccb-4521-a037-b4691b0f0d49/assets/en/trs_en.png',
                     type: 'image',
                     altText: 'A graphical pie chart representation of the data table in the previous slide.'
                 }
@@ -294,7 +294,7 @@ Pulp and paper facilities are required to conduct [Environmental Effects Monitor
                     title:
                         'Phosphorus and nitrates released by pulp and paper facilities that reported to the NPRI from 2010 to 2019',
                     config:
-                        'f6f7baf4-cccb-4521-a037-b4691b0f0d49/ramp-config/en/phosphorus_and_nitrates_of_pnp_2010-2019.json',
+                        '/f6f7baf4-cccb-4521-a037-b4691b0f0d49/ramp-config/en/phosphorus_and_nitrates_of_pnp_2010-2019.json',
                     type: 'map',
                     timeSlider: {
                         range: [2010, 2019],
@@ -316,7 +316,7 @@ Pulp and paper facilities are required to conduct [Environmental Effects Monitor
                     title:
                         'Total disposals and transfers of pulp and paper facilities that reported to the NPRI from 2010 to 2019',
                     config:
-                        'f6f7baf4-cccb-4521-a037-b4691b0f0d49/ramp-config/en/total_disposals_and_transfers_of_pnp_2010-2019.json',
+                        '/f6f7baf4-cccb-4521-a037-b4691b0f0d49/ramp-config/en/total_disposals_and_transfers_of_pnp_2010-2019.json',
                     type: 'map',
                     timeSlider: {
                         range: [2010, 2019],
@@ -335,7 +335,7 @@ Pulp and paper facilities are required to conduct [Environmental Effects Monitor
                     type: 'text'
                 },
                 {
-                    src: 'f6f7baf4-cccb-4521-a037-b4691b0f0d49/assets/en/substances_recovered_en.png',
+                    src: '/f6f7baf4-cccb-4521-a037-b4691b0f0d49/assets/en/substances_recovered_en.png',
                     altText:
                         'Pie chart 1. Proportion of substances directly released in the environment and recovered substances: Proportion of substances directly released in the environment- 96%, Proportion of recovered substances- 4%; Pie chart 2. Proportion of substances subject to a recovery process: Off-site disposal- 36%, On-site disposal- 44%, Recycling- 17%, Treatment- 3%.',
                     type: 'image'
@@ -358,7 +358,7 @@ Pulp and paper facilities are required to conduct [Environmental Effects Monitor
                     type: 'text'
                 },
                 {
-                    src: 'f6f7baf4-cccb-4521-a037-b4691b0f0d49/assets/en/Regulations.jpg',
+                    src: '/f6f7baf4-cccb-4521-a037-b4691b0f0d49/assets/en/Regulations.jpg',
                     altText: 'A stock image of a pulp and paper facility.',
                     type: 'image'
                 }
@@ -383,7 +383,7 @@ Learn more about [pollution prevention](https://www.canada.ca/en/environment-cli
                     type: 'text'
                 },
                 {
-                    config: 'f6f7baf4-cccb-4521-a037-b4691b0f0d49/ramp-config/en/pollution_prevention_activities.json',
+                    config: '/f6f7baf4-cccb-4521-a037-b4691b0f0d49/ramp-config/en/pollution_prevention_activities.json',
                     type: 'map'
                 }
             ]
@@ -405,7 +405,7 @@ The [2019 State of Canada’s Forests report](https://www.nrcan.gc.ca/our-natura
                     type: 'text'
                 },
                 {
-                    src: 'f6f7baf4-cccb-4521-a037-b4691b0f0d49/assets/en/Futur.jpg',
+                    src: '/f6f7baf4-cccb-4521-a037-b4691b0f0d49/assets/en/Futur.jpg',
                     altText: 'An image of a large pile of lumber.',
                     type: 'image'
                 }

--- a/public/f6f7baf4-cccb-4521-a037-b4691b0f0d49/f6f7baf4-cccb-4521-a037-b4691b0f0d49_fr.ts
+++ b/public/f6f7baf4-cccb-4521-a037-b4691b0f0d49/f6f7baf4-cccb-4521-a037-b4691b0f0d49_fr.ts
@@ -38,7 +38,7 @@ Cet aperçu de secteur sur les pâtes et papiers reprend les points saillants du
                     type: 'text'
                 },
                 {
-                    src: 'f6f7baf4-cccb-4521-a037-b4691b0f0d49/assets/fr/PP_sector.jpg',
+                    src: '/f6f7baf4-cccb-4521-a037-b4691b0f0d49/assets/fr/PP_sector.jpg',
                     altText: `Image d'une usine de pâte et papier.`,
                     type: 'image'
                 }
@@ -53,7 +53,7 @@ Cet aperçu de secteur sur les pâtes et papiers reprend les points saillants du
                     type: 'text'
                 },
                 {
-                    config: 'f6f7baf4-cccb-4521-a037-b4691b0f0d49/ramp-config/fr/locations.json',
+                    config: '/f6f7baf4-cccb-4521-a037-b4691b0f0d49/ramp-config/fr/locations.json',
                     type: 'map'
                 }
             ]
@@ -84,7 +84,7 @@ Plusieurs polluants rejetés dans l’environnement par la fabrication de pâtes
                     caption:
                         'Source: Gettyimages, Dorling Kindersley (2021), [schéma d’une usine de fabrication de papier](https://www.gettyimages.ca/detail/illustration/diagram-of-a-paper-making-factory-royalty-free-illustration/75488548?adppopup=true)',
 
-                    src: 'f6f7baf4-cccb-4521-a037-b4691b0f0d49/assets/fr/Mechanical_process_FR.png',
+                    src: '/f6f7baf4-cccb-4521-a037-b4691b0f0d49/assets/fr/Mechanical_process_FR.png',
                     type: 'image',
                     altText:
                         'Étape 1. Préparation de la matière première : broyage mécanique des copeaux de bois. Étape 2. Mise en pâte et blanchiment. Étape 3. Finition de la pâte dans la machine à papier. Étape 4. Expédition du produit final.'
@@ -107,7 +107,7 @@ La grande majorité de la pâte chimique produite au Canada est blanchie. La pâ
                     caption:
                         'Source: Gettyimages, Dorling Kindersley (2021), [schéma d’une usine de fabrication de papier](https://www.gettyimages.ca/detail/illustration/diagram-of-a-paper-making-factory-royalty-free-illustration/75488548?adppopup=true)',
 
-                    src: 'f6f7baf4-cccb-4521-a037-b4691b0f0d49/assets/fr/Chemical_process_FR.png',
+                    src: '/f6f7baf4-cccb-4521-a037-b4691b0f0d49/assets/fr/Chemical_process_FR.png',
                     type: 'image',
                     altText:
                         'Étape 1. Préparation de la matière première : séparation des fibres de bois à l’aide de produits chimiques et de cuisson à haute température. Étape 2. Mise en pâte et blanchiment. Étape 3. Finition de la pâte dans la machine à papier. Étape 4. Expédition du produit final.'
@@ -129,7 +129,7 @@ Certaines installations du secteur industriel des pâtes et papiers possèdent u
                     type: 'text'
                 },
                 {
-                    src: 'f6f7baf4-cccb-4521-a037-b4691b0f0d49/assets/fr/Subprocess.jpg',
+                    src: '/f6f7baf4-cccb-4521-a037-b4691b0f0d49/assets/fr/Subprocess.jpg',
                     altText: `Vue aérienne d'une usine de pâte et papier`,
                     type: 'image'
                 }
@@ -158,7 +158,7 @@ Certaines installations du secteur industriel des pâtes et papiers possèdent u
                     title:
                         'Rejets et éliminations totaux des installations de pâtes et papiers déclarant à l’INRP de 2010 à 2019',
                     config:
-                        'f6f7baf4-cccb-4521-a037-b4691b0f0d49/ramp-config/fr/total_releases_and_disposals_of_pnp_2010-2019.json',
+                        '/f6f7baf4-cccb-4521-a037-b4691b0f0d49/ramp-config/fr/total_releases_and_disposals_of_pnp_2010-2019.json',
                     type: 'map',
                     timeSlider: {
                         range: [2010, 2019],
@@ -180,7 +180,7 @@ Certaines installations du secteur industriel des pâtes et papiers possèdent u
                     title:
                         'Principaux contaminants atmosphériques totaux rejetés par les installations de pâtes et papiers déclarant à l’INRP de 2010 à 2019',
                     config:
-                        'f6f7baf4-cccb-4521-a037-b4691b0f0d49/ramp-config/fr/total_criteria_air_contaminants_of_pnp_2010-2019.json',
+                        '/f6f7baf4-cccb-4521-a037-b4691b0f0d49/ramp-config/fr/total_criteria_air_contaminants_of_pnp_2010-2019.json',
                     type: 'map',
                     timeSlider: {
                         range: [2010, 2019],
@@ -208,7 +208,7 @@ Dans les usines de pâtes et papiers, l’ammoniac (NH<sub>3</sub>) n’est gén
                     type: 'chart',
                     charts: [
                         {
-                            src: 'f6f7baf4-cccb-4521-a037-b4691b0f0d49/charts/fr/CAC_fr.csv',
+                            src: '/f6f7baf4-cccb-4521-a037-b4691b0f0d49/charts/fr/CAC_fr.csv',
 
                             options: {
                                 xAxisLabel: '',
@@ -243,7 +243,7 @@ Le SRT n’est généralement pas fabriqué ni traité en grande quantité, mais
                 {
                     title: `Rejets de soufre réduit total par les installations de pâtes et papiers déclarant à l’INRP de 2010 à 2019`,
                     config:
-                        'f6f7baf4-cccb-4521-a037-b4691b0f0d49/ramp-config/fr/total_reduced_sulphur_of_pnp_2010-2019.json',
+                        '/f6f7baf4-cccb-4521-a037-b4691b0f0d49/ramp-config/fr/total_reduced_sulphur_of_pnp_2010-2019.json',
                     type: 'map',
                     timeSlider: {
                         range: [2010, 2019],
@@ -275,7 +275,7 @@ Le SRT n’est généralement pas fabriqué ni traité en grande quantité, mais
                     type: 'text'
                 },
                 {
-                    src: 'f6f7baf4-cccb-4521-a037-b4691b0f0d49/assets/fr/trs_fr.png',
+                    src: '/f6f7baf4-cccb-4521-a037-b4691b0f0d49/assets/fr/trs_fr.png',
                     type: 'image',
                     altText: '[fr-] A graphical pie chart representation of the data table in the previous slide.'
                 }
@@ -296,7 +296,7 @@ Les installations de pâtes et papiers doivent effectuer des [études de suivis 
                 {
                     title: `Rejets de phosphore et de nitrates par les installations de pâtes et papiers déclarant à l’INRP de 2010 à 2019`,
                     config:
-                        'f6f7baf4-cccb-4521-a037-b4691b0f0d49/ramp-config/fr/phosphorus_and_nitrates_of_pnp_2010-2019.json',
+                        '/f6f7baf4-cccb-4521-a037-b4691b0f0d49/ramp-config/fr/phosphorus_and_nitrates_of_pnp_2010-2019.json',
                     type: 'map',
                     timeSlider: {
                         range: [2010, 2019],
@@ -317,7 +317,7 @@ Les installations de pâtes et papiers doivent effectuer des [études de suivis 
                 {
                     title: `Éliminations et transferts totaux par les installations de pâtes et papiers déclarant à l’INRP de 2010 à 2019`,
                     config:
-                        'f6f7baf4-cccb-4521-a037-b4691b0f0d49/ramp-config/fr/total_disposals_and_transfers_of_pnp_2010-2019.json',
+                        '/f6f7baf4-cccb-4521-a037-b4691b0f0d49/ramp-config/fr/total_disposals_and_transfers_of_pnp_2010-2019.json',
                     type: 'map',
                     timeSlider: {
                         range: [2010, 2019],
@@ -336,7 +336,7 @@ Les installations de pâtes et papiers doivent effectuer des [études de suivis 
                     type: 'text'
                 },
                 {
-                    src: 'f6f7baf4-cccb-4521-a037-b4691b0f0d49/assets/fr/substances_recovered_fr.png',
+                    src: '/f6f7baf4-cccb-4521-a037-b4691b0f0d49/assets/fr/substances_recovered_fr.png',
                     altText:
                         'Diagramme circulaire 1. Proportion des activités de récupération parmi le total des substances : Proportion des substances rejetées directement dans l’environnement- 96%, Proportion des substances récupérées- 4%; Diagramme circulaire 2. Proportion des substances soumises à un procédé de récupération: Élimination hors site- 36%, Élimination sur place- 44%, Recyclage- 17%, Traitement- 3%.',
                     type: 'image'
@@ -366,7 +366,7 @@ Les installations de pâtes et papiers doivent effectuer des [études de suivis 
                     type: 'text'
                 },
                 {
-                    src: 'f6f7baf4-cccb-4521-a037-b4691b0f0d49/assets/fr/Regulations.jpg',
+                    src: '/f6f7baf4-cccb-4521-a037-b4691b0f0d49/assets/fr/Regulations.jpg',
                     altText: `Image d'une usine de pâte et papier`,
                     type: 'image'
                 }
@@ -392,7 +392,7 @@ Apprenez-en plus sur la [prévention de la pollution](https://www.canada.ca/fr/e
                     type: 'text'
                 },
                 {
-                    config: 'f6f7baf4-cccb-4521-a037-b4691b0f0d49/ramp-config/fr/pollution_prevention_activities.json',
+                    config: '/f6f7baf4-cccb-4521-a037-b4691b0f0d49/ramp-config/fr/pollution_prevention_activities.json',
                     type: 'map'
                 }
             ]
@@ -414,7 +414,7 @@ Le rapport sur [L’état des forêts au Canada 2019](https://www.rncan.gc.ca/ou
                     type: 'text'
                 },
                 {
-                    src: 'f6f7baf4-cccb-4521-a037-b4691b0f0d49/assets/fr/Futur.jpg',
+                    src: '/f6f7baf4-cccb-4521-a037-b4691b0f0d49/assets/fr/Futur.jpg',
                     altText: `Image d'une pile de bois.`,
                     type: 'image'
                 }

--- a/public/index-ca-en.html
+++ b/public/index-ca-en.html
@@ -16,7 +16,7 @@
             type="text/javascript"
             src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"
         ></script>
-        <link rel="stylesheet" href="scripts/multi-ramp/rv-styles.css" />
+        <link rel="stylesheet" href="/scripts/multi-ramp/rv-styles.css" />
 
         <!-- top reference links and no-script fallback -->
         <noscript> <%= require('html-loader!../src/assets/static/cdts/refTop.html') %> </noscript>
@@ -26,7 +26,7 @@
     </head>
     <body>
         <!-- template top and no-script fallback -->
-        <div id="def-top">d<%= require('html-loader!../src/assets/static/cdts/top-en.html') %></div>
+        <div id="def-top"><%= require('html-loader!../src/assets/static/cdts/top-en.html') %></div>
 
         <div id="wb-cont">
             <div id="app"></div>
@@ -38,22 +38,22 @@
         <script type="text/javascript">
             // URL Parsing for Language Switch
             var url = new URL(window.location.href);
-            var hashParams = url.hash.split('/');
+            var hashParams = url.href.split('/');
 
             // If there's an empty item at the end of the paramater list (occurs if there's a trailing slash in the URL), clear it.
-            if(hashParams.at(-1).length === 0) {
+            if (hashParams.at(-1).length === 0) {
                 hashParams.pop();
             }
 
             // If content after the last slash in the URL is an anchor, clear it.
-            if(hashParams.at(-1).startsWith("#")) {
+            if (hashParams.at(-1).startsWith('#')) {
                 hashParams.pop();
             }
 
             // Finally, extract the StoryRAMP ID from the URL. If it has an anchor tag in it, remove it since it's not useful on the new page.
             var productID = hashParams.pop();
 
-            if(productID.includes("#")) {
+            if (productID.includes('#')) {
                 productID = productID.split('#')[0];
             }
 
@@ -62,7 +62,7 @@
                 lngLinks: [
                     {
                         lang: 'fr',
-                        href: 'index-ca-fr.html#/fr/' + productID,
+                        href: '/fr/' + productID,
                         text: 'Français'
                     }
                 ],
@@ -94,7 +94,7 @@
             document.write(wet.builder.refFooter({}));
         </script>
 
-        <script src="scripts/multi-ramp/rv-main.js"></script>
+        <script src="/scripts/multi-ramp/rv-main.js"></script>
 
         <style>
             html {
@@ -106,7 +106,7 @@
 <!-- START OF SmartSource Data Collector TAG -->
 <!-- Copyright (c) 1996-2021 Webtrends Inc.  All rights reserved. -->
 <!-- Version: 9.4.0 -->
-<script src="scripts/webtrends.js" type="text/javascript"></script>
+<script src="/scripts/webtrends.js" type="text/javascript"></script>
 <!-- ----------------------------------------------------------------------------------- -->
 <!-- Warning: The two script blocks below must remain inline. Moving them to an external -->
 <!-- JavaScript include file can cause serious problems with cross-domain tracking.      -->

--- a/public/index-ca-fr.html
+++ b/public/index-ca-fr.html
@@ -16,7 +16,7 @@
             type="text/javascript"
             src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"
         ></script>
-        <link rel="stylesheet" href="scripts/multi-ramp/rv-styles.css" />
+        <link rel="stylesheet" href="/scripts/multi-ramp/rv-styles.css" />
 
         <!-- top reference links and no-script fallback -->
         <noscript> <%= require('html-loader!../src/assets/static/cdts/refTop.html') %> </noscript>
@@ -26,7 +26,7 @@
     </head>
     <body>
         <!-- template top and no-script fallback -->
-        <div id="def-top">d<%= require('html-loader!../src/assets/static/cdts/top-fr.html') %></div>
+        <div id="def-top"><%= require('html-loader!../src/assets/static/cdts/top-fr.html') %></div>
 
         <div id="wb-cont">
             <div id="app"></div>
@@ -38,22 +38,22 @@
         <script type="text/javascript">
             // URL Parsing for Language Switch
             var url = new URL(window.location.href);
-            var hashParams = url.hash.split('/');
+            var hashParams = url.href.split('/');
 
             // If there's an empty item at the end of the paramater list (occurs if there's a trailing slash in the URL), clear it.
-            if(hashParams.at(-1).length === 0) {
+            if (hashParams.at(-1).length === 0) {
                 hashParams.pop();
             }
 
             // If content after the last slash in the URL is an anchor, clear it.
-            if(hashParams.at(-1).startsWith("#")) {
+            if (hashParams.at(-1).startsWith('#')) {
                 hashParams.pop();
             }
 
             // Finally, extract the StoryRAMP ID from the URL. If it has an anchor tag in it, remove it since it's not useful on the new page.
             var productID = hashParams.pop();
 
-            if(productID.includes("#")) {
+            if (productID.includes('#')) {
                 productID = productID.split('#')[0];
             }
 
@@ -62,7 +62,7 @@
                 lngLinks: [
                     {
                         lang: 'en',
-                        href: 'index-ca-en.html#/en/' + productID,
+                        href: '/en/' + productID,
                         text: 'English'
                     }
                 ],
@@ -94,7 +94,7 @@
             document.write(wet.builder.refFooter({}));
         </script>
 
-        <script src="scripts/multi-ramp/rv-main.js"></script>
+        <script src="/scripts/multi-ramp/rv-main.js"></script>
 
         <style>
             html {
@@ -106,7 +106,7 @@
 <!-- START OF SmartSource Data Collector TAG -->
 <!-- Copyright (c) 1996-2021 Webtrends Inc.  All rights reserved. -->
 <!-- Version: 9.4.0 -->
-<script src="scripts/webtrends.js" type="text/javascript"></script>
+<script src="/scripts/webtrends.js" type="text/javascript"></script>
 <!-- ----------------------------------------------------------------------------------- -->
 <!-- Warning: The two script blocks below must remain inline. Moving them to an external -->
 <!-- JavaScript include file can cause serious problems with cross-domain tracking.      -->

--- a/public/index.html
+++ b/public/index.html
@@ -4,10 +4,11 @@
         <meta charset="utf-8" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="viewport" content="width=device-width,initial-scale=1.0" />
-        
+        <base href="/" />
+
         <link rel="icon" href="<%= BASE_URL %>favicon.svg" />
         <link rel="stylesheet" href="scripts/multi-ramp/rv-styles.css" />
-        
+
         <title><%= htmlWebpackPlugin.options.title %></title>
     </head>
     <body>
@@ -25,7 +26,7 @@
 <!-- Warning: The two script blocks below must remain inline. Moving them to an external -->
 <!-- JavaScript include file can cause serious problems with cross-domain tracking.      -->
 <!-- ----------------------------------------------------------------------------------- -->
-<script type="text/javascript">
+<!-- <script type="text/javascript">
     //<![CDATA[
     var _tag = new WebTrends();
     _tag.dcsGetId();
@@ -36,11 +37,19 @@
     _tag.dcsCustom = function () {
         // Add custom parameters here.
         //_tag.DCSext.param_name=param_value;
-    }
+    };
     _tag.dcsCollect();
-//]]>
-</script>
+    //]]>
+</script> -->
 <noscript>
-    <div><img alt="DCSIMG" id="DCSIMG" width="1" height="1" src="https://sdc.ncr.ec.gc.ca/dcs2kf7dq10000kzg8kpqz5gp_3q4i/njs.gif?dcsuri=/nojavascript&amp;WT.js=No&amp;WT.tv=9.4.0&amp;dcssip=www.environmental-maps.canada.ca" /></div>
+    <div>
+        <img
+            alt="DCSIMG"
+            id="DCSIMG"
+            width="1"
+            height="1"
+            src="https://sdc.ncr.ec.gc.ca/dcs2kf7dq10000kzg8kpqz5gp_3q4i/njs.gif?dcsuri=/nojavascript&amp;WT.js=No&amp;WT.tv=9.4.0&amp;dcssip=www.environmental-maps.canada.ca"
+        />
+    </div>
 </noscript>
 <!-- END OF SmartSource Data Collector TAG -->

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -21,7 +21,7 @@ const routes = [
 
 export default new Router({
     routes: routes,
-    // mode: 'history', // TODO: uncomment to change to history mode for nicer URLs (eliminating middle hash) see #100
+    mode: 'history',
     scrollBehavior: function (to: Route) {
         if (to.hash) {
             return {

--- a/vue.config.js
+++ b/vue.config.js
@@ -19,5 +19,20 @@ module.exports = {
             title: 'Scenarios de PCAR'
         }
     },
-    publicPath: ''
+    devServer: {
+        historyApiFallback: {
+            //index: 'index-ca-en.html'
+            verbose: true,
+            rewrites: [
+                {
+                    from: /^\/en\/[^.]*$/,
+                    to: '/index-ca-en.html'
+                },
+                {
+                    from: /^\/fr\/[^.]*$/,
+                    to: '/index-ca-fr.html'
+                }
+            ]
+        }
+    }
 };


### PR DESCRIPTION
Closes #100 

## Don't pull until we can verify that the rewrites can be done on our servers


`/en/` urls will route to index-ca-en.html (when serving)
`/fr/` urls will route to index-ca-fr.html (when serving)
Had to adjust paths to be absolute instead of relative.

The rewrites I had to do for webpack dev servers (so probably what needs to be done for prod, etc.)

```
{
    from: /^\/en\/[^.]*$/,
    to: '/index-ca-en.html'
},
{
    from: /^\/fr\/[^.]*$/,
    to: '/index-ca-fr.html'
}
```


It seems like we should remove the route that doesn't have the lang code in the url, as well as having some way to prevent the test config from being loaded in prod.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/195)
<!-- Reviewable:end -->
