### PR TITLE
Dynamic Slideshow

### DIFF
--- a/StoryRampSchema.json
+++ b/StoryRampSchema.json
@@ -138,7 +138,7 @@
             "description": "A multimedia slide component.",
             "oneOf": [
                 {
-                    "$ref": "#/$defs/multimediaImage"
+                    "$ref": "#/$defs/imagePanel"
                 },
                 {
                     "$ref": "#/$defs/multimediaVideo"
@@ -147,7 +147,7 @@
                     "$ref": "#/$defs/multimediaAudio"
                 },
                 {
-                    "$ref": "#/$defs/multimediaSlideshow"
+                    "$ref": "#/$defs/slideshowPanel"
                 }
             ],
             "properties": {
@@ -157,6 +157,88 @@
                     "default": true
                 }
             }
+        },
+
+        "imagePanel": {
+            "type": "object",
+            "description": "An image panel.",
+            "properties": {
+                "images": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/multimediaImage"
+                    },
+                    "description": "An array of images to display in the slideshow.",
+                    "minItems": 1
+                },
+                "loop": {
+                    "type": "boolean",
+                    "description": "Determines whether the slideshow loops back around to the beginning when you reach the end.",
+                    "default": false
+                },
+                "caption": {
+                    "type": "text",
+                    "description": "A caption to display below the slideshow."
+                },
+                "type": {
+                    "type": "string",
+                    "enum": ["slideshow"]
+                }
+            }
+        },
+
+        "slideshowPanel": {
+            "type": "object",
+            "description": "A multimedia slideshow component.",
+            "properties": {
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "type": {
+                                "type": "string",
+                                "description": "Type of this slideshow item.",
+                                "enum": ["text", "map", "image", "chart"]
+                            },
+                            "config": {
+                                "type": "object",
+                                "description": "Config for this slideshow item.",
+                                "oneOf": [
+                                    {
+                                        "$ref": "#/$defs/multimediaImage"
+                                    },
+                                    {
+                                        "$ref": "#/$defs/mapPanel"
+                                    },
+                                    {
+                                        "$ref": "#/$defs/textPanel"
+                                    },
+                                    {
+                                        "$ref": "#/$defs/dqvchartPanel"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "description": "An array of images to display in the slideshow.",
+                    "minItems": 1
+                },
+                "loop": {
+                    "type": "boolean",
+                    "description": "Determines whether the slideshow loops back around to the beginning when you reach the end.",
+                    "default": false
+                },
+                "caption": {
+                    "type": "text",
+                    "description": "A caption to display below the slideshow."
+                },
+                "type": {
+                    "type": "string",
+                    "enum": ["slideshow"]
+                }
+            },
+            "required": ["items", "type"]
         },
 
         "mapPanel": {
@@ -249,10 +331,6 @@
                 "tooltip": {
                     "type": "string",
                     "description": "Tooltip content for the image."
-                },
-                "type": {
-                    "type": "string",
-                    "enum": ["image"]
                 }
             },
             "required": ["src", "type"]
@@ -306,34 +384,6 @@
             "required": ["src", "type"]
         },
 
-        "multimediaSlideshow": {
-            "type": "object",
-            "description": "A multimedia slideshow component.",
-            "properties": {
-                "images": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/$defs/multimediaImage"
-                    },
-                    "description": "An array of images to display in the slideshow.",
-                    "minItems": 1
-                },
-                "loop": {
-                    "type": "boolean",
-                    "description": "Determines whether the slideshow loops back around to the beginning when you reach the end.",
-                    "default": false
-                },
-                "caption": {
-                    "type": "text",
-                    "description": "A caption to display below the slideshow."
-                },
-                "type": {
-                    "type": "string",
-                    "enum": ["slideshow"]
-                }
-            },
-            "required": ["images", "type"]
-        },
         "dqvchartOptions": {
             "type": "object",
             "description": "Configuration for a dqvchart.",
@@ -349,7 +399,20 @@
                 "type": {
                     "type": "string",
                     "description": "The type of chart.",
-                    "enum": ["line", "spline", "area", "areaspline", "column", "bar", "pie", "scatter", "gauge", "arearange", "areasplinerange", "columnrange"]
+                    "enum": [
+                        "line",
+                        "spline",
+                        "area",
+                        "areaspline",
+                        "column",
+                        "bar",
+                        "pie",
+                        "scatter",
+                        "gauge",
+                        "arearange",
+                        "areasplinerange",
+                        "columnrange"
+                    ]
                 },
                 "width": {
                     "type": "number",
@@ -385,79 +448,80 @@
                     "description": "The title of the y-axis."
                 }
             }
