### PR TITLE
Add image/gallery panel editor

### DIFF
--- a/src/components/editor/chart-editor.vue
+++ b/src/components/editor/chart-editor.vue
@@ -3,8 +3,8 @@
         <button class="bg-gray-500 text-white font-semibold h-16 cursor-pointer" id="modal-btn">
             Create New Chart
         </button>
-        <div id="chart-result" class="border-2 border-black m-5" style="height: 500px" v-if="!loading">
-            <chart :config="chartConfig" :key="chartIdx"></chart>
+        <div id="chart-result" class="border-2 border-black m-5" style="height: 500px">
+            <chart-panel :config="chartConfig" :key="chartIdx" v-if="!loading"></chart-panel>
         </div>
     </div>
 </template>
@@ -15,7 +15,7 @@ import ChartPanelV from '@/components/panels/chart-panel.vue';
 
 @Component({
     components: {
-        chart: ChartPanelV
+        'chart-panel': ChartPanelV
     }
 })
 export default class ChartEditorV extends Vue {
@@ -34,6 +34,7 @@ export default class ChartEditorV extends Vue {
                         options: 'plugins csv json samples'
                     }
                 },
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 (chart: any) => {
                     this.createNewChart(chart.toString());
                 }

--- a/src/components/editor/editor.vue
+++ b/src/components/editor/editor.vue
@@ -27,31 +27,41 @@
         <label>{{ $t('editor.contextLabel') }}:</label> <input type="text" v-model="contextLabel" /> <br />
         <label>{{ $t('editor.dateModified') }}:</label> <input type="date" v-model="dateModified" /> <br /><br />
 
-        <!-- MD editor demo -->
+        <!-- MD (text panel) editor demo -->
+        <h3 class="text-xl font-bold my-4">Text Panel Editor Demo</h3>
         <v-md-editor v-model="text" height="400px"></v-md-editor>
         <button class="bg-gray-500 text-white font-semibold h-16 cursor-pointer" @click="generateConfig">
             Generate Config
         </button>
 
-        <!-- chart editor demo -->
-        <chart-editor class="pt-8"></chart-editor>
-
+        <!-- map panel editor demo -->
+        <h3 class="text-xl font-bold mt-8 mb-4">RAMP Panel Editor Demo</h3>
         <iframe src="scripts/ramp-editor/samples/fgpv-author.html" style="width: 70vw; height: 100vh"></iframe>
+
+        <!-- chart panel editor demo -->
+        <h3 class="text-xl font-bold mt-8 mb-4">Chart Panel Editor Demo</h3>
+        <chart-editor></chart-editor>
+
+        <!-- image panel editor demo -->
+        <h3 class="text-xl font-bold mt-8 mb-4">Image Panel Editor Demo</h3>
+        <image-editor></image-editor>
     </div>
 </template>
 
 <script lang="ts">
 import { Component, Vue } from 'vue-property-decorator';
 import { Route } from 'vue-router';
-
 import { StoryRampConfig } from '@/definitions';
+
 import Circle2 from 'vue-loading-spinner/src/components/Circle2.vue';
 import ChartEditorV from './chart-editor.vue';
+import ImageEditorV from './image-editor.vue';
 
 @Component({
     components: {
         spinner: Circle2,
-        'chart-editor': ChartEditorV
+        'chart-editor': ChartEditorV,
+        'image-editor': ImageEditorV
     }
 })
 export default class EditorV extends Vue {
@@ -114,7 +124,7 @@ export default class EditorV extends Vue {
             });
     }
 
