### PR TITLE
Add config option for changing title tag

### DIFF
--- a/StoryRampSchema.json
+++ b/StoryRampSchema.json
@@ -58,6 +58,11 @@
                     "type": "string",
                     "description": "The title for the text panel."
                 },
+                "titleTag": {
+                    "type": "string",
+                    "description": "An optional tag to use for the panel title. If not supplied h2 is used.",
+                    "default": "h2"
+                },
                 "content": {
                     "type": "string",
                     "description": "The main text body."

--- a/src/components/panels/text-panel.vue
+++ b/src/components/panels/text-panel.vue
@@ -1,8 +1,8 @@
 <template>
     <Scrollama class="flex-1 prose max-w-none my-5">
-        <h2 class="px-10 mb-0 chapter-title top-20">
+        <component :is="config.titleTag || 'h2'" class="px-10 mb-0 chapter-title top-20">
             {{ config.title }}
-        </h2>
+        </component>
 
         <div class="px-10 md-content object-contain" v-html="md.render(config.content)"></div>
     </Scrollama>


### PR DESCRIPTION
#260 

Adds a config option that can be used to have a panel title be something other than `h2`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/261)
<!-- Reviewable:end -->
