### PR TITLE
Make ToC slides customizable

### DIFF
--- a/StoryRampSchema.json
+++ b/StoryRampSchema.json
@@ -19,6 +19,11 @@
                 "backgroundImage": {
                     "type": "string",
                     "description": "An image to display in the background of the slide."
+                },
+                "includeInToc": {
+                    "type": "boolean",
+                    "description": "Optional attribute that indicates whether or not to include slide in table of contents. Defaults to true.",
+                    "default": true
                 }
             },
             "required": ["title", "panel"]
@@ -581,6 +586,19 @@
                 "$ref": "#/$defs/slide"
             },
             "minItems": 1
+        },
+
+        "tocOrientation": {
+            "type": "string",
+            "description": "Specifies the orientation of the table of contents navigation menu.",
+            "enum": ["vertical", "horizontal"],
+            "default": "vertical"
+        },
+
+        "returnTop": {
+            "type": "boolean",
+            "description": "Specifies whether a link is added to scroll back to top of page.",
+            "default": true
         },
 
         "contextLink": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ramp-storylines_demo-scenarios-pcar",
     "description": "A user-configurable story product featuring interactive maps, charts and dynamic multimedia content alongside text.",
-    "version": "3.2.2",
+    "version": "3.2.3",
     "private": false,
     "license": "MIT",
     "repository": "https://github.com/ramp4-pcar4/story-ramp",

--- a/public/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000_en.json
+++ b/public/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000_en.json
@@ -72,7 +72,8 @@
                         }
                     ]
                 }
-            ]
+            ],
+            "includeInToc": false
         },
         {
             "title": "Default RAMP4 Sample",
@@ -88,7 +89,8 @@
                     "content": "The default RAMP4 sample.",
                     "type": "text"
                 }
-            ]
+            ],
+            "includeInToc": false
         },
         {
             "title": "Dynamic Panel Test",
@@ -174,7 +176,8 @@
                         }
                     ]
                 }
-            ]
+            ],
+            "includeInToc": false
         },
         {
             "title": "Video Panel",
@@ -191,7 +194,8 @@
                     "src": "https://www.youtube.com/embed/dQw4w9WgXcQ",
                     "height": 700
                 }
-            ]
+            ],
+            "includeInToc": false
         },
         {
             "title": "Oil sands deposits",
@@ -206,7 +210,8 @@
                     "type": "map",
                     "scrollguard": true
                 }
-            ]
+            ],
+            "includeInToc": true
         },
         {
             "title": "Oil sands extraction",
@@ -297,7 +302,8 @@
                     "caption": "NPRI substances reported for oil sands mining facilities",
                     "type": "slideshow"
                 }
-            ]
+            ],
+            "includeInToc": false
         },
         {
             "title": "NPRI substances reported for oil sands mining facilities",
@@ -325,7 +331,8 @@
                     "src": "00000000-0000-0000-0000-000000000000/assets/en/slide 6 - mining trends.jpg",
                     "type": "image"
                 }
-            ]
+            ],
+            "includeInToc": false
         },
         {
             "title": "Reported mine tailings from oil sands surface mining facilities",
@@ -352,7 +359,8 @@
                     "config": "00000000-0000-0000-0000-000000000000/ramp-config/ReleasesandDisposalsbyMiningFacilitiesin2019(satellite).json",
                     "type": "map"
                 }
-            ]
+            ],
+            "includeInToc": false
         },
         {
             "title": "Trends in mine tailings reported from surface mining facilities",
@@ -371,7 +379,8 @@
                     },
                     "type": "map"
                 }
-            ]
+            ],
+            "includeInToc": false
         },
         {
             "title": "In situ facilities",
@@ -385,7 +394,8 @@
                     "src": "00000000-0000-0000-0000-000000000000/assets/en/Slide 10 - SAGD vs CSS.jpg",
                     "type": "image"
                 }
