### PR TITLE
dynamic panel enhancements

### DIFF
--- a/StoryRampSchema.json
+++ b/StoryRampSchema.json
@@ -125,6 +125,21 @@
                     "type": "string",
                     "description": "The colour of the text. Defaults to black.",
                     "default": "#000000"
+                },
+                "reversed": {
+                    "type": "boolean",
+                    "description": "If true, the text slide and dynamic slide will be swapped.",
+                    "default": false
+                },
+                "hideReturn": {
+                    "type": "boolean",
+                    "description": "If true, the return button will be hidden.",
+                    "default": false
+                },
+                "contentWidth": {
+                    "type": "number",
+                    "description": "If provided, the text slide will be set to this value. Caps out at the page width on mobile mode.",
+                    "default": 0
                 }
             },
             "required": ["content", "type", "children", "title"]

--- a/public/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000_en.json
+++ b/public/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000_en.json
@@ -103,7 +103,9 @@
                 {
                     "title": "This Slide Is Dynamic!",
                     "type": "dynamic",
+                    "reversed": true,
                     "content": "You can click on one of the following links to change the right panel.\n\n- <a panel='panel-1'>Text Panel</a>\n- <a panel='panel-2'>Image Panel</a>\n- <a panel='panel-3'>Charts Panel</a>\n- <a panel='panel-4'>Map Panel</a>\n- <a panel='panel-5'>Longer text section with table</a>\n- <a href='#/en/00000000-0000-0000-0000-000000000000#2-oil-sands-deposits' target='_self'>Self target link</a>\n- <a panel='panel-6'>Video externally hosted</a>\n- <a panel='panel-7'>Video locally hosted</a>\n\nFun stuff.",
+                    "contentWidth": 800,
                     "children": [
                         {
                             "id": "panel-1",

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -200,7 +200,10 @@ export interface DynamicPanel extends BasePanel {
     titleTag: string;
     content: string;
     children: DynamicChildItem[];
-    textColour: string;
+    textColour?: string;
+    reversed?: boolean;
+    hideReturn?: boolean;
+    contentWidth?: string;
 }
 
 export interface DynamicChildItem {


### PR DESCRIPTION
### Related Item(s)
#480 #481

### Changes
- Added new dynamic panel property `reversed`: if true, the control slide will appear on the right side of the slide and the dynamic content will appear on the left. Defaults to `false.`
- Added new property `hideReturn`: if true, the "Return" button will not appear. Defaults to `false`.
- Added new property `contentWidth`: the width of the text slide will be set to this value if it is defined. This is capped out at the width of the screen in mobile view.
- The return button and dynamic links will now take into consideration the height of the horizontal table of contents when scrolling.

### Testing
Steps:
1. Open the demo page.
2. Play around with the dynamic slide (titled `This slide is dynamic!`) and ensure everything is working as normal.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/482)
<!-- Reviewable:end -->
