### PR TITLE
fix window resizing issues + horizontal ToC overlapping elements

### DIFF
--- a/src/components/panels/dynamic-panel.vue
+++ b/src/components/panels/dynamic-panel.vue
@@ -214,5 +214,9 @@ const clickBack = (): void => {
         display: flex;
         flex-direction: column-reverse;
     }
+
+    .sticky {
+        top: 0rem !important;
+    }
 }
 </style>

--- a/src/components/panels/interactive-map.vue
+++ b/src/components/panels/interactive-map.vue
@@ -146,11 +146,24 @@ const handlePoint = (id: string, oid: number, layerIndex?: number) => {
     }
 }
 
-.toc-horizontal .rv-map {
-    height: calc(100vh - 6rem) !important;
+.toc-horizontal {
+    .rv-map {
+        height: calc(100vh - 4rem - 2.75rem) !important; // 4rem for the header, 2.75 for the horizontal ToC.
+    }
+
+    .interactive-container {
+        grid-template-columns: repeat(1, calc(100%));
+    }
 }
-.toc-vertical .rv-map {
-    height: calc(100vh - 4rem) !important;
+
+.toc-vertical {
+    .rv-map {
+        height: calc(100vh - 4rem) !important;
+    }
+
+    .interactive-container {
+        grid-template-columns: repeat(1, calc(100vw - 4.1rem));
+    }
 }
 
 .interactive-container {
@@ -168,7 +181,13 @@ const handlePoint = (id: string, oid: number, layerIndex?: number) => {
 
 @media screen and (max-width: 640px) {
     .interactive-container {
-        grid-template-columns: repeat(1, calc(100%));
+        grid-template-columns: repeat(1, calc(100%)) !important;
+    }
+
+    .toc-horizontal {
+        .rv-map {
+            height: calc(100vh - 4rem) !important;
+        }
     }
 }
 

--- a/src/components/panels/map-panel.vue
+++ b/src/components/panels/map-panel.vue
@@ -135,14 +135,14 @@ const setupMap = (config: any) => {
 }
 
 .toc-horizontal .rv-map {
-    height: calc(100vh - 6rem) !important;
+    height: calc(100vh - 4rem - 2.75rem) !important; // 4rem for the header, 2.75 for the horizontal ToC.
 }
 .toc-vertical .rv-map {
     height: calc(100vh - 4rem) !important;
 }
 
 .toc-horizontal .rv-map-title {
-    height: calc(100vh - 11rem) !important;
+    height: calc(100vh - 9rem - 2.75rem) !important; // 9rem for the header + title, 2.75 for the horizontal ToC.
     width: 100%;
 }
 
@@ -152,7 +152,7 @@ const setupMap = (config: any) => {
 }
 
 .has-background {
-    background-color: rgba(255, 255, 255, 0.6);
+    background-color: rgba(255, 255, 255, 0.95);
     margin-bottom: 0em !important;
     padding-bottom: 1em;
     color: black;

--- a/src/components/panels/slideshow-panel.vue
+++ b/src/components/panels/slideshow-panel.vue
@@ -3,7 +3,7 @@
         <div class="flex">
             <div
                 ref="slideshow"
-                class="carousel-container self-center px-10 my-8 mx-auto bg-gray-200_"
+                class="carousel-container self-center px-10 mx-auto bg-gray-200_"
                 :style="{ width: `${width}px` }"
             >
                 <carousel
@@ -127,11 +127,13 @@ window.addEventListener('resize', () => {
         left: calc(-4px - 1.5em);
     }
 
-    :deep(.carousel__prev), :deep(.carousel__next) {
-        height:100%;
+    :deep(.carousel__prev),
+    :deep(.carousel__next) {
+        height: 100%;
 
-        &:hover, &:focus {
-            background-color: #EEEEEE;
+        &:hover,
+        &:focus {
+            background-color: #eeeeee;
         }
     }
 

--- a/src/components/story/horizontal-menu.vue
+++ b/src/components/story/horizontal-menu.vue
@@ -1,5 +1,5 @@
 <template>
-    <div id="h-navbar" class="navbar sticky">
+    <div id="h-navbar" class="navbar h-11 sticky">
         <ul>
             <li v-if="introExists && returnToTop">
                 <a
@@ -147,7 +147,6 @@ const updateActiveIdx = () => {
     border-bottom: 2px;
     border-color: rgba(229, 231, 235, var(--tw-border-opacity));
     position: sticky;
-    height: 100%;
     width: 100%;
     margin: 0;
     display: flex;

--- a/src/components/story/slide.vue
+++ b/src/components/story/slide.vue
@@ -142,4 +142,25 @@ const determinePanelOrder = (idx: number): string => {
 };
 </script>
 
-<style lang="scss" scoped></style>
+<style lang="scss">
+// Offset stickied elements by the height of the header and horizontal ToC so they don't overlap.
+.toc-horizontal {
+    .sticky {
+        top: calc(4rem + 2.75rem); // 4rem for the header, 2.75 for the horizontal ToC.
+    }
+}
+
+.toc-vertical {
+    .sticky {
+        top: calc(4rem); // 4rem for the header, 2.75 for the horizontal ToC.
+    }
+}
+
+@media screen and (max-width: 640px) {
+    .toc-horizontal {
+        .sticky {
+            top: calc(4rem);
+        }
+    }
+}
+</style>

--- a/src/components/story/story-content.vue
+++ b/src/components/story/story-content.vue
@@ -141,6 +141,7 @@ const stepEnter = ({ element }: { element: HTMLElement }): void => {
 .grid-container {
     display: grid;
     grid-template-areas: 'backgroundOverlay';
+    grid-template-columns: repeat(1, calc(100%));
 }
 .grid-content {
     grid-area: backgroundOverlay;


### PR DESCRIPTION
### Related Item(s)
#443 

### Changes
- When resizing the product, everything should now reposition and scale correctly instead of displaying a horizontal scrollbar.
- Also fixes an issue where the horizontal table of contents would cover parts of the stickied content.

### Testing
Steps:
1. Open the demo page.
2. Ensure everything is still positioned correctly, and that the right hand stickied content is nicely aligned at the top of the page under the header.
3. Now, resize the window (not to mobile width just yet).
4. Ensure there is no horizontal scrollbar. Check that everything has resized correctly, and that stickied content is still nicely aligned at the top of the page.
5. Make the page mobile width. Do the same checks and make sure everything is nicely positioned.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/484)
<!-- Reviewable:end -->
