### PR TITLE
fix images not displaying in preview mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ramp-storylines_demo-scenarios-pcar",
     "description": "A user-configurable story product featuring interactive maps, charts and dynamic multimedia content alongside text.",
-    "version": "3.1.5",
+    "version": "3.1.6",
     "private": false,
     "license": "MIT",
     "repository": "https://github.com/ramp4-pcar4/story-ramp",

--- a/src/components/panels/dynamic-panel.vue
+++ b/src/components/panels/dynamic-panel.vue
@@ -37,6 +37,7 @@
             <panel
                 class="flex-2"
                 :config="activeConfig"
+                :configFileStructure="configFileStructure"
                 :slideIdx="slideIdx"
                 :dynamicIdx="activeIdx"
                 :ratio="false"
@@ -54,7 +55,7 @@ import { defineAsyncComponent, getCurrentInstance, onMounted, ref } from 'vue';
 import VueScrollama from 'vue3-scrollama';
 import MarkdownIt from 'markdown-it';
 
-import { BasePanel, DynamicPanel } from '@storylines/definitions';
+import { BasePanel, ConfigFileStructure, DynamicPanel } from '@storylines/definitions';
 
 const panel = defineAsyncComponent(() => import('./panel.vue'));
 
@@ -62,6 +63,9 @@ const props = defineProps({
     config: {
         type: Object as PropType<DynamicPanel>,
         required: true
+    },
+    configFileStructure: {
+        type: Object as PropType<ConfigFileStructure>
     },
     slideIdx: {
         type: Number


### PR DESCRIPTION
### Related Item(s)
#432 

### Changes
- This PR fixes an issue where images were not appearing correctly in preview mode.

### Testing
This is intended to fix an issue in the editor preview, so it won't be noticeable on the Storylines demo page. Just ensure that existing images are appearing as they were before.

Steps once we update the npm package in the editor repo:
1. Open the demo page.
2. Load a project and create a new image panel. Add an image and click the 'Preview' button in the top right.
3. Ensure that the image is displaying correctly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/439)
<!-- Reviewable:end -->
