### PR TITLE
make dynamic links focusable

### DIFF
--- a/src/components/panels/dynamic-panel.vue
+++ b/src/components/panels/dynamic-panel.vue
@@ -11,7 +11,8 @@
                 </button>
             </div>
 
-            <component :is="config.titleTag || 'h2'"
+            <component
+                :is="config.titleTag || 'h2'"
                 class="px-10 mb-0 chapter-title top-20"
                 :style="activeIdx !== defaultPanel.id ? 'margin-top: 0px;' : ''"
             >
@@ -72,6 +73,12 @@ export default class DynamicPanelV extends Vue {
         urls.forEach((el: any) => {
             // Find the target panel and add an event listener to the URL.
             const target = el.attributes['panel'].value;
+
+            // Change the target to self so clicking the link doesn't open in a new window. Also add a
+            // dotted underline to indicate that clicking this link will stay in this window.
+            el.style = 'text-decoration-style: dotted; text-underline-offset: 3px;';
+            el.href = 'javascript:;';
+            el.target = '_self';
 
             el.onclick = () => {
                 // Find the panel.


### PR DESCRIPTION
Closes #270 

Adds a `href` attribute to the dynamic panel links in order to make them focusable. Since these are now treated as proper anchor tags, they appear bold and blue like other links. In order to distinguish between these dynamic anchor tags and regular anchor tags, the underline below will be dotted instead of a solid line.

Example:
![image](https://user-images.githubusercontent.com/25874602/201709926-31f00754-fe8c-490d-b3c0-54296a068eaa.png)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/274)
<!-- Reviewable:end -->
