### PR TITLE
Time slider now affects multiple layers

### DIFF
--- a/src/components/panels/helpers/time-slider.vue
+++ b/src/components/panels/helpers/time-slider.vue
@@ -123,7 +123,18 @@ export default class TimeSlider extends Vue {
                     break;
             }
 
-            this.mapi.layers.allLayers[0].setFilterSql('time_slider', sqlString);
+            if (!this.config.layers || this.config.layers.length === 0) {
+                this.mapi.layers.allLayers.forEach((layer: any) => {
+                    layer.setFilterSql('time_slider', sqlString);
+                });
+            } else {
+                this.config.layers.forEach((layerId) => {
+                    const layers = this.mapi.layers.getLayersById(layerId);
+                    layers.forEach((layer: any) => {
+                        layer.setFilterSql('time_slider', sqlString);
+                    });
+                });
+            }
         });
 
         // to have an element focusable inside the RAMP container, its tabindex must not be 0;

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -121,6 +121,7 @@ export interface TimeSliderConfig {
     range: number[];
     start: number[];
     attribute: string;
+    layers?: string[];
 }
 
 export interface DynamicPanel extends BasePanel {


### PR DESCRIPTION
Closes #329 

Time slider now loops through layers to change filter sql.

Added a config param to give an array of layer IDs for the time slider to affect, not supplying this param will have it affect every layer.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/330)
<!-- Reviewable:end -->
