### PR TITLE
load ramp legacy-api to fix export

### DIFF
--- a/public/index-ca-en.html
+++ b/public/index-ca-en.html
@@ -41,19 +41,19 @@
             var hashParams = url.hash.split('/');
 
             // If there's an empty item at the end of the paramater list (occurs if there's a trailing slash in the URL), clear it.
-            if(hashParams.at(-1).length === 0) {
+            if (hashParams.at(-1).length === 0) {
                 hashParams.pop();
             }
 
             // If content after the last slash in the URL is an anchor, clear it.
-            if(hashParams.at(-1).startsWith("#")) {
+            if (hashParams.at(-1).startsWith('#')) {
                 hashParams.pop();
             }
 
             // Finally, extract the StoryRAMP ID from the URL. If it has an anchor tag in it, remove it since it's not useful on the new page.
             var productID = hashParams.pop();
 
-            if(productID.includes("#")) {
+            if (productID.includes('#')) {
                 productID = productID.split('#')[0];
             }
 
@@ -94,6 +94,7 @@
             document.write(wet.builder.refFooter({}));
         </script>
 
+        <script src="scripts/multi-ramp/legacy-api.js"></script>
         <script src="scripts/multi-ramp/rv-main.js"></script>
 
         <style>

--- a/public/index-ca-fr.html
+++ b/public/index-ca-fr.html
@@ -41,19 +41,19 @@
             var hashParams = url.hash.split('/');
 
             // If there's an empty item at the end of the paramater list (occurs if there's a trailing slash in the URL), clear it.
-            if(hashParams.at(-1).length === 0) {
+            if (hashParams.at(-1).length === 0) {
                 hashParams.pop();
             }
 
             // If content after the last slash in the URL is an anchor, clear it.
-            if(hashParams.at(-1).startsWith("#")) {
+            if (hashParams.at(-1).startsWith('#')) {
                 hashParams.pop();
             }
 
             // Finally, extract the StoryRAMP ID from the URL. If it has an anchor tag in it, remove it since it's not useful on the new page.
             var productID = hashParams.pop();
 
-            if(productID.includes("#")) {
+            if (productID.includes('#')) {
                 productID = productID.split('#')[0];
             }
 
@@ -94,6 +94,7 @@
             document.write(wet.builder.refFooter({}));
         </script>
 
+        <script src="scripts/multi-ramp/legacy-api.js"></script>
         <script src="scripts/multi-ramp/rv-main.js"></script>
 
         <style>

--- a/public/index.html
+++ b/public/index.html
@@ -4,16 +4,17 @@
         <meta charset="utf-8" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="viewport" content="width=device-width,initial-scale=1.0" />
-        
+
         <link rel="icon" href="<%= BASE_URL %>favicon.svg" />
         <link rel="stylesheet" href="scripts/multi-ramp/rv-styles.css" />
-        
+
         <title><%= htmlWebpackPlugin.options.title %></title>
     </head>
     <body>
         <div id="app"></div>
         <!-- built files will be auto injected -->
 
+        <script src="scripts/multi-ramp/legacy-api.js"></script>
         <script src="scripts/multi-ramp/rv-main.js"></script>
     </body>
 </html>
@@ -36,11 +37,19 @@
     _tag.dcsCustom = function () {
         // Add custom parameters here.
         //_tag.DCSext.param_name=param_value;
-    }
+    };
     _tag.dcsCollect();
-//]]>
+    //]]>
 </script>
 <noscript>
-    <div><img alt="DCSIMG" id="DCSIMG" width="1" height="1" src="https://sdc.ncr.ec.gc.ca/dcs2kf7dq10000kzg8kpqz5gp_3q4i/njs.gif?dcsuri=/nojavascript&amp;WT.js=No&amp;WT.tv=9.4.0&amp;dcssip=www.environmental-maps.canada.ca" /></div>
+    <div>
+        <img
+            alt="DCSIMG"
+            id="DCSIMG"
+            width="1"
+            height="1"
+            src="https://sdc.ncr.ec.gc.ca/dcs2kf7dq10000kzg8kpqz5gp_3q4i/njs.gif?dcsuri=/nojavascript&amp;WT.js=No&amp;WT.tv=9.4.0&amp;dcssip=www.environmental-maps.canada.ca"
+        />
+    </div>
 </noscript>
 <!-- END OF SmartSource Data Collector TAG -->

--- a/src/components/story/story.vue
+++ b/src/components/story/story.vue
@@ -84,7 +84,7 @@ import Circle2 from 'vue-loading-spinner/src/components/Circle2.vue';
 })
 export default class StoryV extends Vue {
     config: StoryRampConfig | undefined = undefined;
-    loadStatus: string = 'loading';
+    loadStatus = 'loading';
     activeChapterIndex = -1;
     lang = 'en';
 


### PR DESCRIPTION
Closes #196 

Export was looking for `RV` which is the legacy api. We had it in our scripts folder but weren't actually loading it.