-            ]
+            ],
+            "includeInToc": false
         },
         {
             "title": "NPRI releases from in-situ facilities",
@@ -399,7 +409,8 @@
                     "config": "00000000-0000-0000-0000-000000000000/ramp-config/ReleasestoAirbyInSituFacilitiesforAllSubstancesin2019.json",
                     "type": "map"
                 }
-            ]
+            ],
+            "includeInToc": false
         },
         {
             "title": "Chart Gallery",
@@ -471,7 +482,8 @@
                         }
                     ]
                 }
-            ]
+            ],
+            "includeInToc": false
         },
         {
             "title": "Managing environmental impacts",
@@ -485,11 +497,14 @@
                     "src": "00000000-0000-0000-0000-000000000000/assets/en/GettyImages-516166467__1554821531978__w1920.jpg",
                     "type": "image"
                 }
-            ]
+            ],
+            "includeInToc": false
         }
     ],
+    "tocOrientation": "horizontal",
+    "returnTop": false,
     "contextLink": "https://www.canada.ca/en/environment-climate-change/services/national-pollutant-release-inventory/tools-resources-data/exploredata.html",
     "contextLabel": "Explore National Pollutant Release Inventory data",
     "lang": "en",
-    "dateModified": "2024-07-15"
+    "dateModified": "2024-09-09"
 }

--- a/src/components/story/chapter-menu.vue
+++ b/src/components/story/chapter-menu.vue
@@ -37,7 +37,7 @@
         </div>
 
         <ul class="nav-content menu">
-            <li v-if="introExists">
+            <li v-if="introExists && returnToTop">
                 <a
                     class="flex items-center px-2 py-1 mx-1 cursor-pointer"
                     @click="scrollToChapter('intro')"
@@ -143,11 +143,11 @@
                     }}</span>
                 </router-link>
             </li>
-            <li v-for="(slide, idx) in slides" :key="idx" :class="{ 'is-active': activeChapterIndex === idx }">
+            <li v-for="(slide, idx) in slides" :key="idx" :class="{ 'is-active': activeChapterIndex === slide.index }">
                 <!-- using router-link causes a page refresh which breaks plugin -->
                 <a
                     class="flex items-center px-2 py-1 mx-1 cursor-pointer"
-                    @click="scrollToChapter(`${idx}-${slide.title.toLowerCase().replaceAll(' ', '-')}`)"
+                    @click="scrollToChapter(`${slide.index}-${slide.title.toLowerCase().replaceAll(' ', '-')}`)"
                     v-tippy="{
                         delay: '200',
                         placement: 'right',
@@ -177,7 +177,7 @@
                 </a>
 
                 <router-link
-                    :to="{ hash: `#${idx}-${slide.title.toLowerCase().replaceAll(' ', '-')}` }"
+                    :to="{ hash: `#${slide.index}-${slide.title.toLowerCase().replaceAll(' ', '-')}` }"
                     class="flex items-center px-2 py-1 mx-1"
                     target
                     v-tippy="{
@@ -218,7 +218,11 @@ import type { PropType } from 'vue';
 import { ref, onMounted } from 'vue';
 import { Slide } from '@storylines/definitions';
 
