### PR TITLE
Adjust chart space and reflow

### DIFF
--- a/public/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000_en.json
+++ b/public/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000_en.json
@@ -403,7 +403,7 @@
             ]
         },
         {
-            "title": "DQV Chart",
+            "title": "DQV Chart Gallery",
             "panel": [
                 {
                     "title": "DQV Chart",
@@ -412,7 +412,23 @@
                 },
                 {
                     "type": "chart",
-                    "charts": [{ "src": "00000000-0000-0000-0000-000000000000/charts/en/chartConfig.json" }]
+                    "charts": [
+                        {
+                            "src": "00000000-0000-0000-0000-000000000000/charts/en/chartConfig.json"
+                        },
+                        {
+                            "src": "ea24000c-7dc3-49a9-baac-c55d28dcaeb9/charts/en/Ethlyene.glycol.release.trends.by.sector.2010-2019.tonnes.csv"
+                        },
+                        {
+                            "src": "410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/en/tailings/2.Fort Hill Energy L.P., Fort Hills Oil Sands 2019 Tailings.csv",
+                            "options": {
+                                "title": "Fort Hill Energy L.P., Fort Hills Oil Sands 2019 Tailings (Tonnes)",
+                                "subtitle": "",
+                                "type": "pie",
+                                "colours": ["green", "#FAEBD7", "indigo", "#FFD700", "orange", "red"]
+                            }
+                        }
+                    ]
                 }
             ]
         },
@@ -421,7 +437,7 @@
             "panel": [
                 {
                     "title": "DQV Chart with CSV input",
-                    "content": "Test",
+                    "content": "Test (╯°□°)╯︵ ┻━┻",
                     "type": "text"
                 },
                 {
@@ -438,32 +454,6 @@
                             }
                         }
                     ]
-                }
-            ]
-        },
-        {
-            "title": "Pie chart with custom colours and size",
-            "panel": [
-                {
-                    "title": "Pie chart with custom colours",
-                    "content": "(╯°□°)╯︵ ┻━┻",
-                    "type": "text"
-                },
-                {
-                    "charts": [
-                        {
-                            "src": "410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/en/tailings/2.Fort Hill Energy L.P., Fort Hills Oil Sands 2019 Tailings.csv",
-                            "options": {
-                                "title": "Fort Hill Energy L.P., Fort Hills Oil Sands 2019 Tailings (Tonnes)",
-                                "subtitle": "",
-                                "type": "pie",
-                                "colours": ["green", "#FAEBD7", "indigo", "#FFD700", "orange", "red"],
-                                "width": 800,
-                                "height": 500
-                            }
-                        }
-                    ],
-                    "type": "chart"
                 }
             ]
         },

--- a/src/components/panels/helpers/chart.vue
+++ b/src/components/panels/helpers/chart.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="dv-chart justify-center flex align-middle" dv-config="config">
         <div
-            class="dv-chart-container items-stretch"
+            class="dv-chart-container items-stretch h-full w-full"
             role="region"
             aria-hidden="false"
             :aria-label="title"
@@ -14,9 +14,9 @@
 
 <script lang="ts">
 import { Component, Vue, Prop } from 'vue-property-decorator';
-
-import { Chart } from 'highcharts-vue';
 import { ChartConfig, DQVChartConfig, SeriesData } from '@/definitions';
+import { Chart } from 'highcharts-vue';
+
 import Highcharts from 'highcharts';
 import dataModule from 'highcharts/modules/data';
 import exporting from 'highcharts/modules/exporting';
@@ -50,7 +50,7 @@ export default class ChartV extends Vue {
         'downloadXLS'
     ];
 
-    created(): void {
+    mounted(): void {
         if (this.config.config) {
             // configured JSON structure if exists - for highcharts demo purposes
             this.chartOptions = this.config.config;
@@ -78,17 +78,8 @@ export default class ChartV extends Vue {
                 this.parseCSVFile();
             }
         }
-    }
 
-    mounted(): void {
-        setTimeout(() => {
-            (this.$refs.chart as any).chart.reflow();
-        }, 500);
-
-        window.addEventListener('resize', () => {
-            // adjust width for mobile resolutions
-            (this.$refs.chart as any).chart.reflow();
-        });
+        // window.addEventListener('resize', this.chartResize);
     }
 
     /**
@@ -114,8 +105,10 @@ export default class ChartV extends Vue {
                     renderTo: 'dv-chart-container',
                     type: dqvOptions?.type,
                     ...(dqvOptions?.height &&
-                        this.$el.clientHeight > dqvOptions?.height && { height: dqvOptions?.height }),
-                    ...(dqvOptions?.width && this.$el.clientWidth > dqvOptions?.width && { width: dqvOptions?.width })
+                        this.$el.clientHeight >= dqvOptions.height && {
+                            height: dqvOptions.height
+                        }),
+                    ...(dqvOptions?.width && this.$el.clientWidth >= dqvOptions.width && { width: dqvOptions.width })
                 },
                 ...(dqvOptions?.title && { title: { text: dqvOptions?.title } }),
                 ...(dqvOptions?.subtitle && { subtitle: { text: dqvOptions?.subtitle } }),
@@ -217,6 +210,14 @@ export default class ChartV extends Vue {
             }
         };
     }
+
+    // /**
+    //  * Handle chart resizing to be responsive to screen size.
+    //  */
+    // chartResize(): void {
+    //     console.log('REFLOW');
+    //     this.$refs.chart.chart.reflow();
+    // }
 }
 </script>
 
@@ -231,8 +232,8 @@ export default class ChartV extends Vue {
     }
 
     .dv-chart-container {
-        width: 100% !important;
-        height: 100% !important;
+        max-width: 100vw;
+        max-height: 50vh;
     }
 }
 </style>


### PR DESCRIPTION
Closes #245, #244

**Changes**: 
- make charts take up full available width space on normal resolutions, height remains untouched
- fix mobile flexbox space overlap between charts and text content

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/249)
<!-- Reviewable:end -->
