### PR TITLE
Fix fullscreen using wrong map

### DIFF
--- a/src/components/panels/panel.vue
+++ b/src/components/panels/panel.vue
@@ -2,7 +2,7 @@
     <div
         :class="
             config.type !== 'text'
-                ? `sticky ${config.type === 'map' ? 'top-16' : 'top-8'} sm:self-start flex-2 order-1 sm:order-2 z-40`
+                ? `sticky ${config.type === 'map' ? 'top-16' : 'top-8'} sm:self-start flex-2 order-1 sm:order-2 z-50`
                 : 'flex order-2 sm:order-1'
         "
         class="flex-col relative"

--- a/src/components/story/story.vue
+++ b/src/components/story/story.vue
@@ -17,7 +17,7 @@
 
     <div v-else-if="loadStatus === 'loaded'">
         <div class="storyramp-app bg-white">
-            <header class="sticky top-0 z-50 w-full h-16 leading-9 bg-white border-b border-gray-200">
+            <header class="story-header sticky top-0 w-full h-16 leading-9 bg-white border-b border-gray-200">
                 <div class="flex w-full sm:px-6 py-3 mx-auto">
                     <MobileMenuV
                         class="mobile-menu"
@@ -180,6 +180,10 @@ $font-list: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
     .prose a:not([panel])::after {
         content: url('../../assets/popout.svg');
     }
+}
+
+.story-header {
+    z-index: 60;
 }
 
 @media screen and (min-width: 640px) {


### PR DESCRIPTION
Closes #335 

The z-index on the panels was making the z-index on the maps not function correctly.

There is still a bug in RAMP2 where the fullscreen styles are being applied to every ramp shell, I'll log an issue there but this fixes it in our case.