### PR TITLE
fix bottom of map being cut off when a title is present

### DIFF
--- a/src/components/panels/map-panel.vue
+++ b/src/components/panels/map-panel.vue
@@ -4,7 +4,11 @@
             {{ config.title }}
         </div>
 
-        <div :id="`ramp-map-${slideIdx}`" class="w-full bg-gray-200 rv-map h-story">
+        <div
+            :id="`ramp-map-${slideIdx}`"
+            class="w-full bg-gray-200 h-story"
+            :class="config.title ? 'rv-map-title' : 'rv-map'"
+        >
             <div class="flex items-center justify-center w-full h-full map-loading">
                 <svg class="animate-pulse w-52" viewBox="0 0 100 82.202" xmlns="http://www.w3.org/2000/svg">
                     <path
@@ -158,12 +162,16 @@ export default class MapPanelV extends Vue {
     height: calc(100vh - 4rem) !important;
     width: 100%;
 }
+.rv-map-title {
+    height: calc(100vh - 9rem) !important;
+    width: 100%;
+}
 
 .map-title {
     color: #111827;
     font-weight: 700;
     font-size: 1.5em;
-    margin-top: 2em;
+    margin-top: 1em;
     margin-bottom: 1em;
     line-height: 1.3333333;
 }


### PR DESCRIPTION
Closes #319 (PR 1/2, other PR is in the editor repo)

This PR fixes an issue where maps with a title will have their bottoms cut off. Maps with a title will now be slightly less tall in order to fit on the screen.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/320)
<!-- Reviewable:end -->
