### PR TITLE
update 'scroll to top' svg; fix tooltip placement

### DIFF
--- a/src/components/story/chapter-menu.vue
+++ b/src/components/story/chapter-menu.vue
@@ -46,23 +46,43 @@
                         placement: 'right',
                         content: $t('chapters.return'),
                         animateFill: true,
-                        animation: 'chapter-menu',
-                        offset: isMenuOpen ? [0, -280] : [0, -40]
+                        animation: 'chapter-menu'
                     }"
                     v-if="plugin"
                 >
                     <svg
                         class="flex-shrink-0"
-                        width="24"
-                        height="24"
                         viewBox="0 0 24 24"
-                        xmlns="http://www.w3.org/2000/svg"
+                        width="24px"
+                        height="24px"
                         fill="#fff"
                         stroke="#878787"
+                        xmlns="http://www.w3.org/2000/svg"
                     >
                         <path
+                            data-v-689fab2c=""
                             d="m19.325 16.229c-2.4415 1.4096-4.8829 2.8191-7.3244 4.2286-2.4415-1.4096-4.883-2.8192-7.3245-4.2288-3.55e-5 -2.8191-7.1e-5 -5.6383-1.066e-4 -8.4574 2.4415-1.4096 4.8829-2.8191 7.3244-4.2286 2.4415 1.4096 4.883 2.8192 7.3245 4.2288 3.7e-5 2.8191 7.4e-5 5.6383 1.1e-4 8.4574z"
                             stroke-width=".93974"