-    swapLang() {
+    swapLang(): void {
         this.lang = this.lang === 'en' ? 'fr' : 'en';
         this.fetchConfig();
     }

--- a/src/components/editor/helpers/image-preview.vue
+++ b/src/components/editor/helpers/image-preview.vue
@@ -1,0 +1,35 @@
+<template>
+    <li class="relative w-1/5 m-4 overflow-hidden">
+        <button class="cursor-pointer" @click="() => $emit('delete', imageFile)">
+            <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="24"
+                height="24"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="#000000"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+            >
+                <circle cx="12" cy="12" r="10"></circle>
+                <line x1="15" y1="9" x2="9" y2="15"></line>
+                <line x1="9" y1="9" x2="15" y2="15"></line>
+            </svg>
+        </button>
+        <img class="block object-cover w-full h-full" :src="imageFile.src" />
+        <slot></slot>
+    </li>
+</template>
+
+<script lang="ts">
+import { Component, Vue, Prop } from 'vue-property-decorator';
+import { ImageFile } from '@/definitions';
+
+@Component({})
+export default class ImagePreviewV extends Vue {
+    @Prop() imageFile!: ImageFile;
+}
+</script>
+
+<style lang="scss" scoped></style>

--- a/src/components/editor/helpers/image-preview.vue
+++ b/src/components/editor/helpers/image-preview.vue
@@ -1,23 +1,23 @@
 <template>
-    <li class="relative w-1/5 m-4 overflow-hidden">
-        <button class="cursor-pointer" @click="() => $emit('delete', imageFile)">
-            <svg
-                xmlns="http://www.w3.org/2000/svg"
-                width="24"
-                height="24"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="#000000"
-                stroke-width="2"
-                stroke-linecap="round"
-                stroke-linejoin="round"
+    <li class="image-item items-center my-8 mx-5 overflow-hidden">
+        <div class="relative items-center justify-center text-center w-full">
+            <button
+                class="bg-white absolute h-6 w-6 leading-5 rounded-full top-0 right-0 p-0 cursor-pointer"
+                @click="() => $emit('delete', imageFile)"
             >
-                <circle cx="12" cy="12" r="10"></circle>
-                <line x1="15" y1="9" x2="9" y2="15"></line>
-                <line x1="9" y1="9" x2="15" y2="15"></line>
-            </svg>
-        </button>
-        <img class="block object-cover w-full h-full" :src="imageFile.src" />
+                <svg height="20px" width="20px" viewBox="0 0 352 512" xmlns="http://www.w3.org/2000/svg">
+                    <path
+                        d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                    />
+                </svg>
+            </button>
+            <img
+                class="image-file object-cover w-full h-full"
+                :title="imageFile.id"
+                :src="imageFile.src"
+                :alt="imageFile.altText"
+            />
+        </div>
         <slot></slot>
     </li>
 </template>
@@ -32,4 +32,12 @@ export default class ImagePreviewV extends Vue {
 }
 </script>
 
-<style lang="scss" scoped></style>
+<style lang="scss" scoped>
+.image-item {
+    width: 30%;
+
+    .image-file {
+        aspect-ratio: 1/1;
+    }
+}
+</style>

--- a/src/components/editor/image-editor.vue
+++ b/src/components/editor/image-editor.vue
@@ -1,0 +1,113 @@
+<template>
+    <div class="block">
+        <!-- Upload images area -->
+        <div
+            class="upload-image text-center m-5 p-12 bg-blue-100 cursor-pointer"
+            @dragover.prevent="() => (dragging = true)"
+            @dragleave.prevent="() => (dragging = false)"
+            @drop.prevent="dropImages($event)"
+        >
+            <label for="file-input">
+                <span>
+                    <div>Drag your images here</div>
+                    <div>or <span class="text-blue-400 font-bold">browse</span> to upload</div>
+                </span>
+                <input
+                    type="file"
+                    id="file-input"
+                    class="inline-block font-semibold cursor-pointer"
+                    @change="onFileChange"
+                    multiple="multiple"
+                />
+            </label>
+        </div>
+
+        <!-- Gallery preview of all images -->
+        <ul class="flex flex-wrap list-none" v-show="imageFiles.length">
+            <ImagePreview v-for="(image, idx) in imageFiles" :key="idx" :imageFile="image" @delete="deleteImage">
+                <div class="mt-10">
+                    <label>Alt tag:</label>
+                    <input type="text" v-model="altText" />
+                </div>
+            </ImagePreview>
+        </ul>
+    </div>
+</template>
+
+<script lang="ts">
+import { Component, Vue } from 'vue-property-decorator';
+import { ImageFile } from '@/definitions';
+import ImagePreviewV from '@/components/editor/helpers/image-preview.vue';
+
+@Component({
+    components: {
+        ImagePreview: ImagePreviewV
+    }
+})
+export default class ImageEditorV extends Vue {
+    imageURLs = [] as Array<string>;
+    imageFiles = [] as Array<ImageFile>;
+    imageTitle = '';
+    dragging = false;
+    altText = '';
+
+    // TODO: add file saving mechanism once user save storylines task complete #227
+
+    onFileChange(e: Event): void {
+        // create object URL(s) to display image(s)
+        const filelist = Array.from((e.target as HTMLInputElement).files as ArrayLike<File>);
+        this.imageURLs = filelist.map((file: File) => URL.createObjectURL(file));
+        this.imageFiles = filelist.map((file: File) => {
+            return {
+                id: file.name,
+                src: URL.createObjectURL(file),
+                altText: ''
+            };
+        });
+        console.log('UPLOAD IMAGES: ', this.imageFiles);
+    }
+
+    dropImages(e: DragEvent): void {
+        if (e.dataTransfer !== null) {
+            const files = [...e.dataTransfer.files];
+            this.imageFiles = files.map((file: File) => {
+                return {
+                    id: file.name,
+                    src: URL.createObjectURL(file),
+                    altText: ''
+                };
+            });
+            console.log('DRAG IMAGES: ', this.imageFiles);
+            this.dragging = false;
+        }
+    }
+
+    deleteImage(img: ImageFile): void {
+        const idx = this.imageFiles.findIndex((file: ImageFile) => file.id === img.id);
+        if (idx !== -1) {
+            this.imageFiles.splice(idx, 1);
+        }
+        console.log('DELETING IMAGE: ', img, idx);
+    }
+}
+</script>
+
+<style lang="scss" scoped>
+.upload-image {
+    // max-width: 90%;
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.3);
+    transition: 0.2s ease;
+
+    input[type='file']:not(:focus-visible) {
+        position: absolute !important;
+        width: 1px !important;
+        height: 1px !important;
+        padding: 0 !important;
+        margin: -1px !important;
+        overflow: hidden !important;
+        clip: rect(0, 0, 0, 0) !important;
+        white-space: nowrap !important;
+        border: 0 !important;
+    }
+}
+</style>

