### PR TITLE
Rename and publish NPM package

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ To use the Storylines plugin in your Vue 3 project, follow these steps:
 **1. Install package from npm:**
 
 ```
-npm install ramp-storylines
+npm install ramp-storylines_demo-scenarios-pcar
 ```
 
 **2. Install the plugin in your Vue app:**
@@ -19,15 +19,15 @@ import { createApp } from 'vue';
 import App from './app.vue';
 const app = createApp(App);
 
-import StorylinesViewer from 'ramp-storylines'
+import StorylinesViewer from 'ramp-storylines_demo-scenarios-pcar'
 app.use(StorylinesViewer);
-import 'ramp-storylines/dist/storylines-viewer.css';
+import 'ramp-storylines_demo-scenarios-pcar/dist/storylines-viewer.css';
 ```
 
 **3. Import or merge `i18n` instance from the plugin:**
 
 ```
-import { storylinesI18n } from 'ramp-storylines'
+import { storylinesI18n } from 'ramp-storylines_demo-scenarios-pcar'
 // if there is no existing i18n instance in your app, add Storylines i18n when initializing Vue instance:
 app.use(storylinesI18n);
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-    "name": "ramp-storylines",
+    "name": "ramp-storylines_demo-scenarios-pcar",
     "description": "A user-configurable story product featuring interactive maps, charts and dynamic multimedia content alongside text.",
-    "version": "3.0.5",
+    "version": "3.1.0",
     "private": false,
     "license": "MIT",
     "repository": "https://github.com/ramp4-pcar4/story-ramp",


### PR DESCRIPTION
### Changes
Renames NPM package name and published here: https://www.npmjs.com/package/ramp-storylines_demo-scenarios-pcar 

There was no dedicated method for NPM renaming, so had to deprecate the old package as a workaround: 
https://www.npmjs.com/package/ramp-storylines

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/414)
<!-- Reviewable:end -->
