### PR TITLE
enhance background transitions

### DIFF
--- a/src/components/panels/interactive-map.vue
+++ b/src/components/panels/interactive-map.vue
@@ -150,7 +150,6 @@ const handlePoint = (id: string, oid: number, layerIndex?: number) => {
 .interactive-container {
     display: grid;
     grid-template-areas: 'interactiveOverlay';
-    grid-template-columns: repeat(1, calc(calc(100vw - 4rem) - 2px));
 }
 .interactive-content {
     grid-area: interactiveOverlay;


### PR DESCRIPTION
### Related Item(s)
#464 

### Changes
- Added logic to dynamically calculate the observer threshold based on the element and client height instead of just specifying a threshold. This will allow for a more consistent experience on different screen sizes.
- Added checks to see if the slide is switched while a transition is already in progress. If so, the transition will be reset.
- Added a white background to slides that do not have a background image in order to have the transition appear less "jumpy". Let me know if this is an improvement, it can be removed if not.
- Fixed missing alt tag WCAG error by adding `role="presentation"` to the background image.
- Fixed an issue with the interactive map panel not taking up the entire width of the screen when the ToC is horizontal.

### Notes
If you switch back and forth very quickly between two slides, the animation will be skipped. As far as I'm aware there's not much we can do about this, and I don't think quickly switching between slides is a valid use case for the product anyway.

### Testing
Steps:
1. Open the demo page and play around with the background transitions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/475)
<!-- Reviewable:end -->