--- a/src/components/editor/image-editor.vue
+++ b/src/components/editor/image-editor.vue
@@ -2,32 +2,27 @@
     <div class="block">
         <!-- Upload images area -->
         <div
-            class="upload-image text-center m-5 p-12 bg-blue-100 cursor-pointer"
+            class="upload-image text-center m-5 p-12 bg-blue-100"
+            :class="{ dragging: isDragging }"
             @dragover.prevent="() => (dragging = true)"
             @dragleave.prevent="() => (dragging = false)"
             @drop.prevent="dropImages($event)"
         >
-            <label for="file-input">
+            <label class="cursor-pointer">
                 <span>
                     <div>Drag your images here</div>
                     <div>or <span class="text-blue-400 font-bold">browse</span> to upload</div>
                 </span>
-                <input
-                    type="file"
-                    id="file-input"
-                    class="inline-block font-semibold cursor-pointer"
-                    @change="onFileChange"
-                    multiple="multiple"
-                />
+                <input type="file" class="cursor-pointer" @change="onFileChange" multiple="multiple" />
             </label>
         </div>
 
         <!-- Gallery preview of all images -->
         <ul class="flex flex-wrap list-none" v-show="imageFiles.length">
             <ImagePreview v-for="(image, idx) in imageFiles" :key="idx" :imageFile="image" @delete="deleteImage">
-                <div class="mt-10">
-                    <label>Alt tag:</label>
-                    <input type="text" v-model="altText" />
+                <div class="flex mt-4 items-center">
+                    <label class="alt-label">Alt tag:</label>
+                    <input type="text" />
                 </div>
             </ImagePreview>
         </ul>
