### PR TITLE
remove large amount of whitespace below charts in slideshow panel

### DIFF
--- a/src/components/panels/slideshow-panel.vue
+++ b/src/components/panels/slideshow-panel.vue
@@ -169,7 +169,9 @@ window.addEventListener('resize', () => {
     }
 }
 .carousel-item {
-    height: 80vh;
+    // Max height of the carousel is 80vh, but set height to 100% to items appear in the center of the container.
+    height: 100%;
+    max-height: 80vh;
     top: 0px;
 }
 


### PR DESCRIPTION
### Related Item(s)
https://github.com/ramp4-pcar4/storylines-editor/issues/335

### Changes
- Removes unnecessary whitespace below charts in slideshow panels.

### Testing
Steps:
1. Open the demo page.
2. Jump to the section titled `Chart Gallery` in the table of contents.
3. Ensure that there is no whitespace below the charts.
4. Ensure other slideshows are still displaying correctly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/448)
<!-- Reviewable:end -->
