### PR TITLE
generate saved product ZIP; save images and charts to ZIP

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,11 +11,14 @@
         "@kangc/v-md-editor": "^1.7.11",
         "@tailwindcss/typography": "^0.4.0",
         "@types/highcharts": "^7.0.0",
+        "axios": "^1.2.0",
         "core-js": "^3.6.5",
+        "file-saver": "^2.0.5",
         "highcharts": "^9.3.2",
         "highcharts-vue": "^1.4.0",
         "hooper": "^0.3.4",
         "intersection-observer": "^0.12.0",
+        "jszip": "^3.10.1",
         "markdown-it": "^12.0.6",
         "nouislider": "^15.5.0",
         "vue": "^2.6.11",
@@ -31,6 +34,7 @@
         "vue-tippy": "^4.10.0"
     },
     "devDependencies": {
+        "@types/file-saver": "^2.0.5",
         "@types/markdown-it": "^12.0.1",
         "@typescript-eslint/eslint-plugin": "^4.18.0",
         "@typescript-eslint/parser": "^4.18.0",

--- a/src/components/editor/chart-editor.vue
+++ b/src/components/editor/chart-editor.vue
@@ -53,6 +53,9 @@ import ChartPreviewV from '@/components/editor/helpers/chart-preview.vue';
 })
 export default class ChartEditorV extends Vue {
     @Prop() panel!: any;
+    @Prop() configFileStructure!: any;
+    @Prop() lang!: string;
+
     chartConfigs = [] as Array<ChartFile>;
 
     mounted(): void {
@@ -88,6 +91,9 @@ export default class ChartEditorV extends Vue {
                 config: chart
             };
 
+            // Add chart config to ZIP file.
+            this.configFileStructure.charts[this.lang].file(`${chart.title.text}.json`, JSON.stringify(chart, null, 4));
+
             this.chartConfigs.push(chartConfig);
         }
     }
@@ -95,6 +101,13 @@ export default class ChartEditorV extends Vue {
     editChart(chartInfo: { oldChart: ChartFile; newChart: ChartFile }): void {
         const idx = this.chartConfigs.findIndex((chartFile: ChartFile) => chartFile.name === chartInfo.oldChart.name);
         if (idx !== -1) {
+            // Remove old chart config from ZIP file and add in new one.
+            this.configFileStructure.charts[this.lang].remove(`${chartInfo.oldChart.name}.json`);
+            this.configFileStructure.charts[this.lang].file(
+                `${chartInfo.newChart.name}.json`,
+                JSON.stringify(chartInfo.newChart.config, null, 4)
+            );
+
             this.chartConfigs[idx] = chartInfo.newChart;
         }
     }
@@ -102,6 +115,8 @@ export default class ChartEditorV extends Vue {
     deleteChart(chart: ChartFile): void {
         const idx = this.chartConfigs.findIndex((chartFile: ChartFile) => chartFile.name === chart.name);
         if (idx !== -1) {
+            // Remove the chart from the config file.
+            this.configFileStructure.charts[this.lang].remove(`${chart.name}.json`);
             this.chartConfigs.splice(idx, 1);
         }
     }

--- a/src/components/editor/image-editor.vue
+++ b/src/components/editor/image-editor.vue
@@ -45,6 +45,9 @@ import ImagePreviewV from '@/components/editor/helpers/image-preview.vue';
 })
 export default class ImageEditorV extends Vue {
     @Prop() panel!: any;
+    @Prop() configFileStructure!: any;
+    @Prop() lang!: string;
+
     imageURLs = [] as Array<string>;
     imageFiles = [] as Array<ImageFile>;
     dragging = false;
@@ -60,6 +63,9 @@ export default class ImageEditorV extends Vue {
         this.imageURLs = filelist.map((file: File) => URL.createObjectURL(file));
         this.imageFiles.push(
             ...filelist.map((file: File) => {
+                // Add the uploaded images to the product ZIP file.
+                this.configFileStructure.assets[this.lang].file(file.name, file);
+
                 return {
                     id: file.name,
                     src: URL.createObjectURL(file),
@@ -74,6 +80,9 @@ export default class ImageEditorV extends Vue {
             const files = [...e.dataTransfer.files];
             this.imageFiles.push(
                 ...files.map((file: File) => {
+                    // Add the uploaded images to the product ZIP file.
+                    this.configFileStructure.assets[this.lang].file(file.name, file);
+
                     return {
                         id: file.name,
                         src: URL.createObjectURL(file),
@@ -88,6 +97,8 @@ export default class ImageEditorV extends Vue {
     deleteImage(img: ImageFile): void {
         const idx = this.imageFiles.findIndex((file: ImageFile) => file.id === img.id);
         if (idx !== -1) {
+            // Remove the image from the product ZIP file.
+            this.configFileStructure.assets[this.lang].remove(this.imageFiles[idx].id);
             this.imageFiles.splice(idx, 1);
         }
     }

--- a/src/components/editor/slide-editor.vue
+++ b/src/components/editor/slide-editor.vue
@@ -22,7 +22,10 @@
                     <span class="ml-auto flex-grow"></span>
                     <div v-if="panelIndex === 1" class="flex flex-col">
                         <label class="text-left text-xl">Content type:</label>
-                        <select @change="currentSlide.panel[panelIndex].type = $event.target.value">
+                        <select
+                            @change="currentSlide.panel[panelIndex].type = $event.target.value"
+                            v-model="currentSlide.panel[panelIndex].type"
+                        >
                             <option v-for="thing in Object.keys(editors)" :key="thing" :value="thing">
                                 {{ thing }}
                             </option>
@@ -33,6 +36,8 @@
                     :is="editors[currentSlide.panel[panelIndex].type]"
                     :key="panelIndex + currentSlide.panel[panelIndex].type"
                     :panel="currentSlide.panel[panelIndex]"
+                    :configFileStructure="configFileStructure"
+                    :lang="lang"
                 ></component>
             </div>
         </div>
@@ -63,6 +68,8 @@ import TextEditorV from './text-editor.vue';
 export default class SlideEditorV extends Vue {
     config: StoryRampConfig | undefined = undefined;
     @Prop() currentSlide!: any;
+    @Prop() configFileStructure!: any;
+    @Prop() lang!: string;
 
     panelIndex = 0;
 

--- a/src/components/editor/text-editor.vue
+++ b/src/components/editor/text-editor.vue
@@ -3,7 +3,7 @@
         <label class="text-left">Panel title:</label>
         <input type="text" v-model="panel.title" />
         <label class="text-left">Panel body:</label>
-        <v-md-editor v-model="panel.text" height="400px"></v-md-editor>
+        <v-md-editor v-model="panel.content" height="400px"></v-md-editor>
     </div>
 </template>
 


### PR DESCRIPTION
This PR adds functionality to the save button. Clicking the button generates a ZIP file with the following Storylines project structure:

- {UUID}
    - assets
        - en
        - fr
    - charts
        - en
        - fr
    - ramp-config
        - en
        - fr

This is what is currently saved:
- the Storylines configuration file (at the moment, **only the language being worked on**. We still need to make it so we can swap between English and French configs)
- Uploaded images (**not saved to Storylines config yet**, but images are added to ZIP)
- Created charts (**not saved to Storylines config yet**, but json files are added to ZIP)


At the moment, clicking the button downloads the ZIP file to your browser for testing purposes. The code is there to upload the ZIP file to a server via Axios. The server code is already written ([see demo here](https://github.com/ramp4-pcar4/story-ramp/issues/286#issuecomment-1338050001)), we just need a server to upload it to and then we can update that endpoint.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/305)
<!-- Reviewable:end -->