-    },
-
-    "properties": {
-        "title": {
-            "type": "string",
-            "description": "The title of the story map."
         },
 
-        "introSlide": {
-            "type": "object",
-            "description": "The introductory slide",
-            "properties": {
-                "logo": {
-                    "type": "object",
-                    "description": "Information about the StoryRAMP logo",
-                    "properties": {
-                        "src": {
-                            "type": "string",
-                            "description": "An image source that is displayed at the top of the slide"
+        "properties": {
+            "title": {
+                "type": "string",
+                "description": "The title of the story map."
+            },
+
+            "introSlide": {
+                "type": "object",
+                "description": "The introductory slide",
+                "properties": {
+                    "logo": {
+                        "type": "object",
+                        "description": "Information about the StoryRAMP logo",
+                        "properties": {
+                            "src": {
+                                "type": "string",
+                                "description": "An image source that is displayed at the top of the slide"
+                            },
+                            "altText": {
+                                "type": "string",
+                                "description": "Alt text for the logo"
+                            }
                         },
-                        "altText": {
-                            "type": "string",
-                            "description": "Alt text for the logo"
-                        }
+                        "required": ["src"]
                     },
-                    "required": ["src"]
+                    "title": {
+                        "type": "string",
+                        "description": "The title of the project, displayed under the image"
+                    },
+                    "subtitle": {
+                        "type": "string",
+                        "description": "An optional subtitle that is displayed under the title."
+                    },
+                    "blurb": {
+                        "type": "string",
+                        "description": "Any additional information to display on the introductory slide."
+                    }
                 },
-                "title": {
-                    "type": "string",
-                    "description": "The title of the project, displayed under the image"
-                },
-                "subtitle": {
-                    "type": "string",
-                    "description": "An optional subtitle that is displayed under the title."
-                },
-                "blurb": {
-                    "type": "string",
-                    "description": "Any additional information to display on the introductory slide."
-                }
+                "required": ["logo", "title"]
             },
-            "required": ["logo", "title"]
-        },
 
-        "slides": {
-            "type": "array",
-            "description": "A list of StoryRAMP slides. A minimum of one slide is required.",
-            "items": {
-                "$ref": "#/$defs/slide"
+            "slides": {
+                "type": "array",
+                "description": "A list of StoryRAMP slides. A minimum of one slide is required.",
+                "items": {
+                    "$ref": "#/$defs/slide"
+                },
+                "minItems": 1
             },
-            "minItems": 1
+
+            "contextLink": {
+                "type": "string",
+                "description": "A link pointing to the source information"
+            },
+
+            "contextLabel": {
+                "type": "string",
+                "description": "A description that explains the context link."
+            },
+
+            "lang": {
+                "type": "string",
+                "description": "The language to display in the app",
+                "enum": ["en", "fr"]
+            },
+
+            "dateModified": {
+                "type": "string",
+                "description": "The last date that this config file was modified."
+            }
         },
 
-        "contextLink": {
-            "type": "string",
-            "description": "A link pointing to the source information"
-        },
-
-        "contextLabel": {
-            "type": "string",
-            "description": "A description that explains the context link."
-        },
-
-        "lang": {
-            "type": "string",
-            "description": "The language to display in the app",
-            "enum": ["en", "fr"]
-        },
-
-        "dateModified": {
-            "type": "string",
-            "description": "The last date that this config file was modified."
-        }
-    },
-
-    "required": ["title", "introSlide", "slides"]
+        "required": ["title", "introSlide", "slides"]
+    }
 }

--- a/public/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000_en.json
+++ b/public/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000_en.json
@@ -18,9 +18,13 @@
                     "type": "text"
                 },
                 {
-                    "src": "00000000-0000-0000-0000-000000000000/assets/en/NPRIpictogramme-2016data-EN__1553797637582__w1430.jpg",
                     "type": "image",
-                    "caption": "This is a caption for the image."
+                    "images": [
+                        {
+                            "src": "00000000-0000-0000-0000-000000000000/assets/en/NPRIpictogramme-2016data-EN__1553797637582__w1430.jpg",
+                            "caption": "This is a caption for the image."
+                        }
+                    ]
                 }
             ]
         },
@@ -43,8 +47,12 @@
                         {
                             "id": "panel-2",
                             "panel": {
-                                "src": "00000000-0000-0000-0000-000000000000/assets/en/GettyImages-187242601__1554821467033__w1920.jpg",
-                                "type": "image"
+                                "type": "image",
+                                "images": [
+                                    {
+                                        "src": "00000000-0000-0000-0000-000000000000/assets/en/GettyImages-187242601__1554821467033__w1920.jpg"
+                                    }
+                                ]
                             }
                         },
                         {
@@ -82,6 +90,47 @@
             ]
         },
         {
+            "title": "Dynamic Slideshow Test",
+            "panel": [
+                {
+                    "title": "This is a dynamic slideshow!",
+                    "content": "It is a slideshow that supports text, images, charts, and maps. \n\nNavigate through all the slides to see all the types in action.\n\nMore fun stuff.",
+                    "type": "text"
+                },
+                {
+                    "type": "slideshow",
+                    "items": [
+                        {
+                            "type": "text",
+                            "config": {
+                                "title": "Lorem Ipsum",
+                                "content": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris efficitur lectus dui, vitae hendrerit lacus laoreet vitae. Integer gravida lorem non tortor aliquam porta. Sed ipsum lacus, tristique eu lacus in, malesuada tincidunt mi. Duis vel dolor hendrerit, ornare dui eget, tristique nunc. Fusce eget nunc mauris. Mauris velit justo, lacinia ut metus id, rhoncus accumsan velit. Morbi fermentum lectus in magna ornare, ut placerat mauris eleifend. Integer nec erat arcu.\n\nMorbi turpis lectus, aliquam ut arcu ac, ultricies tristique mi. Vestibulum faucibus sapien non felis ultrices, a tempus urna dapibus. Fusce eget massa non lacus finibus hendrerit id a quam. Aliquam vestibulum posuere rutrum. Quisque vehicula maximus aliquet. Donec aliquet ornare posuere. Fusce a erat vitae eros scelerisque sodales. Nullam posuere arcu a elit consequat egestas. In tincidunt erat sed dolor pulvinar dignissim in in felis. Sed mollis eu arcu quis ornare. Phasellus dignissim odio elit. Nam dictum ante tellus. Suspendisse mollis eleifend dolor quis pulvinar. Proin posuere arcu feugiat rutrum dapibus."
+                            }
+                        },
+                        {
+                            "type": "image",
+                            "config": {
+                                "src": "00000000-0000-0000-0000-000000000000/assets/en/GettyImages-187242601__1554821467033__w1920.jpg"
+                            }
+                        },
+                        {
+                            "type": "chart",
+                            "config": {
+                                "src": "00000000-0000-0000-0000-000000000000/charts/en/chartConfig.json"
+                            }
+                        },
+                        {
+                            "type": "map",
+                            "config": {
+                                "config": "00000000-0000-0000-0000-000000000000/ramp-config/en/OilSandsFacilityLocations2019.json",
+                                "scrollguard": true
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
             "title": "Oil sands deposits",
             "panel": [
                 {
@@ -105,9 +154,13 @@
                     "type": "text"
                 },
                 {
-                    "src": "00000000-0000-0000-0000-000000000000/assets/en/GettyImages-187242601__1554821467033__w1920.jpg",
                     "type": "image",
-                    "fullscreen": false
+                    "images": [
+                        {
+                            "src": "00000000-0000-0000-0000-000000000000/assets/en/GettyImages-187242601__1554821467033__w1920.jpg",
+                            "fullscreen": false
+                        }
+                    ]
                 }
             ]
         },
@@ -120,8 +173,8 @@
                     "type": "text"
                 },
                 {
-                    "src": "00000000-0000-0000-0000-000000000000/assets/en/Slide 3 - mine vs insitu.jpg",
-                    "type": "image"
+                    "type": "image",
+                    "images": [{ "src": "00000000-0000-0000-0000-000000000000/assets/en/Slide 3 - mine vs insitu.jpg" }]
                 }
             ]
         },
@@ -151,42 +204,35 @@
                 {
                     "images": [
                         {
-                            "src": "00000000-0000-0000-0000-000000000000/assets/en/substances/1_AuroraNorth_RelDisp.PNG",
-                            "type": "image"
+                            "src": "00000000-0000-0000-0000-000000000000/assets/en/substances/1_AuroraNorth_RelDisp.PNG"
                         },
                         {
-                            "src": "00000000-0000-0000-0000-000000000000/assets/en/substances/2_FortHills_RelDisp.PNG",
-                            "type": "image"
+                            "src": "00000000-0000-0000-0000-000000000000/assets/en/substances/2_FortHills_RelDisp.PNG"
                         },
                         {
-                            "src": "00000000-0000-0000-0000-000000000000/assets/en/substances/3_Horizon_RelDisp.PNG",
-                            "type": "image"
+                            "src": "00000000-0000-0000-0000-000000000000/assets/en/substances/3_Horizon_RelDisp.PNG"
                         },
                         {
-                            "src": "00000000-0000-0000-0000-000000000000/assets/en/substances/4_Kearl_RelDisp.PNG",
-                            "type": "image"
+                            "src": "00000000-0000-0000-0000-000000000000/assets/en/substances/4_Kearl_RelDisp.PNG"
                         },
                         {
-                            "src": "00000000-0000-0000-0000-000000000000/assets/en/substances/5_MuskegJackpine_R5_RelDisp.PNG",
-                            "type": "image"
+                            "src": "00000000-0000-0000-0000-000000000000/assets/en/substances/5_MuskegJackpine_R5_RelDisp.PNG"
                         },
                         {
-                            "src": "00000000-0000-0000-0000-000000000000/assets/en/substances/6_Suncor_RelDisp.PNG",
-                            "type": "image"
+                            "src": "00000000-0000-0000-0000-000000000000/assets/en/substances/6_Suncor_RelDisp.PNG"
                         },
                         {
-                            "src": "00000000-0000-0000-0000-000000000000/assets/en/substances/7_Syncrude_RelDisp.PNG",
-                            "type": "image"
+                            "src": "00000000-0000-0000-0000-000000000000/assets/en/substances/7_Syncrude_RelDisp.PNG"
                         }
                     ],
                     "loop": true,
                     "caption": "NPRI substances reported for oil sands mining facilities",
-                    "type": "slideshow"
+                    "type": "image"
                 }
             ]
         },
         {
-            "title": "Reported mine tailings from oil sands surface mining facilities",
+            "title": "Chart gallery sample test",
             "panel": [
                 {
                     "title": "Reported mine tailings from oil sands surface mining facilities",
@@ -197,15 +243,14 @@
                     "type": "chart",
                     "charts": [
                         {
-                            "src": "410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/en/tailings/1.Syncrude Canada Ltd., Aurora North Mine Site 2019 Tailings.csv",
+                            "src": "00000000-0000-0000-0000-000000000000/charts/en/Criteria air contaminant releases from oil sands mines_3.csv",
                             "options": {
                                 "title": "Syncrude Canada Ltd., Aurora North Mine Site 2019 Tailings (Tonnes)",
-                                "subtitle": "",
-                                "type": "pie"
+                                "subtitle": ""
                             }
                         },
                         {
-                            "src": "410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/en/tailings/2.Fort Hill Energy L.P., Fort Hills Oil Sands 2019 Tailings.csv",
+                            "src": "00000000-0000-0000-0000-000000000000/charts/en/Mine tailings reported.csv",
                             "options": {
                                 "title": "Fort Hill Energy L.P., Fort Hills Oil Sands 2019 Tailings (Tonnes)",
                                 "subtitle": "",
@@ -213,11 +258,10 @@
                             }
                         },
                         {
-                            "src": "410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/en/tailings/3.Canadian Natural Resources Limited, Horizon Oil Sands Processing Plant and Mine 2019 Tailings.csv",
+                            "src": "00000000-0000-0000-0000-000000000000/charts/en/NPRI releases from thermal in-situ facilities_1.csv",
                             "options": {
                                 "title": "Canadian Natural Resources Limited, Horizon Oil Sands Processing Plant and Mine 2019 Tailings (Tonnes)",
-                                "subtitle": "",
-                                "type": "pie"
+                                "subtitle": ""
                             }
                         }
                     ]
@@ -247,8 +291,8 @@
                     "type": "text"
                 },
                 {
-                    "src": "00000000-0000-0000-0000-000000000000/assets/en/slide 6 - mining trends.jpg",
-                    "type": "image"
+                    "type": "image",
+                    "images": [{ "src": "00000000-0000-0000-0000-000000000000/assets/en/slide 6 - mining trends.jpg" }]
                 }
             ]
         },
