### PR TITLE
fix map configuration loading logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ramp-storylines_demo-scenarios-pcar",
     "description": "A user-configurable story product featuring interactive maps, charts and dynamic multimedia content alongside text.",
-    "version": "3.1.3",
+    "version": "3.1.5",
     "private": false,
     "license": "MIT",
     "repository": "https://github.com/ramp4-pcar4/story-ramp",

--- a/src/components/panels/helpers/chart.vue
+++ b/src/components/panels/helpers/chart.vue
@@ -99,7 +99,7 @@ onMounted(() => {
         downloadXLS: t('chart.downloadXLS'),
         viewData: t('chart.viewData')
     };
-    if ((route.params.lang as string) === 'fr') {
+    if ((route && (route.params.lang as string)) === 'fr') {
         Highcharts.setOptions({
             lang: frMenuLabels
         });


### PR DESCRIPTION
### Related Item(s)
There was no issue posted, but maps were not displaying in the editor preview.

### Changes
- If the `configFileStructure` prop is provided, the panel will grab the map config from the ZIP file instead of attempting to fetch it. 
- If the prop is not provided, it will be fetched as usual.
- Also fixes a bug with charts in the editor.

### Testing
Steps:
1. Open the sample link and ensure that everything still works as expected.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/430)
<!-- Reviewable:end -->
