### PR TITLE
fix window resizing issues, horizontal scrollbar overlap

### DIFF
--- a/StoryRampSchema.json
+++ b/StoryRampSchema.json
@@ -137,9 +137,9 @@
                     "default": false
                 },
                 "contentWidth": {
-                    "type": "number",
-                    "description": "If provided, the text slide will be set to this value. Caps out at the page width on mobile mode.",
-                    "default": 0
+                    "type": "string",
+                    "description": "If provided, the text slide width will be set to this value. Caps out at the page width on mobile mode.",
+                    "default": ""
                 }
             },
             "required": ["content", "type", "children", "title"]

--- a/public/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000_en.json
+++ b/public/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000_en.json
@@ -117,7 +117,7 @@
                     "type": "dynamic",
                     "reversed": true,
                     "content": "You can click on one of the following links to change the right panel.\n\n- <a panel='panel-1'>Text Panel</a>\n- <a panel='panel-2'>Image Panel</a>\n- <a panel='panel-3'>Charts Panel</a>\n- <a panel='panel-4'>Map Panel</a>\n- <a panel='panel-5'>Longer text section with table</a>\n- <a href='#/en/00000000-0000-0000-0000-000000000000#2-oil-sands-deposits' target='_self'>Self target link</a>\n- <a panel='panel-6'>Video externally hosted</a>\n- <a panel='panel-7'>Video locally hosted</a>\n\nFun stuff.",