@@ -261,8 +305,12 @@
                     "type": "text"
                 },
                 {
-                    "src": "00000000-0000-0000-0000-000000000000/assets/en/Top10SubstancesTailings2019.png",
-                    "type": "image"
+                    "type": "image",
+                    "images": [
+                        {
+                            "src": "00000000-0000-0000-0000-000000000000/assets/en/Top10SubstancesTailings2019.png"
+                        }
+                    ]
                 }
             ]
         },
@@ -277,37 +325,30 @@
                 {
                     "images": [
                         {
-                            "src": "00000000-0000-0000-0000-000000000000/assets/en/tailings/AuroraNorth_Tailings.PNG",
-                            "type": "image"
+                            "src": "00000000-0000-0000-0000-000000000000/assets/en/tailings/AuroraNorth_Tailings.PNG"
                         },
                         {
-                            "src": "00000000-0000-0000-0000-000000000000/assets/en/tailings/FortHills_Tailings.PNG",
-                            "type": "image"
+                            "src": "00000000-0000-0000-0000-000000000000/assets/en/tailings/FortHills_Tailings.PNG"
                         },
                         {
-                            "src": "00000000-0000-0000-0000-000000000000/assets/en/tailings/Horizon_Tailings.PNG",
-                            "type": "image"
+                            "src": "00000000-0000-0000-0000-000000000000/assets/en/tailings/Horizon_Tailings.PNG"
                         },
                         {
-                            "src": "00000000-0000-0000-0000-000000000000/assets/en/tailings/Kearl_Tailings.PNG",
-                            "type": "image"
+                            "src": "00000000-0000-0000-0000-000000000000/assets/en/tailings/Kearl_Tailings.PNG"
                         },
                         {
-                            "src": "00000000-0000-0000-0000-000000000000/assets/en/tailings/Muskeg_Tailings.PNG",
-                            "type": "image"
+                            "src": "00000000-0000-0000-0000-000000000000/assets/en/tailings/Muskeg_Tailings.PNG"
                         },
                         {
-                            "src": "00000000-0000-0000-0000-000000000000/assets/en/tailings/Suncor_Tailings.PNG",
-                            "type": "image"
+                            "src": "00000000-0000-0000-0000-000000000000/assets/en/tailings/Suncor_Tailings.PNG"
                         },
                         {
-                            "src": "00000000-0000-0000-0000-000000000000/assets/en/tailings/Syncrude_Tailings.PNG",
-                            "type": "image"
+                            "src": "00000000-0000-0000-0000-000000000000/assets/en/tailings/Syncrude_Tailings.PNG"
                         }
                     ],
                     "loop": true,
                     "caption": "Reported mine tailings from oil sands surface mining facilities",
-                    "type": "slideshow"
+                    "type": "image"
                 }
             ]
         },