-defineProps({
+const props = defineProps({
+    returnToTop: {
+        type: Boolean,
+        default: true
+    },
     slides: {
         type: Array as PropType<Array<Slide>>,
         required: true
@@ -232,7 +236,8 @@ defineProps({
         required: true
     },
     plugin: {
-        type: Boolean
+        type: Boolean,
+        default: false
     }
 });
 

--- a/src/components/story/horizontal-menu.vue
+++ b/src/components/story/horizontal-menu.vue
@@ -1,7 +1,7 @@
 <template>
     <div id="h-navbar" class="navbar sticky">
         <ul>
-            <li v-if="introExists">
+            <li v-if="introExists && returnToTop">
                 <a
                     class="flex items-center px-2 py-1 mx-1 cursor-pointer"
                     @click="scrollToChapter('intro')"
@@ -37,11 +37,11 @@
                     }}</span>
                 </router-link>
             </li>
-            <li v-for="(slide, idx) in slides" :key="idx" :class="{ 'is-active': activeChapterIndex === idx }">
+            <li v-for="(slide, idx) in slides" :key="idx" :class="{ 'is-active': activeChapterIndex === slide.index }">
                 <!-- using router-link causes a page refresh which breaks plugin -->
                 <a
                     class="flex items-center px-2 py-1 mx-1 cursor-pointer"
-                    @click="scrollToChapter(`${idx}-${slide.title.toLowerCase().replaceAll(' ', '-')}`)"
+                    @click="scrollToChapter(`${slide.index}-${slide.title.toLowerCase().replaceAll(' ', '-')}`)"
                     v-tippy="{
                         delay: '200',
                         placement: 'right',
@@ -57,7 +57,7 @@
                 </a>
 
                 <router-link
-                    :to="{ hash: `#${idx}-${slide.title.toLowerCase().replaceAll(' ', '-')}` }"
+                    :to="{ hash: `#${slide.index}-${slide.title.toLowerCase().replaceAll(' ', '-')}` }"
                     class="flex items-center px-2 py-1 mx-1"
                     target
                     v-tippy="{
@@ -87,6 +87,10 @@ import { useI18n } from 'vue-i18n';
 const { t } = useI18n();
 
 defineProps({
+    returnToTop: {
+        type: Boolean,
+        default: true
+    },
     slides: {
         type: Array as PropType<Array<Slide>>,
         required: true
@@ -100,7 +104,8 @@ defineProps({
         required: true
     },
     plugin: {
-        type: Boolean
+        type: Boolean,
+        default: false
     }
 });
 

--- a/src/components/story/mobile-menu.vue
+++ b/src/components/story/mobile-menu.vue
@@ -36,7 +36,7 @@
         </div>
 
         <ul v-show="isMenuOpen" class="dropdown-nav-content bg-white pb-10 w-72 z-10 border-r border-gray-200">
-            <li v-if="introExists">
+            <li v-if="introExists && returnToTop">
                 <button class="flex py-1 px-3" @click="scrollToChapter('intro')" v-if="plugin">
                     <svg
                         class="flex-shrink-0"
@@ -119,10 +119,14 @@
                     }}</span>
                 </router-link>
             </li>
-            <li v-for="(slide, idx) in slides" :key="idx" :class="{ 'is-active': activeChapterIndex === idx }">
+            <li
+                v-for="(slide, idx) in tocSlides"
+                :key="idx"
+                :class="{ 'is-active': activeChapterIndex === slide.index }"
+            >
                 <button
                     class="flex py-1 px-3"
-                    @click="scrollToChapter(`${idx}-${slide.title.toLowerCase().replaceAll(' ', '-')}`)"
+                    @click="scrollToChapter(`${slide.index}-${slide.title.toLowerCase().replaceAll(' ', '-')}`)"
                     v-if="plugin"
                 >
                     <svg
@@ -144,7 +148,7 @@
                     }}</span>
                 </button>
                 <router-link
-                    :to="{ hash: `#${idx}-${slide.title.toLowerCase().replaceAll(' ', '-')}` }"
+                    :to="{ hash: `#${slide.index}-${slide.title.toLowerCase().replaceAll(' ', '-')}` }"
                     class="flex py-1 px-3"
                     target
                     v-else
@@ -174,12 +178,17 @@
 
 <script setup lang="ts">
 import type { PropType } from 'vue';
-import { ref, onMounted } from 'vue';
+import { computed, ref, onMounted } from 'vue';
 import { Slide } from '@storylines/definitions';
 
