### PR TITLE
consider ToC orientation in map height calculation

### DIFF
--- a/src/components/panels/interactive-map.vue
+++ b/src/components/panels/interactive-map.vue
@@ -128,7 +128,6 @@ const handlePoint = (id: string, oid: number, layerIndex?: number) => {
 
 <style lang="scss" scoped>
 .rv-map {
-    height: calc(100vh - 4rem) !important;
     width: 100%;
 
     :deep(.time-slider-container) {
@@ -145,6 +144,13 @@ const handlePoint = (id: string, oid: number, layerIndex?: number) => {
     :deep(.time-slider-container.minimized) {
         height: 50px;
     }
+}
+
+.toc-horizontal .rv-map {
+    height: calc(100vh - 6rem) !important;
+}
+.toc-vertical .rv-map {
+    height: calc(100vh - 4rem) !important;
 }
 
 .interactive-container {

--- a/src/components/panels/map-panel.vue
+++ b/src/components/panels/map-panel.vue
@@ -116,7 +116,6 @@ const setupMap = (config: any) => {
 
 <style lang="scss" scoped>
 .rv-map {
-    height: calc(100vh - 4rem) !important;
     width: 100%;
 
     :deep(.time-slider-container) {
@@ -135,7 +134,19 @@ const setupMap = (config: any) => {
     }
 }
 
-.rv-map-title {
+.toc-horizontal .rv-map {
+    height: calc(100vh - 6rem) !important;
+}
+.toc-vertical .rv-map {
+    height: calc(100vh - 4rem) !important;
+}
+
+.toc-horizontal .rv-map-title {
+    height: calc(100vh - 11rem) !important;
+    width: 100%;
+}
+
+.toc-vertical .rv-map-title {
     height: calc(100vh - 9rem) !important;
     width: 100%;
 }

--- a/src/components/story/story-content.vue
+++ b/src/components/story/story-content.vue
@@ -1,7 +1,7 @@
 <template>
     <div
         class="items-stretch"
-        :class="{ flex: !$props.config?.tocOrientation || $props.config?.tocOrientation === 'vertical' }"
+        :class="$props.config?.tocOrientation === 'horizontal' ? 'toc-horizontal' : 'flex toc-vertical'"
     >
         <horizontal-menu
             class="top-menu"


### PR DESCRIPTION
### Related Item(s)
https://github.com/ramp4-pcar4/tcei-tmx-cwa-storylines/issues/25

### Changes
- Added a new class to the the `story-content` component that specifies whether the table of contents is oriented horizontally or vertically. This class can be utilized in the sub-components for conditional styling.
- Maps should now adjust height to consider the extra space used by the horizontal table of contents. If the product is using a vertical table of contents the height should still be good.

### Testing
Steps:
1. Check out the maps in the demo link and ensure their heights match up with the available space on the screen.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/476)
<!-- Reviewable:end -->
