### PR TITLE
Add support for uploaded video asset files in preview

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ramp-storylines_demo-scenarios-pcar",
     "description": "A user-configurable story product featuring interactive maps, charts and dynamic multimedia content alongside text.",
-    "version": "3.2.6",
+    "version": "3.2.7",
     "private": false,
     "license": "MIT",
     "repository": "https://github.com/ramp4-pcar4/story-ramp",


### PR DESCRIPTION
### Related Item(s)
https://github.com/ramp4-pcar4/storylines-editor/issues/408, https://github.com/ramp4-pcar4/storylines-editor/issues/267

### Changes
- [FEATURE] support for handling captions + transcript files transferred from `configFileStructure`
- [FIX] handle locally uploaded video files by appending `src` directly onto video element

### Notes
Published `v3.2.7` to NPM https://www.npmjs.com/package/ramp-storylines_demo-scenarios-pcar

### Testing
Can test in Storylines Editor when package is updated, for now ensure video panels have no errors in demo.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/493)
<!-- Reviewable:end -->
