### PR TITLE
Rework highlighting for flexible table of contents

### DIFF
--- a/public/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000_en.json
+++ b/public/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000_en.json
@@ -501,8 +501,7 @@
             "includeInToc": false
         }
     ],
-    "tocOrientation": "horizontal",
-    "returnTop": false,
+    "tocOrientation": "vertical",
     "contextLink": "https://www.canada.ca/en/environment-climate-change/services/national-pollutant-release-inventory/tools-resources-data/exploredata.html",
     "contextLabel": "Explore National Pollutant Release Inventory data",
     "lang": "en",

--- a/src/components/story/chapter-menu.vue
+++ b/src/components/story/chapter-menu.vue
@@ -143,7 +143,7 @@
                     }}</span>
                 </router-link>
             </li>
-            <li v-for="(slide, idx) in slides" :key="idx" :class="{ 'is-active': activeChapterIndex === slide.index }">
+            <li v-for="(slide, idx) in slides" :key="idx" :class="{ 'is-active': lastActiveIdx === slide.index }">
                 <!-- using router-link causes a page refresh which breaks plugin -->
                 <a
                     class="flex items-center px-2 py-1 mx-1 cursor-pointer"
@@ -215,7 +215,7 @@
 
 <script setup lang="ts">
 import type { PropType } from 'vue';
-import { ref, onMounted } from 'vue';
+import { ref, watch, onMounted } from 'vue';
 import { Slide } from '@storylines/definitions';
 
 const props = defineProps({
@@ -243,6 +243,14 @@ const props = defineProps({
 
 const isMenuOpen = ref(false);
 const introExists = ref(false);
+const lastActiveIdx = ref(-1);
+
+watch(
+    () => props.activeChapterIndex,
+    () => {
+        updateActiveIdx();
+    }
+);
 
 onMounted(() => {
     const introSection = document.getElementById('intro');
@@ -254,6 +262,11 @@ const scrollToChapter = (id: string): void => {
     if (el) {
         el.scrollIntoView({ behavior: 'smooth' });
     }
+};
+
+const updateActiveIdx = () => {
+    const prevSlides = props.slides.filter((slide) => slide.index <= props.activeChapterIndex);
+    lastActiveIdx.value = prevSlides.length ? prevSlides[prevSlides.length - 1].index : -1;
 };
 </script>
 

--- a/src/components/story/horizontal-menu.vue
+++ b/src/components/story/horizontal-menu.vue
@@ -37,7 +37,7 @@
                     }}</span>
                 </router-link>
             </li>
-            <li v-for="(slide, idx) in slides" :key="idx" :class="{ 'is-active': activeChapterIndex === slide.index }">
+            <li v-for="(slide, idx) in slides" :key="idx" :class="{ 'is-active': lastActiveIdx === slide.index }">
                 <!-- using router-link causes a page refresh which breaks plugin -->
                 <a
                     class="flex items-center px-2 py-1 mx-1 cursor-pointer"
@@ -80,13 +80,13 @@
 
 <script setup lang="ts">
 import type { PropType } from 'vue';
-import { ref, onMounted } from 'vue';
+import { ref, watch, onMounted } from 'vue';
 import { Slide } from '@storylines/definitions';
 
 import { useI18n } from 'vue-i18n';
 const { t } = useI18n();
 
-defineProps({
+const props = defineProps({
     returnToTop: {
         type: Boolean,
         default: true
@@ -110,6 +110,14 @@ defineProps({
 });
 
 const introExists = ref(false);
+const lastActiveIdx = ref(-1);
+
+watch(
+    () => props.activeChapterIndex,
+    () => {
+        updateActiveIdx();
+    }
+);
 
 onMounted(() => {
     const introSection = document.getElementById('intro');
@@ -125,6 +133,11 @@ const scrollToChapter = (id: string): void => {
 
 const getTitle = (slide: Slide): string => {
     return slide.title !== '' ? slide.title : t('chapters.untitled');
+};
+
+const updateActiveIdx = () => {
+    const prevSlides = props.slides.filter((slide) => slide.index <= props.activeChapterIndex);
+    lastActiveIdx.value = prevSlides.length ? prevSlides[prevSlides.length - 1].index : -1;
 };
 </script>
 

--- a/src/components/story/mobile-menu.vue
+++ b/src/components/story/mobile-menu.vue
@@ -119,11 +119,7 @@
                     }}</span>
                 </router-link>
             </li>
-            <li
-                v-for="(slide, idx) in tocSlides"
-                :key="idx"
-                :class="{ 'is-active': activeChapterIndex === slide.index }"
-            >
+            <li v-for="(slide, idx) in tocSlides" :key="idx" :class="{ 'is-active': lastActiveIdx === slide.index }">
                 <button
                     class="flex py-1 px-3"
                     @click="scrollToChapter(`${slide.index}-${slide.title.toLowerCase().replaceAll(' ', '-')}`)"
@@ -178,7 +174,7 @@
 
 <script setup lang="ts">
 import type { PropType } from 'vue';
-import { computed, ref, onMounted } from 'vue';
+import { computed, ref, watch, onMounted } from 'vue';
 import { Slide } from '@storylines/definitions';
 
 const props = defineProps({
@@ -191,7 +187,8 @@ const props = defineProps({
         required: true
     },
     activeChapterIndex: {
-        type: Number
+        type: Number,
+        required: true
     },
     lang: {
         type: String
@@ -204,10 +201,18 @@ const props = defineProps({
 
 const isMenuOpen = ref(false);
 const introExists = ref(true);
+const lastActiveIdx = ref(-1);
 
 // filter out which slides are visible in the table of contents while preserving original slide index
 const tocSlides = computed(() =>
     props.slides.map((slide, idx) => ({ ...slide, index: idx })).filter((slide) => slide.includeInToc !== false)
+);
+
+watch(
+    () => props.activeChapterIndex,
+    () => {
+        updateActiveIdx();
+    }
 );
 
 onMounted(() => {
@@ -220,6 +225,11 @@ const scrollToChapter = (id: string): void => {
     if (el) {
         el.scrollIntoView({ behavior: 'smooth' });
     }
+};
+
+const updateActiveIdx = () => {
+    const prevSlides = tocSlides.value.filter((slide) => slide.index <= props.activeChapterIndex);
+    lastActiveIdx.value = prevSlides.length ? prevSlides[prevSlides.length - 1].index : -1;
 };
 </script>
 


### PR DESCRIPTION
### Related Item(s)
Closes #465 

### Changes
- [FIX] ToC highlighting for customized table of contents menu, will highlight the last slide that exists before current active slide that is part of the ToC menu

### Testing
Scroll around and make sure there is a highlighted ToC section at all times + highlighted section makes logical sense if it active slide is not part of ToC.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/466)
<!-- Reviewable:end -->