@@ -348,8 +389,8 @@
                     "type": "text"
                 },
                 {
-                    "src": "00000000-0000-0000-0000-000000000000/assets/en/Slide 10 - SAGD vs CSS.jpg",
-                    "type": "image"
+                    "type": "image",
+                    "images": [{ "src": "00000000-0000-0000-0000-000000000000/assets/en/Slide 10 - SAGD vs CSS.jpg" }]
                 }
             ]
         },
@@ -377,7 +418,12 @@
                 },
                 {
                     "config": "00000000-0000-0000-0000-000000000000/ramp-config/en/ReleasestoAirbyInSituFacilitiesforAllSubstances2010to2019(timeslider).json",
-                    "type": "map"
+                    "type": "map",
+                    "timeSlider": {
+                        "range": [2010, 2019],
+                        "start": [2010, 2019],
+                        "attribute": "Reporting_Year___Année"
+                    }
                 }
             ]
         },
@@ -390,8 +436,12 @@
                     "type": "text"
                 },
                 {
-                    "src": "00000000-0000-0000-0000-000000000000/assets/en/Slide%2013%20-%20InSitu%20Trends__1554406944277__w594.jpg",
-                    "type": "image"
+                    "type": "image",
+                    "images": [
+                        {
+                            "src": "00000000-0000-0000-0000-000000000000/assets/en/Slide%2013%20-%20InSitu%20Trends__1554406944277__w594.jpg"
+                        }
+                    ]
                 }
             ]
         },
