### PR TITLE
add demo markdown editor; swap to French config

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
         "lint": "vue-cli-service lint"
     },
     "dependencies": {
+        "@kangc/v-md-editor": "^1.7.11",
         "@tailwindcss/typography": "^0.4.0",
         "@types/highcharts": "^7.0.0",
         "core-js": "^3.6.5",

--- a/src/components/editor/editor.vue
+++ b/src/components/editor/editor.vue
@@ -1,9 +1,15 @@
 <template>
     <!-- If the configuration file is being fetched, display a spinner to indicate loading. -->
     <div class="editor-container">
-        <div class="text-2xl font-bold mb-5">
-            {{ uuid ? $t('editor.editProduct') : $t('editor.createProduct') }}
+        <div class="flex">
+            <div class="flex text-2xl font-bold mb-5">
+                {{ config ? $t('editor.editProduct') : $t('editor.createProduct') }}
+            </div>
+            <button v-if="config" @click="swapLang">
+                {{ lang === 'en' ? $t('editor.frenchConfig') : $t('editor.englishConfig') }}
+            </button>
         </div>
+
         <label>{{ $t('editor.uuid') }}:</label> <input type="text" v-model="uuid" />
         <button v-on:click="fetchConfig">{{ $t('editor.load') }}</button>
 
@@ -19,7 +25,10 @@
         <br />
         <label>{{ $t('editor.contextLink') }}:</label> <input type="text" v-model="contextLink" /> <br />
         <label>{{ $t('editor.contextLabel') }}:</label> <input type="text" v-model="contextLabel" /> <br />
-        <label>{{ $t('editor.dateModified') }}:</label> <input type="date" v-model="dateModified" /> <br />
+        <label>{{ $t('editor.dateModified') }}:</label> <input type="date" v-model="dateModified" /> <br /><br />
+
+        <v-md-editor v-model="text" height="400px"></v-md-editor>
+        <button @click="generateConfig">Generate Config</button>
     </div>
 </template>
 
@@ -47,6 +56,8 @@ export default class EditorV extends Vue {
     contextLink = '';
     contextLabel = '';
     dateModified = '';
+    text =
+        '# Hello!\n\nThis is a **test**. When you press the `generate config` button, a config snippet will be printed to the console.';
 
     created(): void {
         this.uuid = this.$route.params.uid ?? undefined;
@@ -91,6 +102,42 @@ export default class EditorV extends Vue {
                     console.error(err.stack);
                 }
             });
+    }
+
+    swapLang() {
+        this.lang = this.lang === 'en' ? 'fr' : 'en';
+        this.fetchConfig();
+    }
+
+    generateConfig(): StoryRampConfig {
+        const config = {
+            title: this.title,
+            lang: this.lang,
+            introSlide: {
+                logo: {
+                    src: this.logo
+                },
+                title: this.title
+            },
+            slides: [
+                {
+                    title: 'Test Slide',
+                    panel: [
+                        {
+                            title: 'Text Slide',
+                            content: this.text,
+                            type: 'text'
+                        }
+                    ]
+                }
+            ],
+            contextLabel: this.contextLabel,
+            contextLink: this.contextLink,
+            dateModified: this.dateModified
+        };
+
+        console.log(config);
+        return config;
     }
 
     // react to param changes in URL

--- a/src/lang/lang.csv
+++ b/src/lang/lang.csv
@@ -18,3 +18,5 @@ editor.contextLabel,Context Label,1,Libellé de contexte,0
 editor.dateModified,Date Modified,1,Date modifiée,0
 editor.load,Load,1,Charger,0
 editor.browse,Browse,1,Parcourir,0
+editor.frenchConfig,View French Config,1,Afficher la configuration française,0
+editor.englishConfig,View English Config,1,Afficher la configuration en anglais,0

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,19 @@ import App from './app.vue';
 import router from './router';
 import './style.css';
 
+import VueMarkdownEditor from '@kangc/v-md-editor';
+import '@kangc/v-md-editor/lib/style/base-editor.css';
+import githubTheme from '@kangc/v-md-editor/lib/theme/github.js';
+import '@kangc/v-md-editor/lib/theme/style/github.css';
+import enUS from '@kangc/v-md-editor/lib/lang/en-US';
+import hljs from 'highlight.js';
+
+VueMarkdownEditor.lang.use('en-US', enUS);
+VueMarkdownEditor.use(githubTheme, {
+    Hljs: hljs
+});
+Vue.use(VueMarkdownEditor);
+
 import { i18n } from './lang';
 
 import VueTippy, { TippyComponent } from 'vue-tippy';

--- a/src/shims-vue.d.ts
+++ b/src/shims-vue.d.ts
@@ -3,6 +3,9 @@ declare module '*.vue' {
     export default Vue;
 }
 
+declare module '@kangc/v-md-editor';
+declare module '@kangc/v-md-editor/lib/lang/en-US';
+declare module '@kangc/v-md-editor/lib/theme/github.js';
 declare module 'vue-scrollama';
 declare module 'vue-tippy';
 declare module 'vue-progressive-image';


### PR DESCRIPTION
Closes #229 and #230

### Changes in this PR
- added a markdown editor to the editor page
- added a "generate config" button which, at the moment, generates an example config which is filled from the fields on the page and prints it to the console
- added a "View English/French Config" button to the top right of the page which switches between the English and French configuration files. This button doesn't switch the language of the page, only the configuration file.

### Testing this PR
These features have been added to the basic editor page for now. We can move them around and change how they look as we develop further.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/238)
<!-- Reviewable:end -->
