### PR TITLE
make fullscreen button more visible, add tooltip

### DIFF
--- a/src/components/panels/helpers/fullscreen.vue
+++ b/src/components/panels/helpers/fullscreen.vue
@@ -3,9 +3,11 @@
         <div class="relative bg-white">
             <button
                 v-if="expandable !== undefined ? expandable : true"
-                class="expand-button absolute items-center justify-center p-3 z-10"
+                class="fullscreenButton expand-button absolute items-center justify-center p-3 z-10"
                 :class="[fullscreen ? `top-0` : `bottom-0`, type === 'image' ? `right-10` : `right-2`]"
                 :aria-label="$t('image.fullscreen')"
+                :content="$t(fullscreen ? 'fullscreen.deactivate' : 'fullscreen.activate')"
+                v-tippy="{ placement: 'top', hideOnClick: false }"
                 @click="toggleFullscreen"
             >
                 <svg
@@ -59,5 +61,9 @@ export default class FullscreenV extends Vue {
 .fullscreenElement {
     z-index: 100;
     background: #000;
+}
+.fullscreenButton {
+    filter: invert(1);
+    mix-blend-mode: difference;
 }
 </style>

--- a/src/lang/lang.csv
+++ b/src/lang/lang.csv
@@ -10,6 +10,8 @@ timeslider.expand,Expand,1,Développer,1
 timeslider.minimize,Minimize,1,Réduire,1
 timeslider.play,Play,1,Lire,0
 timeslider.pause,Pause,1,Pause,0
+fullscreen.activate,Enter Fullscreen,1,Entrer en plein écran,0
+fullscreen.deactivate,Exit Fullscreen,1,Sortie plein écran,0
 editor.createProduct,Create New Storylines Product,1,Créer un nouveau produit Storylines,0
 editor.editProduct,Edit Existing Storylines Product,1,Modifier le produit Storylines existant,0
 editor.uuid,UUID,1,UUID,0


### PR DESCRIPTION
Closes #269 

Makes the full screen button a bit more visible when placed over a dark image, and adds a tooltip to the button.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/282)
<!-- Reviewable:end -->
