### PR TITLE
Make slideshow forward, back buttons full height

### DIFF
--- a/src/components/panels/slideshow-panel.vue
+++ b/src/components/panels/slideshow-panel.vue
@@ -117,7 +117,6 @@ window.addEventListener('resize', () => {
         overflow: visible;
         padding-left: initial !important;
         border-radius: 100%;
-        background: radial-gradient(white, transparent 75%);
     }
 
     :deep(.carousel__next) {
@@ -126,6 +125,14 @@ window.addEventListener('resize', () => {
 
     :deep(.carousel__prev) {
         left: calc(-4px - 1.5em);
+    }
+
+    :deep(.carousel__prev), :deep(.carousel__next) {
+        height:100%;
+
+        &:hover, &:focus {
+            background-color: #EEEEEE;
+        }
     }
 
     :deep(.carousel__pagination) {


### PR DESCRIPTION
### Related Item(s)
#412 

### Changes
- [FIX] slideshow forward and back buttons now match the height of the slideshow

### Notes
Sometime in between the issue opening and now slideshows became a static height matching the largest item. I did not implement the animation on height changes because as far as I can tell height changes do not happen anymore.

### Testing
Steps:
1. open sample
2. Scroll down to one of the slideshows
3. hover and see the hover styling and that the button covers the whole height
4. tab to the button and see the same styling and height

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/458)
<!-- Reviewable:end -->
