### PR TITLE
fix maps not loading in dynamic panels

### DIFF
--- a/src/components/panels/dynamic-panel.vue
+++ b/src/components/panels/dynamic-panel.vue
@@ -7,7 +7,13 @@
 
             <div class="px-10 md-content" v-html="md.render(config.content)"></div>
         </Scrollama>
-        <panel class="dynamic-content flex-2" :config="activeConfig" :ratio="false"></panel>
+        <panel
+            class="dynamic-content flex-2"
+            :config="activeConfig"
+            :slideIdx="slideIdx"
+            :dynamicIdx="activeIdx"
+            :ratio="false"
+        ></panel>
     </div>
 </template>
 
@@ -26,9 +32,11 @@ import { DynamicPanel, BasePanel } from '@/definitions';
 })
 export default class DynamicPanelV extends Vue {
     @Prop() config!: DynamicPanel;
+    @Prop() slideIdx!: string;
 
     // By default, the active config is set to the first child in the children list.
     activeConfig: BasePanel = this.config.children[0].panel;
+    activeIdx = '0';
 
     md = new MarkdownIt({ html: true });
 
@@ -55,7 +63,17 @@ export default class DynamicPanelV extends Vue {
                 });
 
                 // If the panel exists, switch the displayed panel.
-                if (panel) this.activeConfig = panel.panel;
+                if (panel) {
+                    // Quickly reset the config so the panel component can be reset.
+                    this.activeConfig = {
+                        type: 'loading'
+                    };
+
+                    setTimeout(() => {
+                        this.activeConfig = panel.panel;
+                        this.activeIdx = panel.id;
+                    }, 10);
+                }
             };
         });
     }

--- a/src/components/panels/loading-panel.vue
+++ b/src/components/panels/loading-panel.vue
@@ -1,0 +1,23 @@
+<template>
+    <Scrollama class="flex-1 prose max-w-none my-5">
+        <div class="block py-20 align-middle text-center h-full" style="margin: 0 auto">
+            <spinner size="120px" background="#00D2D3" color="#009cd1" stroke="10px" style="margin: 0 auto"></spinner>
+        </div>
+    </Scrollama>
+</template>
+
+<script lang="ts">
+import Scrollama from 'vue-scrollama';
+import { Component, Vue } from 'vue-property-decorator';
+import Circle2 from 'vue-loading-spinner/src/components/Circle2.vue';
+
+@Component({
+    components: {
+        Scrollama,
+        spinner: Circle2
+    }
+})
+export default class LoadingPanelV extends Vue {}
+</script>
+
+<style scoped lang="scss"></style>

--- a/src/components/panels/panel.vue
+++ b/src/components/panels/panel.vue
@@ -23,6 +23,7 @@ import VideoPanelV from './video-panel.vue';
 import SlideshowPanelV from './slideshow-panel.vue';
 import ChartPanelV from './chart-panel.vue';
 import DynamicPanelV from './dynamic-panel.vue';
+import LoadingPanelV from './loading-panel.vue';
 
 @Component({
     components: {
@@ -47,7 +48,8 @@ export default class PanelV extends Vue {
             [PanelType.Video]: VideoPanelV,
             [PanelType.Slideshow]: SlideshowPanelV,
             [PanelType.Chart]: ChartPanelV,
-            [PanelType.Dynamic]: DynamicPanelV
+            [PanelType.Dynamic]: DynamicPanelV,
+            [PanelType.Loading]: LoadingPanelV
         };
 
         return panelTemplates[this.config.type];

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -93,7 +93,8 @@ export enum PanelType {
     Video = 'video',
     Audio = 'audio',
     Slideshow = 'slideshow',
-    Dynamic = 'dynamic'
+    Dynamic = 'dynamic',
+    Loading = 'loading'
 }
 
 export interface BasePanel {


### PR DESCRIPTION
Closes #246 

This PR fixes an issue where dynamic panels wouldn't load multiple maps in the same panel. A quick loading spinner is now shown when switching between panels so maps will load properly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/248)
<!-- Reviewable:end -->
