### PR TITLE
Text hidden behind ToC

### DIFF
--- a/src/components/story/chapter-menu.vue
+++ b/src/components/story/chapter-menu.vue
@@ -30,7 +30,7 @@
                     <path d="m3.5 17h17" />
                 </svg>
                 <span
-                    class="flex-1 pl-2 ml-2 overflow-hidden leading-normal text-left overflow-ellipsis whitespace-nowrap"
+                    class="flex-1 ml-4 overflow-hidden leading-normal text-left overflow-ellipsis whitespace-nowrap"
                     >{{ $t('chapters.title') }}</span
                 >
             </button>


### PR DESCRIPTION
For #395 

**Changes**
- CSS changes to ensure `chapters.title` hides behind ToC correctly, it was showing a bit before

**Notes**
Before changes:
![toc before](https://github.com/ramp4-pcar4/story-ramp/assets/83516523/32eae9a0-5874-4790-846b-05861d229206)

After changes:
![toc hidden](https://github.com/ramp4-pcar4/story-ramp/assets/83516523/2fb48866-4822-4bd8-a77f-0e5117ef88da)
![toc hidden fr](https://github.com/ramp4-pcar4/story-ramp/assets/83516523/7a8b5c0e-d142-4221-8708-bc0d08ce0f75)

**Testing**
1. Close the expanded Table of Contents. 
2. Ensure that there is no text peeking out.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/397)
<!-- Reviewable:end -->