+                            style="fill: rgba(255, 255, 255, 0); fill-opacity: 0"
+                            transform="matrix(1, 0, 0, 1, 8.881784197001252e-16, 0)"
+                        />
+                        <g transform="matrix(1, 0, 0, 1, 0.07912001013755887, 1.1142139434814453)">
+                            <polygon
+                                points="11.956 9.662 9.522 12.097 9.862 12.437 11.956 10.344 14.049 12.437 14.39 12.097"
+                                style=""
+                            />
+                            <path
+                                style="fill: rgb(135, 135, 135); stroke-width: 1.5px"
+                                d="M 11.917 10.545 L 11.917 15.649"
+                            />
+                        </g>
+                        <rect
+                            x="9.114"
+                            y="8.74"
+                            width="5.842"
+                            height="0.487"
+                            style=""
+                            transform="matrix(1, 0, 0, 1, 8.881784197001252e-16, 0)"
                         />
                     </svg>
                     <span class="flex-1 ml-4 overflow-hidden leading-normal overflow-ellipsis whitespace-nowrap">{{
@@ -79,23 +99,43 @@
                         placement: 'right',
                         content: $t('chapters.return'),
                         animateFill: true,
-                        animation: 'chapter-menu',
-                        offset: isMenuOpen ? [0, -280] : [0, -40]
+                        animation: 'chapter-menu'
                     }"
                     v-else
                 >
                     <svg
                         class="flex-shrink-0"
-                        width="24"
-                        height="24"
                         viewBox="0 0 24 24"
-                        xmlns="http://www.w3.org/2000/svg"
+                        width="24px"
+                        height="24px"
                         fill="#fff"
                         stroke="#878787"
+                        xmlns="http://www.w3.org/2000/svg"
                     >
                         <path
+                            data-v-689fab2c=""
                             d="m19.325 16.229c-2.4415 1.4096-4.8829 2.8191-7.3244 4.2286-2.4415-1.4096-4.883-2.8192-7.3245-4.2288-3.55e-5 -2.8191-7.1e-5 -5.6383-1.066e-4 -8.4574 2.4415-1.4096 4.8829-2.8191 7.3244-4.2286 2.4415 1.4096 4.883 2.8192 7.3245 4.2288 3.7e-5 2.8191 7.4e-5 5.6383 1.1e-4 8.4574z"
                             stroke-width=".93974"
+                            style="fill: rgba(255, 255, 255, 0); fill-opacity: 0"
+                            transform="matrix(1, 0, 0, 1, 8.881784197001252e-16, 0)"
+                        />
+                        <g transform="matrix(1, 0, 0, 1, 0.07912001013755887, 1.1142139434814453)">
+                            <polygon
+                                points="11.956 9.662 9.522 12.097 9.862 12.437 11.956 10.344 14.049 12.437 14.39 12.097"
+                                style=""
+                            />
+                            <path
+                                style="fill: rgb(135, 135, 135); stroke-width: 1.5px"
+                                d="M 11.917 10.545 L 11.917 15.649"
+                            />
+                        </g>
+                        <rect
+                            x="9.114"
+                            y="8.74"
+                            width="5.842"
+                            height="0.487"
+                            style=""
+                            transform="matrix(1, 0, 0, 1, 8.881784197001252e-16, 0)"
                         />
                     </svg>
                     <span class="flex-1 ml-4 overflow-hidden leading-normal overflow-ellipsis whitespace-nowrap">{{
@@ -113,8 +153,7 @@
                         placement: 'right',
                         content: slide.title,
                         animateFill: true,
-                        animation: 'chapter-menu',
-                        offset: isMenuOpen ? [0, -280] : [0, -40]
+                        animation: 'chapter-menu'
                     }"
                     v-if="plugin"
                 >
@@ -146,8 +185,7 @@
                         placement: 'right',
                         content: slide.title,
                         animateFill: true,
-                        animation: 'chapter-menu',
-                        offset: isMenuOpen ? [0, -280] : [0, -40]
+                        animation: 'chapter-menu'
                     }"
                     v-else
                 >

--- a/src/components/story/mobile-menu.vue
+++ b/src/components/story/mobile-menu.vue
@@ -40,16 +40,37 @@
                 <button class="flex py-1 px-3" @click="scrollToChapter('intro')" v-if="plugin">
                     <svg
                         class="flex-shrink-0"
-                        width="24"
-                        height="24"
                         viewBox="0 0 24 24"
-                        xmlns="http://www.w3.org/2000/svg"
+                        width="24px"
+                        height="24px"
                         fill="#fff"
                         stroke="#878787"
+                        xmlns="http://www.w3.org/2000/svg"
                     >
                         <path
+                            data-v-689fab2c=""
                             d="m19.325 16.229c-2.4415 1.4096-4.8829 2.8191-7.3244 4.2286-2.4415-1.4096-4.883-2.8192-7.3245-4.2288-3.55e-5 -2.8191-7.1e-5 -5.6383-1.066e-4 -8.4574 2.4415-1.4096 4.8829-2.8191 7.3244-4.2286 2.4415 1.4096 4.883 2.8192 7.3245 4.2288 3.7e-5 2.8191 7.4e-5 5.6383 1.1e-4 8.4574z"
                             stroke-width=".93974"
+                            style="fill: rgba(255, 255, 255, 0); fill-opacity: 0"
+                            transform="matrix(1, 0, 0, 1, 8.881784197001252e-16, 0)"
+                        />
+                        <g transform="matrix(1, 0, 0, 1, 0.07912001013755887, 1.1142139434814453)">
+                            <polygon
+                                points="11.956 9.662 9.522 12.097 9.862 12.437 11.956 10.344 14.049 12.437 14.39 12.097"
+                                style=""
+                            />
+                            <path
+                                style="fill: rgb(135, 135, 135); stroke-width: 1.5px"
+                                d="M 11.917 10.545 L 11.917 15.649"
+                            />
+                        </g>
+                        <rect
+                            x="9.114"
+                            y="8.74"
+                            width="5.842"
+                            height="0.487"
+                            style=""
+                            transform="matrix(1, 0, 0, 1, 8.881784197001252e-16, 0)"
                         />
                     </svg>
                     <span class="flex-1 ml-4 overflow-hidden leading-normal overflow-ellipsis whitespace-nowrap">{{
@@ -60,16 +81,37 @@
                 <router-link :to="{ hash: '#intro' }" class="flex py-1 px-3" target v-else>
                     <svg
                         class="flex-shrink-0"
-                        width="24"
-                        height="24"
                         viewBox="0 0 24 24"
-                        xmlns="http://www.w3.org/2000/svg"
+                        width="24px"
+                        height="24px"
                         fill="#fff"
                         stroke="#878787"
+                        xmlns="http://www.w3.org/2000/svg"
                     >
                         <path
+                            data-v-689fab2c=""
                             d="m19.325 16.229c-2.4415 1.4096-4.8829 2.8191-7.3244 4.2286-2.4415-1.4096-4.883-2.8192-7.3245-4.2288-3.55e-5 -2.8191-7.1e-5 -5.6383-1.066e-4 -8.4574 2.4415-1.4096 4.8829-2.8191 7.3244-4.2286 2.4415 1.4096 4.883 2.8192 7.3245 4.2288 3.7e-5 2.8191 7.4e-5 5.6383 1.1e-4 8.4574z"
                             stroke-width=".93974"
+                            style="fill: rgba(255, 255, 255, 0); fill-opacity: 0"
+                            transform="matrix(1, 0, 0, 1, 8.881784197001252e-16, 0)"
+                        />
+                        <g transform="matrix(1, 0, 0, 1, 0.07912001013755887, 1.1142139434814453)">
+                            <polygon
+                                points="11.956 9.662 9.522 12.097 9.862 12.437 11.956 10.344 14.049 12.437 14.39 12.097"
+                                style=""
+                            />
+                            <path
+                                style="fill: rgb(135, 135, 135); stroke-width: 1.5px"
+                                d="M 11.917 10.545 L 11.917 15.649"
+                            />
+                        </g>
+                        <rect
+                            x="9.114"
+                            y="8.74"
+                            width="5.842"
+                            height="0.487"
+                            style=""
+                            transform="matrix(1, 0, 0, 1, 8.881784197001252e-16, 0)"
                         />
                     </svg>
                     <span class="flex-1 ml-4 overflow-hidden leading-normal overflow-ellipsis whitespace-nowrap">{{


### PR DESCRIPTION
### Related Item(s)
#371, #421

### Changes
- This PR changes the "Scroll to Top" button to be more distinct from the other chapter hexagons in the navigation bar.
- This PR also updates the positioning of tooltips so as not to cover the hexagons/chapter titles.

### Notes
The new scroll to top button. Let me know if I should make any modifications!
![image](https://github.com/ramp4-pcar4/story-ramp/assets/25874602/e6c4e201-6129-40db-89cb-9e9110b802e8)


### Testing
Steps:
1. Open the demo page.
2. Ensure that the new icon is appearing correctly.
3. Ensure that tooltips are appearing properly and no longer cover the hexagon or chapter title.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/437)
<!-- Reviewable:end -->