-defineProps({
+const props = defineProps({
+    returnToTop: {
+        type: Boolean,
+        default: true
+    },
     slides: {
-        type: Array as PropType<Array<Slide>>
+        type: Array as PropType<Array<Slide>>,
+        required: true
     },
     activeChapterIndex: {
         type: Number
@@ -188,12 +197,18 @@ defineProps({
         type: String
     },
     plugin: {
-        type: Boolean
+        type: Boolean,
+        default: false
     }
 });
 
 const isMenuOpen = ref(false);
 const introExists = ref(true);
+
+// filter out which slides are visible in the table of contents while preserving original slide index
+const tocSlides = computed(() =>
+    props.slides.map((slide, idx) => ({ ...slide, index: idx })).filter((slide) => slide.includeInToc !== false)
+);
 
 onMounted(() => {
     const introSection = document.getElementById('intro');

--- a/src/components/story/story-content.vue
+++ b/src/components/story/story-content.vue
@@ -6,7 +6,8 @@
         <horizontal-menu
             class="top-menu"
             :active-chapter-index="activeChapterIndex"
-            :slides="config.slides"
+            :return-to-top="config.returnTop ?? true"
+            :slides="tocSlides"
             :plugin="!!configFileStructure || !!plugin"
             :lang="lang"
             :style="{ top: headerHeight + 'px' }"
@@ -15,7 +16,8 @@
         <chapter-menu
             class="side-menu"
             :active-chapter-index="activeChapterIndex"
-            :slides="config.slides"
+            :return-to-top="!!config.returnTop ?? true"
+            :slides="tocSlides"
             :plugin="!!configFileStructure || !!plugin"
             :lang="lang"
             v-else
@@ -49,7 +51,7 @@
 
 <script setup lang="ts">
 import type { PropType } from 'vue';
-import { onMounted, ref } from 'vue';
+import { computed, onMounted, ref } from 'vue';
 import { useRoute } from 'vue-router';
 import { ConfigFileStructure, StoryRampConfig } from '@storylines/definitions';
 import 'intersection-observer';
@@ -82,6 +84,11 @@ const props = defineProps({
         type: Number
     }
 });
+
+// filter out which slides are visible in the table of contents while preserving original slide index
+const tocSlides = computed(() =>
+    props.config.slides.map((slide, idx) => ({ ...slide, index: idx })).filter((slide) => slide.includeInToc !== false)
+);
 
 const activeChapterIndex = ref(-1);
 const horizontalNavHeight = ref(0);

--- a/src/components/story/story.vue
+++ b/src/components/story/story.vue
@@ -25,6 +25,7 @@
                     <mobile-menu
                         class="mobile-menu"
                         :active-chapter-index="activeChapterIndex"
+                        :return-to-top="config.returnTop ?? true"
                         :slides="config.slides"
                         :lang="lang"
                     />

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -8,6 +8,7 @@ export interface StoryRampConfig {
     contextLink: string;
     contextLabel: string;
     tocOrientation: string;
+    returnTop?: boolean;
     dateModified: string;
 }
 
@@ -117,7 +118,9 @@ export interface Slide {
     // tuple definition to restrict array size
     // panel: [BasePanel, BasePanel | undefined];
     panel: BasePanel[];
+    index: number;
     backgroundImage: string;
+    includeInToc?: boolean;
 }
 
 export enum PanelType {


### PR DESCRIPTION
### Related Item(s)
https://github.com/ramp4-pcar4/storylines-editor/issues/370, https://github.com/ramp4-pcar4/tcei-tmx-cwa-storylines/issues/9

### Changes
- [FEATURE] add customization to table of contents menu with each slide having a configurable flag (`includeInToc`) and return to top of page being a global config flag (`returnTop`)

### Notes
Can revert 0000 config properties before merge if needed. Also will publish new NPM version after all TCEI required fixes are merged. 

### Testing
Test table of contents navigation/highlighting and ensure all slides with `includeInToc: false` are not included in navigation menu.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/461)
<!-- Reviewable:end -->
