### PR TITLE
Replace default test page at root route with error page

### DIFF
--- a/src/components/story/story.vue
+++ b/src/components/story/story.vue
@@ -89,10 +89,14 @@ export default class StoryV extends Vue {
     lang = 'en';
 
     created(): void {
-        const uid = this.$route.params.uid ? this.$route.params.uid : '00000000-0000-0000-0000-000000000000';
+        const uid = this.$route.params.uid;
         this.lang = this.$route.params.lang ? this.$route.params.lang : 'en';
         if (uid) {
             this.fetchConfig(uid, this.lang);
+        } else {
+            console.error(`Please supply the language and id URL params in the form of /[lang]/[uid].`);
+            // if no URL params have been provided redirect to canada.ca 404 page
+            window.location.href = 'https://www.canada.ca/errors/404.html';
         }
 
         // set page lang


### PR DESCRIPTION
Left the no param root route but page will now default to display the error page when loaded with no URL params. Can also use the 404 canada.ca page if that is the preferred option. Removed the test page from being the default.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/199)
<!-- Reviewable:end -->