-                    "contentWidth": 800,
+                    "contentWidth": "60%",
                     "children": [
                         {
                             "id": "panel-1",

--- a/src/components/panels/dynamic-panel.vue
+++ b/src/components/panels/dynamic-panel.vue
@@ -6,9 +6,12 @@
         :class="!!config.reversed ? 'sm:flex-row-reverse' : 'sm:flex-row'"
     >
         <scrollama
-            class="dynamic-content-slide order-2 sm:order-1 prose max-w-none mb-5 mx-1 py-5"
+            class="dynamic-content-slide order-2 sm:order-1 prose max-w-none min-w-0 mb-5 mx-1 py-5"
             :class="{ 'has-background': background, 'flex-1': !!config.contentWidth === false }"
-            :style="{ color: config.textColour ?? '#000', width: `${config.contentWidth}px` }"
+            :style="{
+                color: config.textColour ?? '#000',
+                width: !isMobile ? `${config.contentWidth}` : undefined
+            }"
         >
             <component
                 :is="config.titleTag || 'h2'"
@@ -24,7 +27,7 @@
         <div
             :class="
                 activeConfig.type !== 'text'
-                    ? `sticky top-0 sm:self-start flex-2 order-1 sm:order-2 z-40 dynamic-content-media sm:flex-col`
+                    ? `sticky top-0 sm:self-start flex-2 order-1 sm:order-2 z-40 dynamic-content-media sm:flex-col min-w-0`
                     : 'flex-2 order-2 sm:order-1 dynamic-content-text'
             "
         >
@@ -92,6 +95,7 @@ const defaultPanel = props.config.children[0];
 // By default, the active config is set to the first child in the children list.
 const activeConfig = ref<BasePanel>(defaultPanel.panel);
 const activeIdx = ref(defaultPanel.id);
+const isMobile = ref(false);
 
 const md = new MarkdownIt({ html: true });
 
@@ -103,6 +107,12 @@ onMounted(() => {
         .forEach((el: Element) => ((el as HTMLAnchorElement).target = '_blank'));
 
     addDynamicURLs();
+
+    // Check for a switch from normal view to mobile view. Fixed text panel width will need to be adjusted.
+    isMobile.value = window.innerWidth <= 640;
+    window.addEventListener('resize', () => {
+        isMobile.value = window.innerWidth <= 640;
+    });
 });
 
 /**

--- a/src/components/panels/interactive-map.vue
+++ b/src/components/panels/interactive-map.vue
@@ -5,7 +5,7 @@
                 <PointOfInterestItem :point="point" :index="index" @poi-changed="handlePoint"></PointOfInterestItem>
             </div>
         </div>
-        <div :id="`ramp-map-${slideIdx}`" class="bg-gray-200 h-story rv-map sticky top-16 interactive-content"></div>
+        <div :id="`ramp-map-${slideIdx}`" class="bg-gray-200 h-story rv-map sticky interactive-content"></div>
     </div>
 </template>
 
@@ -146,11 +146,21 @@ const handlePoint = (id: string, oid: number, layerIndex?: number) => {
     }
 }
 
-.toc-horizontal .rv-map {
-    height: calc(100vh - 6rem) !important;
+.toc-horizontal {
+    .rv-map {
+        height: calc(100vh - 4rem - 2.75rem) !important; // 4rem for the header, 2.75 for the horizontal ToC.
+    }
+    .interactive-container {
+        grid-template-columns: repeat(1, calc(100%));
+    }
 }
-.toc-vertical .rv-map {
-    height: calc(100vh - 4rem) !important;
+.toc-vertical {
+    .rv-map {
+        height: calc(100vh - 4rem) !important;
+    }
+    .interactive-container {
+        grid-template-columns: repeat(1, calc(100vw - 4.1rem));
+    }
 }
 
 .interactive-container {
@@ -168,7 +178,12 @@ const handlePoint = (id: string, oid: number, layerIndex?: number) => {
 
 @media screen and (max-width: 640px) {
     .interactive-container {
-        grid-template-columns: repeat(1, calc(100%));
+        grid-template-columns: repeat(1, calc(100%)) !important;
+    }
+    .toc-horizontal {
+        .rv-map {
+            height: calc(100vh - 4rem) !important;
+        }
     }
 }
 

--- a/src/components/panels/map-panel.vue
+++ b/src/components/panels/map-panel.vue
@@ -9,10 +9,10 @@
         </div>
 
         <div class="flex sm:flex-row flex-col w-full h-story" v-if="config.teleportGrid">
-            <div class="storylines-grid-container sm:order-1 order-2 flex-1 ramp-styles" ref="grid"></div>
+            <div class="storylines-grid-container sm:order-1 order-2 flex-1 min-w-0 ramp-styles" ref="grid"></div>
             <div
                 :id="`ramp-map-${slideIdx}`"
-                class="sm:order-2 order-1 flex-2 bg-gray-200"
+                class="sm:order-2 order-1 flex-2 min-w-0 bg-gray-200"
                 :class="config.title ? 'rv-map-title' : 'rv-map'"
             ></div>
         </div>
@@ -175,15 +175,15 @@ const setupMap = (config: any) => {
     }
 }
 
-.toc-horizontal .rv-map {
-    height: calc(100vh - 6rem) !important;
+.toc-horizontal .rv-map,
+.toc-horizontal .storylines-grid-container {
+    height: calc(100vh - 4rem - 2.75rem) !important; // 4rem for the header, 2.75 for the horizontal ToC.
 }
 .toc-vertical .rv-map {
     height: calc(100vh - 4rem) !important;
 }
-
 .toc-horizontal .rv-map-title {
-    height: calc(100vh - 11rem) !important;
+    height: calc(100vh - 9rem - 2.75rem) !important; // 9rem for the header + title, 2.75 for the horizontal ToC.
     width: 100%;
 }
 
@@ -193,7 +193,7 @@ const setupMap = (config: any) => {
 }
 
 .has-background {
-    background-color: rgba(255, 255, 255, 0.6);
+    background-color: rgba(255, 255, 255, 0.95);
     margin-bottom: 0em !important;
     padding-bottom: 1em;
     color: black;

--- a/src/components/panels/panel.vue
+++ b/src/components/panels/panel.vue
@@ -3,8 +3,8 @@
         :class="
             config.type !== PanelType.Text
                 ? `${
-                      config.type === PanelType.Map ? 'top-16 overflow-x-auto overflow-y-hidden' : 'top-8'
-                  } sm:self-start flex-2`
+                      config.type === PanelType.Map ? 'overflow-x-auto overflow-y-hidden' : ''
+                  } sm:self-start flex-2 min-w-0`
                 : 'flex flex-1'
         "
         class="flex-col relative"

--- a/src/components/panels/slideshow-panel.vue
+++ b/src/components/panels/slideshow-panel.vue
@@ -3,7 +3,7 @@
         <div class="flex">
             <div
                 ref="slideshow"
-                class="carousel-container self-center px-10 mb-8 mx-auto bg-gray-200_"
+                class="carousel-container self-center px-10 mx-auto bg-gray-200_"
                 :style="{ width: `${width}px` }"
             >
                 <carousel

--- a/src/components/panels/video-panel.vue
+++ b/src/components/panels/video-panel.vue
@@ -139,7 +139,7 @@ const extensionType = (file: string): string | undefined => {
 <style lang="scss">
 @media screen and (max-width: 640px) {
     .video-container {
-        width: 100vw !important;
+        width: 100%;
         max-width: 100vw;
         background-color: white;
     }

--- a/src/components/story/chapter-menu.vue
+++ b/src/components/story/chapter-menu.vue
@@ -1,7 +1,7 @@
 <template>
     <div
         :class="isMenuOpen ? 'w-72' : ''"
-        class="nav-bar sticky self-start w-12 duration-500 ease-in-out transition-width top-16"
+        class="nav-bar sticky self-start w-12 duration-500 ease-in-out transition-width"
     >
         <div class="flex items-center mt-4 mb-12">
             <button

--- a/src/components/story/horizontal-menu.vue
+++ b/src/components/story/horizontal-menu.vue
@@ -1,5 +1,5 @@
 <template>
-    <div id="h-navbar" class="navbar sticky">
+    <div id="h-navbar" class="navbar h-11 sticky">
         <ul>
             <li v-if="introExists && returnToTop">
                 <a
@@ -147,7 +147,6 @@ const updateActiveIdx = () => {
     border-bottom: 2px;
     border-color: rgba(229, 231, 235, var(--tw-border-opacity));
     position: sticky;
-    height: 100%;
     width: 100%;
     margin: 0;
     display: flex;

--- a/src/components/story/slide.vue
+++ b/src/components/story/slide.vue
@@ -142,4 +142,25 @@ const determinePanelOrder = (idx: number): string => {
 };
 </script>
 
-<style lang="scss" scoped></style>
+<style lang="scss">
+// Offset stickied elements by the height of the header and horizontal ToC so they don't overlap.
+.toc-horizontal {
+    .sticky {
+        top: calc(4rem + 2.75rem); // 4rem for the header, 2.75 for the horizontal ToC.
+    }
+}
+
+.toc-vertical {
+    .sticky {
+        top: calc(4rem); // 4rem for the header, 2.75 for the horizontal ToC.
+    }
+}
+
+@media screen and (max-width: 640px) {
+    .toc-horizontal {
+        .sticky {
+            top: calc(4rem);
+        }
+    }
+}
+</style>

--- a/src/components/story/story-content.vue
+++ b/src/components/story/story-content.vue
@@ -118,7 +118,7 @@ onMounted(() => {
 
 const handleSlideChange = (event: number): void => {
     const img = props.config.slides[event].backgroundImage;
-    backgroundImage.value = img ?? 'none';
+    backgroundImage.value = !!img ? img : 'none';
 };
 
 /**
@@ -151,6 +151,7 @@ const addPanelPadding = (idx: number): string => {
 .grid-container {
     display: grid;
     grid-template-areas: 'backgroundOverlay';
+    grid-template-columns: repeat(1, calc(100%));
 }
 .grid-content {
     grid-area: backgroundOverlay;


### PR DESCRIPTION
### Related Item(s)
#443, #487

### Changes
- When resizing the product, everything should now reposition and scale correctly instead of displaying a horizontal scrollbar.
- Also fixes an issue where the horizontal table of contents would cover parts of the stickied content.
- Removed the `top-8` and `top-16` classes from panels as they are no longer required.

### Testing
Steps:
1. Open the demo page.
2. Ensure everything is still positioned correctly, and that the right hand stickied content is nicely aligned at the top of the page under the header.
3. Now, resize the window (not to mobile width just yet).
4. Ensure there is no horizontal scrollbar. Check that everything has resized correctly, and that stickied content is still nicely aligned at the top of the page.
5. Make the page mobile width. Do the same checks and make sure everything is nicely positioned.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/488)
<!-- Reviewable:end -->