@@ -404,8 +454,12 @@
                     "type": "text"
                 },
                 {
-                    "src": "00000000-0000-0000-0000-000000000000/assets/en/GettyImages-516166467__1554821531978__w1920.jpg",
-                    "type": "image"
+                    "type": "image",
+                    "images": [
+                        {
+                            "src": "00000000-0000-0000-0000-000000000000/assets/en/GettyImages-516166467__1554821531978__w1920.jpg"
+                        }
+                    ]
                 }
             ]
         },
@@ -440,15 +494,6 @@
                         },
                         {
                             "src": "ea24000c-7dc3-49a9-baac-c55d28dcaeb9/charts/en/Ethlyene.glycol.release.trends.by.sector.2010-2019.tonnes.csv"
-                        },
-                        {
-                            "src": "410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/en/tailings/2.Fort Hill Energy L.P., Fort Hills Oil Sands 2019 Tailings.csv",
-                            "options": {
-                                "title": "Fort Hill Energy L.P., Fort Hills Oil Sands 2019 Tailings (Tonnes)",
-                                "subtitle": "",
-                                "type": "pie",
-                                "colours": ["green", "#FAEBD7", "indigo", "#FFD700", "orange", "red"]
-                            }
                         }
                     ]
                 }
@@ -466,8 +511,7 @@
                     "type": "chart",
                     "charts": [
                         {
-                            "src": "ea24000c-7dc3-49a9-baac-c55d28dcaeb9/charts/en/Ethlyene.glycol.release.trends.by.sector.2010-2019.tonnes.csv",
-
+                            "src": "00000000-0000-0000-0000-000000000000/charts/en/NPRI releases from thermal in-situ facilities_1.csv",
                             "options": {
                                 "xAxisLabel": "X Axis Test From Config",
                                 "yAxisLabel": "Y Axis Test From Config",

--- a/public/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000_fr.json
+++ b/public/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000_fr.json
@@ -18,8 +18,12 @@
                     "type": "text"
                 },
                 {
-                    "src": "00000000-0000-0000-0000-000000000000/assets/fr/NPRIpictogramme-2016data-FR__1552505700147__w975.jpg",
-                    "type": "image"
+                    "type": "image",
+                    "images": [
+                        {
+                            "src": "00000000-0000-0000-0000-000000000000/assets/fr/NPRIpictogramme-2016data-FR__1552505700147__w975.jpg"
+                        }
+                    ]
                 }
             ]
         },
@@ -47,8 +51,12 @@
                     "type": "text"
                 },
                 {
-                    "src": "00000000-0000-0000-0000-000000000000/assets/fr/GettyImages-187242601__1554821412825__w1920.jpg",
-                    "type": "image"
+                    "type": "image",
+                    "images": [
+                        {
+                            "src": "00000000-0000-0000-0000-000000000000/assets/fr/GettyImages-187242601__1554821412825__w1920.jpg"
+                        }
+                    ]
                 }
             ]
         },
@@ -61,8 +69,8 @@
                     "type": "text"
                 },
                 {
-                    "src": "00000000-0000-0000-0000-000000000000/assets/fr/Slide 3 - mine vs insitu.jpg",
-                    "type": "image"
+                    "type": "image",
+                    "images": [{ "src": "00000000-0000-0000-0000-000000000000/assets/fr/Slide 3 - mine vs insitu.jpg" }]
                 }
             ]
         },
@@ -91,37 +99,30 @@
                 {
                     "images": [
                         {
-                            "src": "00000000-0000-0000-0000-000000000000/assets/fr/substances/AuroraNorth_RelDisp_FR.PNG",
-                            "type": "image"
+                            "src": "00000000-0000-0000-0000-000000000000/assets/fr/substances/AuroraNorth_RelDisp_FR.PNG"
                         },
                         {
-                            "src": "00000000-0000-0000-0000-000000000000/assets/fr/substances/FortHills_RelDisp_FR.PNG",
-                            "type": "image"
+                            "src": "00000000-0000-0000-0000-000000000000/assets/fr/substances/FortHills_RelDisp_FR.PNG"
                         },
                         {
-                            "src": "00000000-0000-0000-0000-000000000000/assets/fr/substances/Horizon_RelDisp_FR.PNG",
-                            "type": "image"
+                            "src": "00000000-0000-0000-0000-000000000000/assets/fr/substances/Horizon_RelDisp_FR.PNG"
                         },
                         {
-                            "src": "00000000-0000-0000-0000-000000000000/assets/fr/substances/Kearl_RelDisp_FR.PNG",
-                            "type": "image"
+                            "src": "00000000-0000-0000-0000-000000000000/assets/fr/substances/Kearl_RelDisp_FR.PNG"
                         },
                         {
-                            "src": "00000000-0000-0000-0000-000000000000/assets/fr/substances/MuskegJackpine_RelDisp_FR.PNG",
-                            "type": "image"
+                            "src": "00000000-0000-0000-0000-000000000000/assets/fr/substances/MuskegJackpine_RelDisp_FR.PNG"
                         },
                         {
-                            "src": "00000000-0000-0000-0000-000000000000/assets/fr/substances/Suncor_RelDisp_FR.PNG",
-                            "type": "image"
+                            "src": "00000000-0000-0000-0000-000000000000/assets/fr/substances/Suncor_RelDisp_FR.PNG"
                         },
                         {
-                            "src": "00000000-0000-0000-0000-000000000000/assets/fr/substances/Syncrude_RelDisp_FR.PNG",
-                            "type": "image"
+                            "src": "00000000-0000-0000-0000-000000000000/assets/fr/substances/Syncrude_RelDisp_FR.PNG"
                         }
                     ],
                     "loop": true,
                     "caption": "NPRI substances reported for oil sands mining facilities",
-                    "type": "slideshow"
+                    "type": "image"
                 }
             ]
         },
