### PR TITLE
Fix CSV sourced charts in Vue 3

### DIFF
--- a/public/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000_en.json
+++ b/public/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000_en.json
@@ -71,7 +71,12 @@
                                         "src": "00000000-0000-0000-0000-000000000000/charts/en/chartConfig.json"
                                     },
                                     {
-                                        "src": "ea24000c-7dc3-49a9-baac-c55d28dcaeb9/charts/en/Ethlyene.glycol.release.trends.by.sector.2010-2019.tonnes.csv"
+                                        "src": "00000000-0000-0000-0000-000000000000/charts/en/1 Mount royal.csv",
+                                        "options": {
+                                            "title": "Selenium releases and disposals in 2019",
+                                            "subtitle": "",
+                                            "type": "pie"
+                                        }
                                     }
                                 ]
                             }
@@ -461,8 +466,37 @@
                             "src": "00000000-0000-0000-0000-000000000000/charts/en/chartConfig.json"
                         },
                         {
-                            "src": "00000000-0000-0000-0000-000000000000/charts/en/csvUrlChart.json"
+                            "src": "00000000-0000-0000-0000-000000000000/charts/en/Total releases of ethylene glycol for 2019, by province_en.csv",
+                            "options": {
+                                "title": "Figure 2: Total releases of ethylene glycol for 2019, by province",
+                                "xAxisLabel": "Quantity (tonnes)",
+                                "subtitle": "",
+                                "type": "bar"
+                            }
                         },
+                        {
+                            "src": "00000000-0000-0000-0000-000000000000/charts/en/EG_releases_2019_en.csv",
+                            "options": {
+                                "title": "Figure 1: Percentage of total ethylene glycol releases for 2019, by sector",
+                                "subtitle": "",
+                                "type": "pie"
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "title": "Hybrid chart with bar and line",
+            "panel": [
+                {
+                    "title": "Hybrid chart with bar and line",
+                    "content": "Demo of a hybrid chart consisting of both a bar and line chart using a custom configured highcharts json file.",
+                    "type": "text"
+                },
+                {
+                    "type": "chart",
+                    "charts": [
                         {
                             "src": "00000000-0000-0000-0000-000000000000/charts/en/hybridChartConfig.json"
                         }

--- a/public/00000000-0000-0000-0000-000000000000/charts/en/1 Mount royal.csv
+++ b/public/00000000-0000-0000-0000-000000000000/charts/en/1 Mount royal.csv
@@ -1,0 +1,10 @@
+Cardinal River Operations Direct Discharges,504,1.61%
+Cardinal River Operations Tailings Management,2066,6.61%
+Elkview Operations Tailings Management,5798,18.54%
+Fording River Operations Direct Discharges,3860,12.34%
+Fording River Operations Tailings Management,9114,29.14%
+Greenhills Operations Direct Discharges,700,2.24%
+Greenhills Operations Tailings Management,2066,6.61%
+Line Creek Operations Direct Discharges,1222,3.91%
+Line Creek Operations Tailings Management,4487,14.35%
+

--- a/public/00000000-0000-0000-0000-000000000000/charts/en/EG_releases_2019_en.csv
+++ b/public/00000000-0000-0000-0000-000000000000/charts/en/EG_releases_2019_en.csv
@@ -1,0 +1,3 @@
+Airports and Services to Airports,94%
+Oil and Gas (Conventional and Non-Conventional),2%
+All Other Sectors,4%

--- a/public/00000000-0000-0000-0000-000000000000/charts/en/Total releases of ethylene glycol for 2019, by province_en.csv
+++ b/public/00000000-0000-0000-0000-000000000000/charts/en/Total releases of ethylene glycol for 2019, by province_en.csv
@@ -1,0 +1,11 @@
+Province,Quantity
+Prince Edward Island,0.08
+New Brunswick,3
+Quebec,88
+Nova Scotia,230
+Saskatchewan,367
+Manitoba,403
+Newfoundland and Labrador,432
+British Columbia,649
+Alberta,3073
+Ontario,10828

--- a/src/components/panels/helpers/chart.vue
+++ b/src/components/panels/helpers/chart.vue
@@ -14,7 +14,7 @@
 
 <script setup lang="ts">
 import type { PropType } from 'vue';
-import { getCurrentInstance, onMounted, ref } from 'vue';
+import { inject, onMounted, ref } from 'vue';
 import {
     ChartConfig,
     ConfigFileStructure,
@@ -70,6 +70,9 @@ const menuOptions = [
     'downloadCSV',
     'downloadXLS'
 ];
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const $papa: any = inject('$papa');
 
 onMounted(() => {
     const isMobile = el.value.clientWidth <= 640;
@@ -194,7 +197,7 @@ const parseCSVFile = (data: CSVFile): void => {
     };
 
     // download: true needed for local files which is treated as an URL
-    getCurrentInstance()?.proxy?.$papa.parse(data.url ? data.url : data, {
+    $papa.parse(data.url ? data.url : data, {
         header: dqvOptions?.type === 'pie' ? false : true,
         dynamicTyping: true,
         download: !!data.url,

--- a/src/components/panels/helpers/time-slider/time-slider.vue
+++ b/src/components/panels/helpers/time-slider/time-slider.vue
@@ -84,7 +84,6 @@ const range = ref<string[]>(['', '']);
 const intervalID = ref(-1);
 
 onMounted(() => {
-    console.log(props);
     sliderElement.value = sliderTarget.value as HTMLElement;
     slider.value = noUiSlider.create(sliderElement.value, {
         start: props.config.start,

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,4 +25,6 @@ app.use(router)
     .use(VuePapaParse)
     .use(VueFullscreen);
 
+app.provide('$papa', app.config.globalProperties.$papa);
+
 app.mount('#app');


### PR DESCRIPTION
Fixes access to Vue Papa Parse library in composition API by using provide/inject. Added a few CSV sourced charts for testing on the demo page.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/393)
<!-- Reviewable:end -->
