### PR TITLE
Fix footer for full screen map

### DIFF
--- a/src/components/story/story.vue
+++ b/src/components/story/story.vue
@@ -40,7 +40,7 @@
 
             <intro :config="config.introSlide"></intro>
 
-            <div class="w-full mx-auto pb-10" id="story">
+            <div class="w-full mx-auto pb-10 mb-6" id="story">
                 <story-content :config="config" :lang="lang" :headerHeight="headerHeight" @step="updateActiveIndex" />
             </div>
 


### PR DESCRIPTION
### Related Item(s)
#459

### Changes
- Added a bottom margin to the storylines content component

### Notes
- The issue seems to only occur when there is one full screen map slide. Any other full screen slide seem to work fine

### Testing
Steps:
1. Create a new storylines product (can use storylines editor to do this)
2. Add one full screen map slide
3. Copy the folder for this product over to your local storylines repo
4. Run storylines for this new product
5. Scroll down and observe that the footer isn't cut off anymore

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/474)
<!-- Reviewable:end -->