@@ -187,8 +188,8 @@
                     "type": "text"
                 },
                 {
-                    "src": "00000000-0000-0000-0000-000000000000/assets/fr/slide 6 trends in mining.jpg",
-                    "type": "image"
+                    "type": "image",
+                    "images": [{ "src": "00000000-0000-0000-0000-000000000000/assets/fr/slide 6 trends in mining.jpg" }]
                 }
             ]
         },
@@ -201,8 +202,10 @@
                     "type": "text"
                 },
                 {
-                    "src": "00000000-0000-0000-0000-000000000000/assets/fr/Top10SubstancesTailings2019.png",
-                    "type": "image"
+                    "type": "image",
+                    "images": [
+                        { "src": "00000000-0000-0000-0000-000000000000/assets/fr/Top10SubstancesTailings2019.png" }
+                    ]
                 }
             ]
         },
@@ -217,37 +220,30 @@
                 {
                     "images": [
                         {
-                            "src": "00000000-0000-0000-0000-000000000000/assets/fr/tailings/AuroraNorth_Tailings_FR.PNG",
-                            "type": "image"
+                            "src": "00000000-0000-0000-0000-000000000000/assets/fr/tailings/AuroraNorth_Tailings_FR.PNG"
                         },
                         {
-                            "src": "00000000-0000-0000-0000-000000000000/assets/fr/tailings/FortHills_Tailings_FR.PNG",
-                            "type": "image"
+                            "src": "00000000-0000-0000-0000-000000000000/assets/fr/tailings/FortHills_Tailings_FR.PNG"
                         },
                         {
-                            "src": "00000000-0000-0000-0000-000000000000/assets/fr/tailings/Horizon_Tailings_FR.PNG",
-                            "type": "image"
+                            "src": "00000000-0000-0000-0000-000000000000/assets/fr/tailings/Horizon_Tailings_FR.PNG"
                         },
                         {
-                            "src": "00000000-0000-0000-0000-000000000000/assets/fr/tailings/Kearl_Tailings_FR.PNG",
-                            "type": "image"
+                            "src": "00000000-0000-0000-0000-000000000000/assets/fr/tailings/Kearl_Tailings_FR.PNG"
                         },
                         {
-                            "src": "00000000-0000-0000-0000-000000000000/assets/fr/tailings/Muskeg_Tailings_FR.PNG",
-                            "type": "image"
+                            "src": "00000000-0000-0000-0000-000000000000/assets/fr/tailings/Muskeg_Tailings_FR.PNG"
                         },
                         {
-                            "src": "00000000-0000-0000-0000-000000000000/assets/fr/tailings/Suncor_Tailings_FR.PNG",
-                            "type": "image"
+                            "src": "00000000-0000-0000-0000-000000000000/assets/fr/tailings/Suncor_Tailings_FR.PNG"
                         },
                         {
-                            "src": "00000000-0000-0000-0000-000000000000/assets/fr/tailings/Syncrude_Tailings_FR.PNG",
-                            "type": "image"
+                            "src": "00000000-0000-0000-0000-000000000000/assets/fr/tailings/Syncrude_Tailings_FR.PNG"
                         }
                     ],
                     "loop": true,
                     "caption": "Résidus miniers déclarés à l’INRP par les installations d’exploitation minière à ciel ouvert de sables bitumineux",
-                    "type": "slideshow"
+                    "type": "image"
                 }
             ]
         },
@@ -288,8 +284,8 @@
                     "type": "text"
                 },
                 {
-                    "src": "00000000-0000-0000-0000-000000000000/assets/fr/Slide 10 - SAGD vs CSS.jpg",
-                    "type": "image"
+                    "type": "image",
+                    "images": [{ "src": "00000000-0000-0000-0000-000000000000/assets/fr/Slide 10 - SAGD vs CSS.jpg" }]
                 }
             ]
         },
@@ -330,8 +326,12 @@
                     "type": "text"
                 },
                 {
-                    "src": "00000000-0000-0000-0000-000000000000/assets/fr/Slide%2013%20Insitu%20trends%20-%20French__1554407015712__w628.jpg",
-                    "type": "image"
+                    "type": "image",
+                    "images": [
+                        {
+                            "src": "00000000-0000-0000-0000-000000000000/assets/fr/Slide%2013%20Insitu%20trends%20-%20French__1554407015712__w628.jpg"
+                        }
+                    ]
                 }
             ]
         },
@@ -344,8 +344,10 @@
                     "type": "text"
                 },
                 {
-                    "src": "00000000-0000-0000-0000-000000000000/assets/fr/slide%2014%20-%20athabasca.jpg",
-                    "type": "image"
+                    "type": "image",
+                    "images": [
+                        { "src": "00000000-0000-0000-0000-000000000000/assets/fr/slide%2014%20-%20athabasca.jpg" }
+                    ]
                 }
             ]
         }

--- a/src/components/panels/image-panel.vue
+++ b/src/components/panels/image-panel.vue
@@ -1,39 +1,82 @@
 <template>