@@ -47,37 +42,40 @@ import ImagePreviewV from '@/components/editor/helpers/image-preview.vue';
 export default class ImageEditorV extends Vue {
     imageURLs = [] as Array<string>;
     imageFiles = [] as Array<ImageFile>;
-    imageTitle = '';
     dragging = false;
-    altText = '';
-
     // TODO: add file saving mechanism once user save storylines task complete #227
+
+    get isDragging(): boolean {
+        return this.dragging;
+    }
 
     onFileChange(e: Event): void {
         // create object URL(s) to display image(s)
         const filelist = Array.from((e.target as HTMLInputElement).files as ArrayLike<File>);
         this.imageURLs = filelist.map((file: File) => URL.createObjectURL(file));
-        this.imageFiles = filelist.map((file: File) => {
-            return {
-                id: file.name,
-                src: URL.createObjectURL(file),
-                altText: ''
-            };
-        });
-        console.log('UPLOAD IMAGES: ', this.imageFiles);
-    }
-
-    dropImages(e: DragEvent): void {
-        if (e.dataTransfer !== null) {
-            const files = [...e.dataTransfer.files];
-            this.imageFiles = files.map((file: File) => {
+        this.imageFiles.push(
+            ...filelist.map((file: File) => {
                 return {
                     id: file.name,
                     src: URL.createObjectURL(file),
                     altText: ''
                 };
-            });
-            console.log('DRAG IMAGES: ', this.imageFiles);
+            })
+        );
+    }
+
+    dropImages(e: DragEvent): void {
+        if (e.dataTransfer !== null) {
+            const files = [...e.dataTransfer.files];
+            this.imageFiles.push(
+                ...files.map((file: File) => {
+                    return {
+                        id: file.name,
+                        src: URL.createObjectURL(file),
+                        altText: ''
+                    };
+                })
+            );
             this.dragging = false;
         }
     }
@@ -87,17 +85,16 @@ export default class ImageEditorV extends Vue {
         if (idx !== -1) {
             this.imageFiles.splice(idx, 1);
         }
-        console.log('DELETING IMAGE: ', img, idx);
+    }
+
+    saveChanges(): void {
+        // TODO - save all alt texts, image files, final config, etc.
     }
 }
 </script>
 
 <style lang="scss" scoped>
 .upload-image {
-    // max-width: 90%;
-    box-shadow: 0 0 10px rgba(0, 0, 0, 0.3);
-    transition: 0.2s ease;
-
     input[type='file']:not(:focus-visible) {
         position: absolute !important;
         width: 1px !important;
@@ -109,5 +106,15 @@ export default class ImageEditorV extends Vue {
         white-space: nowrap !important;
         border: 0 !important;
     }
+}
+
+.alt-label {
+    width: 21% !important;
+    margin: 0 0.5rem !important;
+}
+
+.dragging {
+    background-color: #fffaf0;
+    border-color: #fff;
 }
 </style>

--- a/src/components/panels/slideshow-panel.vue
+++ b/src/components/panels/slideshow-panel.vue
@@ -5,8 +5,6 @@
                 <slide v-for="(image, index) in config.images" :key="index" :index="index" class="self-center">
                     <img
                         :src="image.src"
-                        :height="image.height"
-                        :width="image.width"
                         :alt="image.altText || ''"
                         :style="{ width: `${image.width}px`, height: `${image.height}px` }"
                         class="m-auto story-graphic carousel-image"

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -179,3 +179,11 @@ export interface ChartConfig {
     config: any;
     options?: DQVOptions;
 }
+
+export interface ImageFile {
+    id: string;
+    src: string;
+    altText: string;
+    width?: number;
+    height?: number;
+}


### PR DESCRIPTION
Closes #234 

**Changes**:
- implements image gallery slide editor/creator based on UX mockups (see image below) 
- option to upload or drag and drop images

**Missing**:
- ability to reorder images in preview mode
- file/config saving mechanism dependent on #227

![image](https://user-images.githubusercontent.com/31557789/200921762-7c5f80c1-cade-4fe3-9486-ea1043f5dcc4.png)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/259)
<!-- Reviewable:end -->
