### PR TITLE
remove unintended border from main storylines app buttons

### DIFF
--- a/src/components/editor/editor.vue
+++ b/src/components/editor/editor.vue
@@ -189,21 +189,21 @@ $font-list: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
         width: 60vw;
     }
 
-    label {
+    .editor-container label {
         width: 10vw;
         text-align: right;
         margin-right: 15px;
         display: inline-block;
     }
 
-    input {
+    .editor-container input {
         padding: 5px 10px;
         margin: 2px;
         border: 1px solid black;
         width: 20vw;
     }
 
-    button {
+    .editor-container button {
         padding: 5px 10px;
         margin: 2px;
         border: 1px solid black;


### PR DESCRIPTION
Fixes an issue where all buttons in the main Storylines app had a black border around them.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/240)
<!-- Reviewable:end -->