-    <div class="graphic self-start justify-center flex flex-col h-full align-middle py-5 w-full">
-        <full-screen :expandable="config.fullscreen" :type="config.type">
-            <img
-                ref="img"
-                :src="slideIdx > 2 ? '' : config.src"
-                :class="config.class"
-                :alt="config.altText || ''"
-                :style="{ width: `${config.width}px`, height: `${config.height}px` }"
-                class="graphic-image px-10 mx-auto my-6 flex object-contain sm:max-w-screen sm:max-h-screen"
-            />
-        </full-screen>
+    <div v-if="config.images.length === 1">
+        <div class="graphic self-start justify-center flex flex-col h-full align-middle py-5 w-full">
+            <full-screen :expandable="config.images[0].fullscreen" :type="config.type">
+                <img
+                    ref="img"
+                    :src="slideIdx > 2 ? '' : config.images[0].src"
+                    :class="config.images[0].class"
+                    :alt="config.images[0].altText || ''"
+                    :style="{ width: `${config.images[0].width}px`, height: `${config.images[0].height}px` }"
+                    class="graphic-image px-10 mx-auto my-6 flex object-contain sm:max-w-screen sm:max-h-screen"
+                />
+            </full-screen>
 
+            <div
+                v-if="config.images[0].caption"
+                class="text-center text-sm max-w-full graphic-caption"
+                v-html="md.render(config.images[0].caption)"
+            ></div>
+        </div>
+    </div>
+    <div class="flex" v-else>
         <div
-            v-if="config.caption"
-            class="text-center text-sm max-w-full graphic-caption"
-            v-html="md.render(config.caption)"
-        ></div>
+            ref="images"
+            class="carousel self-center px-10 my-8 mx-auto bg-gray-200_ h-28_"
+            :style="{ width: `${width}px` }"
+        >
+            <full-screen :expandable="config.fullscreen" :type="config.type">
+                <hooper ref="carousel" v-if="width !== -1" class="h-full bg-white" :infiniteScroll="config.loop">
+                    <slide v-for="(image, index) in config.images" :key="index" :index="index" class="self-center">
+                        <img
+                            :data-src="image.src"
+                            :src="slideIdx > 2 ? '' : image.src"
+                            :alt="image.altText || ''"
+                            :style="{ width: `${image.width}px`, height: `${image.height}px` }"
+                            class="m-auto story-graphic carousel-image"
+                        />
+                        <div
+                            v-if="image.caption"
+                            class="text-center my-8 text-sm"
+                            v-html="md.render(image.caption)"
+                        ></div>
+                    </slide>
+
+                    <hooper-navigation slot="hooper-addons"></hooper-navigation>
+                    <hooper-pagination slot="hooper-addons"></hooper-pagination>
+                </hooper>
+            </full-screen>
+
+            <div v-if="config.caption" class="text-center mt-5 text-sm" v-html="md.render(config.caption)"></div>
+        </div>
     </div>
 </template>
 
 <script lang="ts">
-import { ImagePanel } from '@/definitions';
 import { Component, Vue, Prop } from 'vue-property-decorator';
+import { Hooper, Slide, Navigation as HooperNavigation, Pagination as HooperPagination } from 'hooper';
+import 'hooper/dist/hooper.css';
 
 import MarkdownIt from 'markdown-it';
+
+import { ImagePanel } from '@/definitions';
 import FullscreenV from '@/components/panels/helpers/fullscreen.vue';
 
 @Component({
     components: {
-        'full-screen': FullscreenV
+        Hooper,
+        Slide,
+        'full-screen': FullscreenV,
+        HooperNavigation,
+        HooperPagination
     }
 })
