### PR TITLE
Fix video container width at 100% on mobile

### DIFF
--- a/src/components/panels/video-panel.vue
+++ b/src/components/panels/video-panel.vue
@@ -139,6 +139,7 @@ const extensionType = (file: string): string | undefined => {
 <style lang="scss">
 @media screen and (max-width: 640px) {
     .video-container {
+        width: 100vw !important;
         max-width: 100vw;
         background-color: white;
     }


### PR DESCRIPTION
### Related Item(s)
Missed part for https://github.com/ramp4-pcar4/tcei-tmx-cwa-storylines/issues/23

### Changes
- [FIX] set video panel width to take up all possible space on mobile 

### Testing
Steps:
1. Test "cumulative effects" video slide on mobile

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/479)
<!-- Reviewable:end -->
