### PR TITLE
fix styling issues in preview mode

### DIFF
--- a/src/components/story/horizontal-menu.vue
+++ b/src/components/story/horizontal-menu.vue
@@ -3,7 +3,7 @@
         <ul>
             <li v-if="introExists">
                 <a
-                    class="items-center px-2 py-1 mx-1 cursor-pointer"
+                    class="flex items-center px-2 py-1 mx-1 cursor-pointer"
                     @click="scrollToChapter('intro')"
                     v-tippy="{
                         delay: '200',
@@ -14,7 +14,7 @@
                     }"
                     v-if="plugin"
                 >
-                    <span class="flex-1 ml-4 overflow-hidden leading-normal overflow-ellipsis whitespace-nowrap">{{
+                    <span class="flex-1 overflow-hidden leading-normal overflow-ellipsis whitespace-nowrap">{{
                         $t('chapters.return')
                     }}</span>
                 </a>
@@ -45,14 +45,14 @@
                     v-tippy="{
                         delay: '200',
                         placement: 'right',
-                        content: slide.title,
+                        content: getTitle(slide),
                         animateFill: true,
                         animation: 'chapter-menu'
                     }"
                     v-if="plugin"
                 >
-                    <span class="flex-1 ml-4 overflow-hidden leading-normal overflow-ellipsis whitespace-nowrap">{{
-                        slide.title
+                    <span class="flex-1 overflow-hidden leading-normal overflow-ellipsis whitespace-nowrap">{{
+                        getTitle(slide)
                     }}</span>
                 </a>
 
@@ -63,14 +63,14 @@
                     v-tippy="{
                         delay: '200',
                         placement: 'right',
-                        content: slide.title,
+                        content: getTitle(slide),
                         animateFill: true,
                         animation: 'chapter-menu'
                     }"
                     v-else
                 >
                     <span class="flex-1 overflow-hidden leading-normal overflow-ellipsis whitespace-nowrap">{{
-                        slide.title
+                        getTitle(slide)
                     }}</span>
                 </router-link>
             </li>
@@ -82,6 +82,9 @@
 import type { PropType } from 'vue';
 import { ref, onMounted } from 'vue';
 import { Slide } from '@storylines/definitions';
+
+import { useI18n } from 'vue-i18n';
+const { t } = useI18n();
 
 defineProps({
     slides: {
@@ -113,6 +116,10 @@ const scrollToChapter = (id: string): void => {
     if (el) {
         el.scrollIntoView({ behavior: 'smooth' });
     }
+};
+
+const getTitle = (slide: Slide): string => {
+    return slide.title !== '' ? slide.title : t('chapters.untitled');
 };
 </script>
 

--- a/src/lang/lang.csv
+++ b/src/lang/lang.csv
@@ -2,6 +2,7 @@ key,enValue,enValid,frValue,frValid
 chapters.title,Chapters,1,Chapitres,1
 chapters.return,Return to top,1,Retournez en haut,1
 chapters.menu,Toggle menu,1,Menu bascule,0
+chapters.untitled,Untitled Slide,1,Diapositive sans titre,0
 layer.loading,The layer is loading...,1,La couche est en cours de téléchargement...,1
 scrollguard.desc,Use ctrl + scroll to zoom the map,1,Utilisez les touches Ctrl et + pour faire un zoom de la carte,1
 story.date,Date modified:,1,Date de modification:,1


### PR DESCRIPTION
### Related Item(s)
https://github.com/ramp4-pcar4/storylines-editor/issues/346, https://github.com/ramp4-pcar4/storylines-editor/issues/337, https://github.com/ramp4-pcar4/storylines-editor/issues/328

### Changes
- The `Return to top` button will now be vertically aligned.
- Removed an unnecessary left margin from the active chapter button to ensure the text is centered in the button.
- Slides with no name will now be displayed in the table of contents as `Untitled Slide`.

### Testing

These issues only exist in preview mode, so you won't be able to test this using the Storylines demo page. We can verify this is fixed during the next editor testing party.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/449)
<!-- Reviewable:end -->