-export default class ImagePanelV extends Vue {
+export default class SlideshowPanelV extends Vue {
     @Prop() config!: ImagePanel;
+    @Prop() configFileStructure!: any;
     @Prop() slideIdx!: number;
+
+    width = -1;
 
     md = new MarkdownIt({ html: true });
 
@@ -42,7 +85,13 @@ export default class ImagePanelV extends Vue {
             ? new IntersectionObserver(([image]) => {
                   // lazy load images
                   if (image.isIntersecting) {
-                      (this.$refs.img as Element).setAttribute('src', this.config.src);
+                      if (this.config.images.length === 1) {
+                          (this.$refs.img as Element).setAttribute('src', this.config.images[0].src);
+                      } else {
+                          (this.$refs.images as Element).querySelectorAll('.carousel-image').forEach((img) => {
+                              img.setAttribute('src', img.getAttribute('data-src')!);
+                          });
+                      }
                       this.$forceUpdate();
                       this.observer!.disconnect();
                   }
@@ -50,13 +99,87 @@ export default class ImagePanelV extends Vue {
             : undefined;
 
     mounted(): void {
-        this.observer?.observe(this.$refs.img as Element);
+        setTimeout(() => {
+            this.width = this.$el.clientWidth;
+        }, 100);
+
+        // obtain image files from ZIP folder in editor preview mode
+        if (this.configFileStructure) {
+            this.config.images.forEach((image) => {
+                const assetSrc = `${image.src.substring(image.src.indexOf('/') + 1)}`;
+                if (this.configFileStructure.zip.file(assetSrc)) {
+                    this.configFileStructure.zip
+                        .file(assetSrc)
+                        .async('blob')
+                        .then((res: any) => {
+                            image.src = URL.createObjectURL(res);
+                            this.$forceUpdate();
+                        });
+                }
+            });
+        }
+
+        if (this.config.images.length > 1) {
+            this.observer?.observe(this.$refs.images as Element);
+        } else if (this.config.images.length === 1) {
+            this.observer?.observe(this.$refs.img as Element);
+        }
     }
 }
 </script>
 
-<style lang="scss">
+<style lang="scss" scoped>
+.hooper {
+    height: auto;
+
+    ::v-deep .hooper-navigation svg {
+        overflow: visible;
+        padding-left: initial !important;
+        border-radius: 100%;
+        background: radial-gradient(white, transparent 75%);
+    }
+
+    ::v-deep .hooper-next {
+        right: calc(-32px - 2em);
+    }
+
+    ::v-deep .hooper-prev {
+        left: calc(-32px - 2em);
+    }
+
+    ::v-deep .hooper-pagination {
+        transform: translate(50%, 200%);
+    }
+
+    ::v-deep .hooper-indicator {
+        border: 1px solid #878787;
+
+        width: 24px;
+        height: 6px;
+        border-radius: 0px;
+
+        &.is-active {
+            border: none;
+            background-color: var(--sr-accent-colour);
+        }
+
+        &:hover {
+            background-color: white;
+            // background-color: lighten(#00d2d3, 20%);
+            border-color: var(--sr-accent-colour);
+        }
+    }
+}
+
 @media screen and (max-width: 640px) {
+    .carousel {
+        max-width: 100vw;
+        background-color: white;
+    }
+    .carousel-image {
+        max-height: 48vh;
+    }
+
     .graphic {
         max-width: 100vw;
         background-color: white;

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -28,6 +28,21 @@ export interface SeriesData {
     type?: string;
 }
 
+export interface PieSeriesData {
+    name: string;
+    data: PieDataRow[];
+}
+
+export interface PieDataRow {
+    name: string;
+    y?: number;
+}
+
+export interface LineSeriesData {
+    name: string;
+    data: number[];
+}
+
 export interface DQVChartConfig {
     chart: {
         type: string;
@@ -55,7 +70,9 @@ export interface DQVChartConfig {
     data?: {
         csvURL: string;
         enablePolling: boolean;
+        csv?: string;
     };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     plotOptions?: any;
     exporting?: {
         buttons: {
@@ -65,7 +82,7 @@ export interface DQVChartConfig {
         };
         enabled: boolean;
     };
-    series?: SeriesData[] | { data: SeriesData[] };
+    series?: PieSeriesData | LineSeriesData[];
 }
 
 export interface Intro {
@@ -74,7 +91,7 @@ export interface Intro {
         altText?: string;
     };
     title: string;
-    subtitle?: string;
+    subtitle: string;
     blurb?: string;
 }
 
@@ -102,21 +119,28 @@ export interface BasePanel {
     width?: number;
 }
 
-export interface TextPanel extends BasePanel {
+export interface TextPanel extends BasePanel, TextConfig {
     type: PanelType.Text;
+}
+
+export interface TextConfig {
     title: string;
-    titleTag: string;
+    titleTag?: string;
     content: string; // in md format
 }
 
-export interface MapPanel extends BasePanel {
+export interface MapPanel extends BasePanel, MapConfig {
     type: PanelType.Map;
+}
+
+export interface MapConfig {
     config: string;
     fullscreen?: boolean;
     timeSlider?: TimeSliderConfig;
     title: string;
     scrollguard: boolean;
 }
+
 export interface TimeSliderConfig {
     range: number[];
     start: number[];
@@ -127,7 +151,7 @@ export interface TimeSliderConfig {
 export interface DynamicPanel extends BasePanel {
     type: PanelType.Dynamic;
     title: string;
-    titleTag: string;
+    titleTag?: string;
     content: string;
     children: DynamicChildItem[];
 }
@@ -139,9 +163,17 @@ export interface DynamicChildItem {
 
 export interface ImagePanel extends BasePanel {
     type: PanelType.Image;
+    images: Array<ImageConfig>;
+    fullscreen?: boolean;
+    loop?: boolean;
+    caption?: string;
+}
+
+export interface ImageConfig {
     src: string;
     width?: number;
     height?: number;
+    temp?: string;
     class?: string;
     fullscreen?: boolean;
     altText?: string;
@@ -165,10 +197,15 @@ export interface AudioPanel extends BasePanel {
 
 export interface SlideshowPanel extends BasePanel {
     type: PanelType.Slideshow;
-    images: ImagePanel[];
+    items: Array<SlideshowItem>;
     fullscreen?: boolean;
     loop?: boolean;
     caption?: string;
+}
+
+export interface SlideshowItem {
+    type: string;
+    config: ImageConfig | ChartConfig | MapConfig | TextConfig;
 }
 
 export interface ChartPanel extends BasePanel {
@@ -179,7 +216,26 @@ export interface ChartPanel extends BasePanel {
 
 export interface ChartConfig {
     src: string;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     config?: any;
     name?: string;
     options?: DQVOptions;
+}
+
+export interface ImageFile {
+    id: string;
+    src: string;
+    altText: string;
+    caption?: string;
+    width?: number;
+    height?: number;
+}
+
+export interface DefaultConfigs {
+    text: TextPanel;
+    image: ImagePanel;
+    slideshow: SlideshowPanel;
+    chart: ChartPanel;
+    dynamic: DynamicPanel;
+    map: MapPanel;
 }


### PR DESCRIPTION
Closes #318.

You can now add a slideshow that supports all panel types (text, image, chart, map).

⚠️ Caution: This PR makes breaking changes to the current schema, so people should be comfortable with the design before this is merged. The details are in the files, but here are the changes that would be needed to migrate current products:

* For all the current slideshow panels, just change the type to image.
* For all the current image panels, add an images array and drop your single image config inside that array.

Essentially, the current image panels now support multiple images (similar to chart panels) and the slideshow panels support all panel types instead of just images.

Feel free to play around with creating, editing, viewing etc. slideshows and suggest changes to design, implementation, etc.