### PR TITLE
fix broken basemap thumbnails

### DIFF
--- a/src/components/panels/map-panel.vue
+++ b/src/components/panels/map-panel.vue
@@ -182,4 +182,8 @@ export default class MapPanelV extends Vue {
         background: #fff;
     }
 }
+
+::v-deep rv-basemap-item .rv-basemap-thumb img {
+    max-width: none;
+}
 </style>


### PR DESCRIPTION
I decided to go the easy route and just add a more specific selector that unsets `max-width`.

I remember for ramp4 that trying to get tailwind preflight to behave is a mess and images in some places are styled with the `max-width: 100%` in mind.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/262)
<!-- Reviewable:end -->
