### PR TITLE
create basic editor page, load data from config given UUID

### DIFF
--- a/public/index-ca-en.html
+++ b/public/index-ca-en.html
@@ -57,12 +57,18 @@
                 productID = productID.split('#')[0];
             }
 
+            // Check to see if the 'editor' route is included in the URL. If so, keep it.
+            var hasEditor = hashParams.pop() === 'editor';
+
+            // Build new URL route.
+            var newURLRoute = hasEditor ? 'editor/' + productID : productID;
+
             var defTop = document.getElementById('def-top');
             defTop.outerHTML = wet.builder.top({
                 lngLinks: [
                     {
                         lang: 'fr',
-                        href: 'index-ca-fr.html#/fr/' + productID,
+                        href: 'index-ca-fr.html#/fr/' + newURLRoute,
                         text: 'Français'
                     }
                 ],

--- a/public/index-ca-fr.html
+++ b/public/index-ca-fr.html
@@ -57,12 +57,18 @@
                 productID = productID.split('#')[0];
             }
 
+            // Check to see if the 'editor' route is included in the URL. If so, keep it.
+            var hasEditor = hashParams.pop() === 'editor';
+
+            // Build new URL route.
+            var newURLRoute = hasEditor ? 'editor/' + productID : productID;
+
             var defTop = document.getElementById('def-top');
             defTop.outerHTML = wet.builder.top({
                 lngLinks: [
                     {
                         lang: 'en',
-                        href: 'index-ca-en.html#/en/' + productID,
+                        href: 'index-ca-en.html#/en/' + newURLRoute,
                         text: 'English'
                     }
                 ],

--- a/src/components/editor/editor.vue
+++ b/src/components/editor/editor.vue
@@ -1,0 +1,164 @@
+<template>
+    <!-- If the configuration file is being fetched, display a spinner to indicate loading. -->
+    <div class="editor-container">
+        <div class="text-2xl font-bold mb-5">
+            {{ uuid ? $t('editor.editProduct') : $t('editor.createProduct') }}
+        </div>
+        <label>{{ $t('editor.uuid') }}:</label> <input type="text" v-model="uuid" />
+        <button v-on:click="fetchConfig">{{ $t('editor.load') }}</button>
+
+        <!-- If config is loading, display a small spinner. -->
+        <div v-if="loadStatus === 'loading'" class="inline m-3">
+            <spinner size="20px" background="#00D2D3" color="#009cd1" stroke="2px" class="inline-block"></spinner>
+        </div>
+        <br />
+
+        <label>{{ $t('editor.title') }}:</label> <input type="text" v-model="title" /> <br />
+        <label>{{ $t('editor.logo') }}:</label> <input type="text" v-model="logo" />
+        <button v-on:click="fetchConfig">{{ $t('editor.browse') }}</button>
+        <br />
+        <label>{{ $t('editor.contextLink') }}:</label> <input type="text" v-model="contextLink" /> <br />
+        <label>{{ $t('editor.contextLabel') }}:</label> <input type="text" v-model="contextLabel" /> <br />
+        <label>{{ $t('editor.dateModified') }}:</label> <input type="date" v-model="dateModified" /> <br />
+    </div>
+</template>
+
+<script lang="ts">
+import { Component, Vue } from 'vue-property-decorator';
+import { Route } from 'vue-router';
+
+import { StoryRampConfig } from '@/definitions';
+import Circle2 from 'vue-loading-spinner/src/components/Circle2.vue';
+
+@Component({
+    components: {
+        spinner: Circle2
+    }
+})
+export default class EditorV extends Vue {
+    config: StoryRampConfig | undefined = undefined;
+    loadStatus = 'waiting';
+    lang = 'en';
+
+    // Form properties.
+    uuid: any = undefined;
+    title: any = '';
+    logo: any = '';
+    contextLink: any = '';
+    contextLabel: any = '';
+    dateModified: any = '';
+
+    created(): void {
+        this.uuid = this.$route.params.uid ?? undefined;
+        this.lang = this.$route.params.lang ? this.$route.params.lang : 'en';
+
+        this.config = undefined;
+
+        if (this.uuid) {
+            this.fetchConfig(this.uuid);
+        }
+    }
+
+    fetchConfig(uid: any): void {
+        this.loadStatus = 'loading';
+
+        fetch(`${this.uuid}/${this.uuid}_${this.lang}.json`)
+            .then((res) => {
+                res.json().then((config: any) => {
+                    this.config = config;
+                    this.loadStatus = 'loaded';
+
+                    // Load in form values from the config file.
+                    this.title = this.config?.title;
+                    this.logo = this.config?.introSlide.logo.src;
+                    this.contextLink = this.config?.contextLink;
+                    this.contextLabel = this.config?.contextLabel;
+                    this.dateModified = this.config?.dateModified;
+                });
+            })
+            .catch((err) => {
+                if (err.code === 'MODULE_NOT_FOUND') {
+                    console.error(`There exists no config given by the URL params: ${err}`);
+                    this.loadStatus = 'error';
+                } else {
+                    // Some unknown error, possibly a build error that could indicate an error in the
+                    // configuration file.
+                    this.loadStatus = 'error';
+
+                    // Print out the error stack.
+                    console.error(err.stack);
+                }
+            });
+    }
+
+    // react to param changes in URL
+    beforeRouteUpdate(to: Route, from: Route, next: () => void): void {
+        this.lang = to.params.lang;
+        this.$i18n.locale = this.lang;
+
+        next();
+    }
+}
+</script>
+
+<style lang="scss">
+$font-list: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+
+.storyramp-app {
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6,
+    .h1,
+    .h2,
+    .h3,
+    .h4,
+    .h5,
+    .h6 {
+        font-family: $font-list;
+        line-height: 1.5;
+        border-bottom: 0px;
+    }
+
+    .storyramp-modified {
+        max-width: 1536px;
+        margin: 0 auto;
+        padding-left: 15px;
+        padding-top: 1em;
+        padding-bottom: 1em;
+    }
+
+    .editor-container {
+        margin: 0 auto;
+        width: 60vw;
+    }
+
+    label {
+        width: 10vw;
+        text-align: right;
+        margin-right: 15px;
+        display: inline-block;
+    }
+
+    input {
+        padding: 5px 10px;
+        margin: 2px;
+        border: 1px solid black;
+        width: 20vw;
+    }
+
+    button {
+        padding: 5px 10px;
+        margin: 2px;
+        border: 1px solid black;
+    }
+}
+
+@media screen and (min-width: 640px) {
+    .mobile-menu {
+        display: none !important;
+    }
+}
+</style>

--- a/src/lang/lang.csv
+++ b/src/lang/lang.csv
@@ -8,3 +8,13 @@ timeslider.expand,Expand,1,Développer,1
 timeslider.minimize,Minimize,1,Réduire,1
 timeslider.play,Play,1,Lire,0
 timeslider.pause,Pause,1,Pause,0
+editor.createProduct,Create New Storylines Product,1,Créer un nouveau produit Storylines,0
+editor.editProduct,Edit Existing Storylines Product,1,Modifier le produit Storylines existant,0
+editor.uuid,UUID,1,UUID,0
+editor.title,Title,1,Titre,0
+editor.logo,Logo,1,Logo,0
+editor.contextLink,Context Link,1,Lien contextuel,0
+editor.contextLabel,Context Label,1,Libellé de contexte,0
+editor.dateModified,Date Modified,1,Date modifiée,0
+editor.load,Load,1,Charger,0
+editor.browse,Browse,1,Parcourir,0

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,5 +1,6 @@
 import Vue from 'vue';
 import StoryV from '@/components/story/story.vue';
+import EditorV from '@/components/editor/editor.vue';
 import Router, { Route } from 'vue-router';
 
 Vue.use(Router);
@@ -8,6 +9,14 @@ const routes = [
     {
         path: '/',
         component: StoryV
+    },
+    {
+        path: '/:lang/editor',
+        component: EditorV
+    },
+    {
+        path: '/:lang/editor/:uid',
+        component: EditorV
     },
     {
         path: '/:uid',


### PR DESCRIPTION
Closes #226 and #228 

### Changes in this PR
- adds a basic editor page to the app
- if a UUID is provided via the URL or `UUID` field on the page, the configuration file will attempt to load based on the language provided in the URL
- modifies the existing language switch code to support this new `editor` page
- adds unofficial French translations for the editor (from Google Translate) 

### Testing this PR
To access this new page locally, you can visit one of the following URLs:

With a UUID provided: http://localhost:8080/index-ca-en.html#/en/editor/00000000-0000-0000-0000-000000000000
With no UUID provided: http://localhost:8080/index-ca-en.html#/en/editor/