### PR TITLE
fix title overlapping y-axis; reposition carousel buttons

### DIFF
--- a/src/components/panels/chart-panel.vue
+++ b/src/components/panels/chart-panel.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="chart self-center px-10 my-8 mx-auto bg-gray-200_">
+    <div class="chart self-center my-8 mx-auto bg-gray-200_">
         <chart :config="config" :configFileStructure="configFileStructure" />
     </div>
 </template>
@@ -28,7 +28,6 @@ defineProps({
 @media screen and (max-width: 640px) {
     .chart {
         max-width: 100vw;
-        max-height: 50vh;
         background-color: white;
     }
 }

--- a/src/components/panels/helpers/chart.vue
+++ b/src/components/panels/helpers/chart.vue
@@ -356,15 +356,21 @@ const makeLineChart = (fields: string[], csvData: CSVDataRow[], defaultOptions: 
 .highcharts-table-caption {
     display: none;
 }
+.highcharts-title {
+    font-size: 1.5em !important;
+}
 
 @media screen and (max-width: 640px) {
     .dv-chart {
         background-color: white;
     }
 
+    .highcharts-title {
+        font-size: 1em !important;
+    }
+
     .dv-chart-container {
         max-width: 100vw;
-        max-height: 50vh;
     }
 }
 </style>

--- a/src/components/panels/slideshow-panel.vue
+++ b/src/components/panels/slideshow-panel.vue
@@ -129,8 +129,7 @@ window.addEventListener('resize', () => {
     }
 
     :deep(.carousel__pagination) {
-        position: absolute;
-        bottom: calc(-6px - 4em);
+        position: relative;
         left: 50%;
         transform: translate(-50%, 0);
     }
@@ -182,6 +181,7 @@ window.addEventListener('resize', () => {
     }
     .carousel-item {
         max-height: 48vh;
+        overflow-y: auto;
     }
     :deep(.fullscreenButton) {
         right: 0px;


### PR DESCRIPTION
### Related Item(s)
#446 #447 

### Changes
- Repositioned the carousel buttons so that they no longer overlap elements below the carousel
- Resized chart title text on smaller screen sizes so the title shouldn't overlap the chart data
- Removed a bunch of x-margin so the charts take up more width on smaller screens
- Added a y-overflow to charts so the legend doesn't get cut off

### Notes
*Additional comments about the changes in this PR, including screenshots/gifs*

### Testing
Steps:
1. Open the demo page on a small screen.
2. Ensure chart titles are not overlapping charts
3. Ensure the charts are taking up a reasonable width within the panel
4. Ensure that the carousel buttons are not overlapping the text below
