### PR TITLE
editor: add new/remove slide functionality and toc

### DIFF
--- a/src/components/editor/chart-editor.vue
+++ b/src/components/editor/chart-editor.vue
@@ -10,7 +10,7 @@
 </template>
 
 <script lang="ts">
-import { Component, Vue } from 'vue-property-decorator';
+import { Component, Vue, Prop } from 'vue-property-decorator';
 import ChartPanelV from '@/components/panels/chart-panel.vue';
 
 @Component({
@@ -19,6 +19,7 @@ import ChartPanelV from '@/components/panels/chart-panel.vue';
     }
 })
 export default class ChartEditorV extends Vue {
+    @Prop() panel!: any;
     chartConfig = {};
     chartIdx = 0;
     loading = true;
@@ -48,6 +49,7 @@ export default class ChartEditorV extends Vue {
             charts: [{ config: JSON.parse(chartInfo) }]
         };
         console.log('CHART CONFIG: ', chartConfig);
+        this.panel = chartConfig;
         this.chartConfig = chartConfig;
         this.loading = false;
         this.chartIdx += 1;

--- a/src/components/editor/image-editor.vue
+++ b/src/components/editor/image-editor.vue
@@ -30,7 +30,7 @@
 </template>
 
 <script lang="ts">
-import { Component, Vue } from 'vue-property-decorator';
+import { Component, Vue, Prop } from 'vue-property-decorator';
 import { ImageFile } from '@/definitions';
 import ImagePreviewV from '@/components/editor/helpers/image-preview.vue';
 
@@ -40,6 +40,7 @@ import ImagePreviewV from '@/components/editor/helpers/image-preview.vue';
     }
 })
 export default class ImageEditorV extends Vue {
+    @Prop() panel!: any;
     imageURLs = [] as Array<string>;
     imageFiles = [] as Array<ImageFile>;
     dragging = false;

--- a/src/components/editor/slide-editor.vue
+++ b/src/components/editor/slide-editor.vue
@@ -1,0 +1,86 @@
+<template>
+    <div class="flex-grow mx-5">
+        <div v-if="currentSlide !== ''">
+            <div class="flex">
+                <div class="flex flex-col">
+                    <label>Slide title:</label>
+                    <input type="text" v-model="currentSlide.title" />
+                </div>
+                <span class="ml-auto"></span>
+                <button>Previous Slide</button>
+                <button>Next Slide</button>
+            </div>
+            <br />
+            <div class="flex">
+                <button @click="panelIndex = 0" :class="panelIndex == 0 ? 'font-extrabold' : ''">Left Panel</button>
+                <button @click="panelIndex = 1" :class="panelIndex == 1 ? 'font-extrabold' : ''">Right Panel</button>
+            </div>
+            <br />
+            <div>
+                <div class="flex">
+                    <span class="font-bold text-xl">Content:</span>
+                    <span class="ml-auto flex-grow"></span>
+                    <div v-if="panelIndex === 1" class="flex flex-col">
+                        <label class="text-left text-xl">Content type:</label>
+                        <select @change="currentSlide.panel[panelIndex].type = $event.target.value">
+                            <option v-for="thing in Object.keys(editors)" :key="thing" :value="thing">
+                                {{ thing }}
+                            </option>
+                        </select>
+                    </div>
+                </div>
+                <component
+                    :is="editors[currentSlide.panel[panelIndex].type]"
+                    :key="panelIndex + currentSlide.panel[panelIndex].type"
+                    :panel="currentSlide.panel[panelIndex]"
+                ></component>
+            </div>
+        </div>
+        <div v-else>
+            <span>Please select a slide to edit.</span>
+        </div>
+    </div>
+</template>
+
+<script lang="ts">
+import { Component, Vue, Prop } from 'vue-property-decorator';
+import { Route } from 'vue-router';
+import { StoryRampConfig } from '@/definitions';
+
+import Circle2 from 'vue-loading-spinner/src/components/Circle2.vue';
+import ChartEditorV from './chart-editor.vue';
+import ImageEditorV from './image-editor.vue';
+import TextEditorV from './text-editor.vue';
+
+@Component({
+    components: {
+        spinner: Circle2,
+        'chart-editor': ChartEditorV,
+        'image-editor': ImageEditorV,
+        'text-editor': TextEditorV
+    }
+})
+export default class SlideEditorV extends Vue {
+    config: StoryRampConfig | undefined = undefined;
+    @Prop() currentSlide!: any;
+
+    panelIndex = 0;
+
+    editors = {
+        text: 'text-editor',
+        image: 'image-editor',
+        chart: 'chart-editor'
+    };
+}
+</script>
+
+<style lang="scss" scoped>
+label {
+    text-align: left !important;
+}
+
+.table-of-contents-slide button {
+    padding: 0;
+    border: none;
+}
+</style>

--- a/src/components/editor/slide-toc.vue
+++ b/src/components/editor/slide-toc.vue
@@ -1,0 +1,114 @@
+<template>
+    <div>
+        <div class="flex">
+            <span>SLIDES</span>
+            <span class="ml-auto"></span>
+            <button v-on:click="addNewSlide">+ New Slide</button>
+        </div>
+        <ul>
+            <li class="flex toc-slide" v-for="(slide, index) in slides" :key="slide.title + index">
+                <div class="flex" @click="selectSlide(index)">
+                    <span class="self-center w-44 overflow-ellipsis whitespace-nowrap overflow-hidden flex-shrink-0"
+                        >Slide {{ index + 1 }}: {{ slide.title | '' }}</span
+                    >
+                    <span class="ml-auto flex-grow"></span>
+                    <button @click.stop="removeSlide(index)">
+                        <svg xmlns="http://www.w3.org/2000/svg" height="24" width="24">
+                            <path
+                                d="M7 21q-.825 0-1.412-.587Q5 19.825 5 19V6H4V4h5V3h6v1h5v2h-1v13q0 .825-.587 1.413Q17.825 21 17 21Zm2-4h2V8H9Zm4 0h2V8h-2Z"
+                            />
+                        </svg>
+                    </button>
+                    <div class="flex flex-col">
+                        <button
+                            :class="index == 0 ? 'text-gray-500 cursor-not-allowed' : ''"
+                            @click.stop="moveUp(index)"
+                            :disabled="index == 0"
+                        >
+                            <svg xmlns="http://www.w3.org/2000/svg" class="fill-current" height="20" width="20">
+                                <path d="m2 16 8-12 8 12Z" />
+                            </svg>
+                        </button>
+                        <button
+                            class="rotate-180 transform"
+                            :class="index == slides.length - 1 ? 'text-gray-500 cursor-not-allowed' : ''"
+                            @click.stop="moveDown(index)"
+                            :disabled="index == slides.length - 1"
+                        >
+                            <svg xmlns="http://www.w3.org/2000/svg" class="fill-current" height="20" width="20">
+                                <path d="m2 16 8-12 8 12Z" />
+                            </svg>
+                        </button>
+                    </div>
+                </div>
+            </li>
+        </ul>
+    </div>
+</template>
+
+<script lang="ts">
+import { Component, Vue, Prop } from 'vue-property-decorator';
+import { Route } from 'vue-router';
+import { StoryRampConfig } from '@/definitions';
+
+import Circle2 from 'vue-loading-spinner/src/components/Circle2.vue';
+import SlideEditorV from './slide-editor.vue';
+
+@Component({
+    components: {
+        spinner: Circle2,
+        'slide-editor': SlideEditorV
+    }
+})
+export default class SlideTocV extends Vue {
+    @Prop() slides!: any[];
+
+    slideIndex: number | undefined = undefined;
+
+    selectSlide(index: number): void {
+        this.slideIndex = index;
+        this.$emit('slide-change', this.slideIndex);
+    }
+
+    addNewSlide(): void {
+        this.slides.push({
+            title: 'New Slide',
+            panel: [
+                {
+                    type: 'text',
+                    title: '',
+                    content: ''
+                },
+                {
+                    type: 'text',
+                    title: '',
+                    content: ''
+                }
+            ]
+        });
+    }
+
+    removeSlide(index: number): void {
+        if (index === this.slideIndex) {
+            this.slideIndex = undefined;
+            this.$emit('slide-change', this.slideIndex);
+        }
+        const removedSlide = this.slides.splice(index, 1) as any;
+    }
+
+    moveUp(index: number): void {
+        this.moveDown(index - 1);
+    }
+
+    moveDown(index: number): void {
+        this.slides.splice(index + 1, 0, this.slides.splice(index, 1)[0]);
+    }
+}
+</script>
+
+<style lang="scss" scoped>
+.toc-slide button {
+    border: none !important;
+    padding: 0 !important;
+}
+</style>

--- a/src/components/editor/text-editor.vue
+++ b/src/components/editor/text-editor.vue
@@ -1,0 +1,25 @@
+<template>
+    <div class="flex flex-col">
+        <label class="text-left">Panel title:</label>
+        <input type="text" v-model="panel.title" />
+        <label class="text-left">Panel body:</label>
+        <v-md-editor v-model="panel.text" height="400px"></v-md-editor>
+    </div>
+</template>
+
+<script lang="ts">
+import { Component, Vue, Prop } from 'vue-property-decorator';
+
+@Component({
+    components: {}
+})
+export default class TextEditorV extends Vue {
+    @Prop() panel!: any;
+}
+</script>
+
+<style lang="scss" scoped>
+label {
+    text-align: left !important;
+}
+</style>


### PR DESCRIPTION
#233 #237 

Slide table of contents where you can add, remove and reorder slides.
Slides can be given a title and both left and right panels are editable. Left panel is constrained to text only, right panel has a dropdown for panel type. Text panels are synced with the config, I had no idea how to sync the image panel properly (it is given the panel as a prop though so all that needs to be done is setting it).

Added a basic UI for things vaguely following the mockups, will need more work done but things are there.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/285)
<!-- Reviewable:end -->
