### PR TITLE
Add edit functionality to chart editor and fix modal styling 

### DIFF
--- a/src/components/editor/helpers/image-preview.vue
+++ b/src/components/editor/helpers/image-preview.vue
@@ -41,5 +41,9 @@ export default class ImagePreviewV extends Vue {
     .image-file {
         aspect-ratio: 1/1;
     }
+
+    button {
+        padding: 0 !important;
+    }
 }
 </style>


### PR DESCRIPTION
Closes #242, #243

*NOTE*: The main add chart button summoner automatically saves the last added chart options by default when adding multiple charts, not sure if this is a critical bug but if so can log a new issue for that. 

**Changes**: 
- adds edit functionality to each individual chart in gallery preview
- fixes highcharts editor modal styling so that header buttons are not cut-off, chart dimensions are on same line, etc. 
- enforces a no-duplicate chart name rule so that each edit button has its own unique ID to summon its corresponding chart modal (throws a screen alert for error), but can also adapt to a unique ID for each chart as a possible enhancement

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/300)
<!-- Reviewable:end -->
