### PR TITLE
fix map height on mobile resolution

### DIFF
--- a/src/components/panels/map-panel.vue
+++ b/src/components/panels/map-panel.vue
@@ -177,7 +177,8 @@ export default class MapPanelV extends Vue {
 }
 
 @media screen and (max-width: 640px) {
-    .rv-map {
+    .rv-map,
+    .rv-map-title {
         max-height: 40vh;
 
         ::v-deep .time-slider-container {


### PR DESCRIPTION
Closes #339 

Fixes an issue where maps with a title would take up the entire screen height on mobile view.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/342)
<!-- Reviewable:end -->
