### PR TITLE
fix cut off chapter menu

### DIFF
--- a/src/components/panels/dynamic-panel.vue
+++ b/src/components/panels/dynamic-panel.vue
@@ -11,7 +11,8 @@
                 </button>
             </div>
 
-            <component :is="config.titleTag || 'h2'"
+            <component
+                :is="config.titleTag || 'h2'"
                 class="px-10 mb-0 chapter-title top-20"
                 :style="activeIdx !== defaultPanel.id ? 'margin-top: 0px;' : ''"
             >

--- a/src/components/story/chapter-menu.vue
+++ b/src/components/story/chapter-menu.vue
@@ -88,6 +88,7 @@
                     }}</span>
                 </router-link>
             </li>
+            <div class="h-10 flex-shrink-0"></div>
         </ul>
     </div>
 </template>


### PR DESCRIPTION
Closes #275 

Added a buffer to the bottom of the chapter menu so that things should not get cut off on mobile.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/277)
<!-- Reviewable:end -->
