### PR TITLE
remove unnecessary whitespace above maps in slideshow panels

### DIFF
--- a/src/components/panels/slideshow-panel.vue
+++ b/src/components/panels/slideshow-panel.vue
@@ -170,6 +170,7 @@ window.addEventListener('resize', () => {
 }
 .carousel-item {
     height: 80vh;
+    top: 0px;
 }
 
 @media screen and (max-width: 640px) {


### PR DESCRIPTION
### Related Item(s)
#433 

### Changes
- This PR removes the whitespace above maps in slideshow panels. Maps should no longer be cut-off.

### Testing
Steps:
1. Open a product that has a slideshow with a map in it.
2. Ensure that no whitespace appears above the map and that it isn't cut off.
