### PR TITLE
add support for transitional background images

### DIFF
--- a/StoryRampSchema.json
+++ b/StoryRampSchema.json
@@ -15,6 +15,10 @@
                 },
                 "panel": {
                     "$ref": "#/$defs/panel"
+                },
+                "backgroundImage": {
+                    "type": "string",
+                    "description": "An image to display in the background of the slide."
                 }
             },
             "required": ["title", "panel"]
@@ -70,6 +74,11 @@
                 "type": {
                     "type": "string",
                     "enum": ["text"]
+                },
+                "textColour": {
+                    "type": "string",
+                    "description": "The colour of the text. Defaults to black.",
+                    "default": "#000000"
                 }
             },
             "required": ["content", "type", "title"]
@@ -103,6 +112,11 @@
                 "type": {
                     "type": "string",
                     "enum": ["dynamic"]
+                },
+                "textColour": {
+                    "type": "string",
+                    "description": "The colour of the text. Defaults to black.",
+                    "default": "#000000"
                 }
             },
             "required": ["content", "type", "children", "title"]

--- a/public/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000_en.json
+++ b/public/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000_en.json
@@ -11,6 +11,7 @@
     "slides": [
         {
             "title": "Overview",
+            "backgroundImage": "00000000-0000-0000-0000-000000000000/assets/en/GettyImages-516166467__1554821531978__w1920.jpg",
             "panel": [
                 {
                     "title": "Overview",
@@ -26,6 +27,7 @@
         },
         {
             "title": "Default RAMP4 Sample",
+            "backgroundImage": "00000000-0000-0000-0000-000000000000/assets/en/GettyImages-187242601__1554821467033__w1920.jpg",
             "panel": [
                 {
                     "config": "00000000-0000-0000-0000-000000000000/ramp-config/test-ramp4.json",
@@ -41,6 +43,7 @@
         },
         {
             "title": "Dynamic Panel Test",
+            "backgroundImage": "00000000-0000-0000-0000-000000000000/assets/en/GettyImages-516166467__1554821531978__w1920.jpg",
             "panel": [
                 {
                     "title": "This Slide Is Dynamic!",
@@ -127,6 +130,8 @@
         },
         {
             "title": "Video Panel",
+            "backgroundImage": "00000000-0000-0000-0000-000000000000/assets/en/GettyImages-516166467__1554821531978__w1920.jpg",
+
             "panel": [
                 {
                     "title": "Video Test for YoutTube content",
@@ -174,6 +179,8 @@
         },
         {
             "title": "In-situ extraction",
+            "backgroundImage": "00000000-0000-0000-0000-000000000000/assets/en/GettyImages-187242601__1554821467033__w1920.jpg",
+
             "panel": [
                 {
                     "title": "In-situ extraction",
@@ -203,6 +210,7 @@
         },
         {
             "title": "NPRI substances reported for oil sands mining facilities",
+            "backgroundImage": "00000000-0000-0000-0000-000000000000/assets/en/GettyImages-516166467__1554821531978__w1920.jpg",
             "panel": [
                 {
                     "title": "NPRI substances reported for oil sands mining facilities",

--- a/src/components/panels/dynamic-panel.vue
+++ b/src/components/panels/dynamic-panel.vue
@@ -1,6 +1,10 @@
 <template>
     <div ref="el" :id="key" class="story-slide w-full h-full flex sm:flex-row flex-col">
-        <VueScrollama class="flex-1 order-2 sm:order-1 prose max-w-none my-5">
+        <VueScrollama
+            class="flex-1 order-2 sm:order-1 prose max-w-none my-5 mx-1 py-5"
+            :class="{ 'has-background': background }"
+            :style="{ color: config.textColour ?? '#000' }"
+        >
             <component
                 :is="config.titleTag || 'h2'"
                 class="px-10 mb-0 chapter-title top-20"
@@ -36,6 +40,7 @@
                 :slideIdx="slideIdx"
                 :dynamicIdx="activeIdx"
                 :ratio="false"
+                :background="background"
                 ref="content"
             >
             </panel>
@@ -60,6 +65,9 @@ const props = defineProps({
     },
     slideIdx: {
         type: Number
+    },
+    background: {
+        type: Boolean
     }
 });
 
@@ -173,6 +181,10 @@ const clickBack = (): void => {
 }
 .return-button img {
     margin: 0px;
+}
+.has-background {
+    background-color: rgba(255, 255, 255, 0.6);
+    border-radius: 20px;
 }
 
 @media screen and (max-width: 640px) {

--- a/src/components/panels/image-panel.vue
+++ b/src/components/panels/image-panel.vue
@@ -7,7 +7,7 @@
                 :class="config.class"
                 :alt="config.altText || ''"
                 :style="{ width: `${config.width}px`, height: `${config.height}px` }"
-                class="graphic-image px-10 mx-auto my-6 flex object-contain sm:max-w-screen sm:max-h-screen"
+                class="graphic-image px-10 mx-auto flex object-contain sm:max-w-screen sm:max-h-screen"
             />
         </fullscreen>
 
@@ -15,6 +15,7 @@
             v-if="config.caption"
             class="text-center text-sm max-w-full graphic-caption"
             v-html="md.render(config.caption)"
+            :class="{ 'has-background': background }"
         ></div>
     </div>
 </template>
@@ -38,6 +39,9 @@ const props = defineProps({
     slideIdx: {
         type: Number,
         default: 0
+    },
+    background: {
+        type: Boolean
     }
 });
 
@@ -76,7 +80,12 @@ onMounted((): void => {
 });
 </script>
 
-<style lang="scss">
+<style lang="scss" scoped>
+.has-background {
+    background-color: rgba(255, 255, 255, 1);
+    border-radius: 0px 0px 20px 20px;
+    color: black;
+}
 @media screen and (max-width: 640px) {
     .graphic {
         max-width: 100vw;

--- a/src/components/panels/map-panel.vue
+++ b/src/components/panels/map-panel.vue
@@ -1,6 +1,10 @@
 <template>
     <div ref="el" class="flex flex-col h-full align-middle w-full">
-        <div class="px-10 mb-0 chapter-title top-20 map-title text-center" v-if="config.title">
+        <div
+            class="px-10 mb-0 chapter-title top-20 map-title text-center"
+            :class="{ 'has-background': background }"
+            v-if="config.title"
+        >
             {{ config.title }}
         </div>
         <div :id="`ramp-map-${slideIdx}`" class="w-full bg-gray-200 h-story rv-map"></div>
@@ -29,6 +33,9 @@ const props = defineProps({
     },
     configFileStructure: {
         type: Object as PropType<ConfigFileStructure>
+    },
+    background: {
+        type: Boolean
     }
 });
 
@@ -117,6 +124,13 @@ const init = async () => {
 .rv-map-title {
     height: calc(100vh - 9rem) !important;
     width: 100%;
+}
+
+.has-background {
+    background-color: rgba(255, 255, 255, 0.6);
+    margin-bottom: 0em !important;
+    padding-bottom: 1em;
+    color: black;
 }
 
 .map-title {

--- a/src/components/panels/panel.vue
+++ b/src/components/panels/panel.vue
@@ -17,6 +17,7 @@
             :slideIdx="slideIdx"
             :lang="lang"
             :style="config.customStyles"
+            :background="background"
         ></component>
     </div>
 </template>
@@ -51,6 +52,9 @@ const props = defineProps({
     },
     lang: {
         type: String
+    },
+    background: {
+        type: Boolean
     }
 });
 

--- a/src/components/panels/slideshow-panel.vue
+++ b/src/components/panels/slideshow-panel.vue
@@ -43,7 +43,12 @@
                     </template>
                 </carousel>
 
-                <div v-if="config.caption" class="text-center mt-5 text-sm" v-html="md.render(config.caption)"></div>
+                <div
+                    v-if="config.caption"
+                    class="text-center mt-5 text-sm"
+                    :class="{ 'has-background': background }"
+                    v-html="md.render(config.caption)"
+                ></div>
             </div>
         </div>
     </div>
@@ -73,6 +78,9 @@ const props = defineProps({
     slideIdx: {
         type: Number,
         required: true
+    },
+    background: {
+        type: Boolean
     }
 });
 
@@ -91,6 +99,14 @@ window.addEventListener('resize', () => {
 </script>
 
 <style lang="scss" scoped>
+.has-background {
+    background-color: rgba(255, 255, 255, 1);
+    border-radius: 0px 0px 20px 20px;
+    color: black;
+    margin-top: 0px !important;
+    padding-top: 5px;
+}
+
 .carousel {
     height: auto;
     text-align: left;

--- a/src/components/panels/text-panel.vue
+++ b/src/components/panels/text-panel.vue
@@ -1,5 +1,9 @@
 <template>
-    <VueScrollama class="prose max-w-none my-5">
+    <VueScrollama
+        class="prose max-w-none my-5 mx-1 py-5"
+        :class="{ 'has-background': background }"
+        :style="{ color: config.textColour ?? '#000' }"
+    >
         <component :is="config.titleTag || 'h2'" class="px-10 mb-0 chapter-title top-20">
             {{ config.title }}
         </component>
@@ -20,6 +24,9 @@ const props = defineProps({
     config: {
         type: Object as PropType<TextPanel>,
         required: true
+    },
+    background: {
+        type: Boolean
     }
 });
 
@@ -39,6 +46,11 @@ onMounted((): void => {
 </script>
 
 <style scoped lang="scss">
+.has-background {
+    background-color: rgba(255, 255, 255, 0.6);
+    border-radius: 20px;
+}
+
 @media screen and (max-width: 640px) {
     .chapter-title {
         max-width: 100vw;

--- a/src/components/story/background-image.vue
+++ b/src/components/story/background-image.vue
@@ -1,0 +1,85 @@
+<template>
+    <div class="sticky z-10 grid-background" style="top: 60px; height: 100vh">
+        <!-- Vue3 transition for switching between a slide with no background a slide with a background. -->
+        <Transition name="fade" mode="out-in">
+            <div v-if="newImage !== 'none'" class="w-full h-full">
+                <img v-if="oldImage !== 'none'" class="fade-in w-full h-full" :src="oldImage" />
+                <img class="fade-in w-full h-full" :class="{ hide: activeImage === 1 }" :src="newImage" />
+            </div>
+            <div class="w-full h-full" v-else></div>
+        </Transition>
+    </div>
+</template>
+
+<script setup>
+import { watch, ref } from 'vue';
+
+const emit = defineEmits(['background-changed']);
+const props = defineProps({
+    src: {
+        type: String,
+        required: true
+    }
+});
+
+const oldImage = ref('none');
+const newImage = ref('none');
+const activeImage = ref(0);
+
+watch(
+    () => props.src,
+    () => {
+        // Here's how the fancy crossfade works. We have a primary image element and a secondary image element.
+        // The primary element is what's displaying the current slide background, and the secondary element is only used
+        // DURING a transition period.
+
+        // When a new slide comes into view with a background applied, we display this background on the secondary component
+        // whilst gradually transitioning the opacity of the primary element to 0 (triggers when `activeImage` is 1). This gives
+        // us the effect of the new background smoothly coming in. Once the opacity hits 0, we move the new background image
+        // to the primary element and set the opacity back to 1.
+
+        oldImage.value = props.src;
+        activeImage.value = 1;
+
+        // This is the crossfade case where we're switching between two background images.
+        if (props.src !== 'none' && newImage.value !== 'none') {
+            setTimeout(() => {
+                activeImage.value = 0;
+                oldImage.value = newImage.value;
+                newImage.value = props.src;
+                emit('background-changed', true);
+            }, 350); // timeout length is set to animation time (0.3s) plus a little bit of buffer.
+        } else {
+            // Not a crossfade case. We're either transitioning from nothing into an image or from an image into nothing.
+            // This case uses Vue3 transitions.
+            newImage.value = props.src;
+            activeImage.value = 0;
+
+            emit('background-changed', newImage.value !== 'none');
+        }
+    },
+    { immediate: false }
+);
+</script>
+
+<style scoped>
+.hide {
+    opacity: 0 !important;
+    transition: opacity 0.3s linear;
+}
+
+img {
+    position: absolute;
+    opacity: 1;
+}
+
+.fade-enter-active,
+.fade-leave-active {
+    transition: opacity 0.2s ease-in;
+}
+
+.fade-enter-from,
+.fade-leave-to {
+    opacity: 0;
+}
+</style>

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -117,6 +117,7 @@ export interface Slide {
     // tuple definition to restrict array size
     // panel: [BasePanel, BasePanel | undefined];
     panel: BasePanel[];
+    backgroundImage: string;
 }
 
 export enum PanelType {
@@ -142,6 +143,7 @@ export interface TextPanel extends BasePanel {
     title: string;
     titleTag: string;
     content: string; // in md format
+    textColour: string;
 }
 
 export interface MapPanel extends BasePanel {
@@ -165,6 +167,7 @@ export interface DynamicPanel extends BasePanel {
     titleTag: string;
     content: string;
     children: DynamicChildItem[];
+    textColour: string;
 }
 
 export interface DynamicChildItem {


### PR DESCRIPTION
### Related Item(s)
#401 

### Changes
- Adds support for transitional background images. The configuration flag is `backgroundImage` and takes a path to an image. 
- When a background is active, text components (text slides, captions, titles, etc.) will be placed in a semi-transparent container to keep an accessible contrast.

### Testing
Steps:
1. Open the sample page and scroll down.
2. Ensure that contrast is OK for text, captions, titles, etc.
3. Ensure that everything is working well on mobile.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/417)
<!-- Reviewable:end -->
