### PR TITLE
fix intro slide not loading when logo is missing

### DIFF
--- a/src/components/story/introduction.vue
+++ b/src/components/story/introduction.vue
@@ -1,6 +1,11 @@
 <template>
     <div class="py-24 mx-auto text-center max-w-9xl" id="intro">
-        <img class="inline-block" :src="config.logo.src" :alt="config.logo.altText" />
+        <img
+            v-if="config.logo && config.logo.src"
+            class="inline-block"
+            :src="config.logo.src"
+            :alt="config.logo.altText"
+        />
 
         <h1 class="m-10 text-5xl font-bold text-gray-800">
             {{ config.title }}


### PR DESCRIPTION
Closes #207 (2/2)

Fixes issue where the intro slide wasn't appearing if the logo section was missing from the config.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/343)
<!-- Reviewable:end -->
