### PR TITLE
Preserve video aspect ratio upon changing browser size

### DIFF
--- a/src/components/panels/video-panel.vue
+++ b/src/components/panels/video-panel.vue
@@ -139,8 +139,7 @@ const extensionType = (file: string): string | undefined => {
 <style lang="scss">
 @media screen and (max-width: 640px) {
     .video-container {
-        width: 100%;
-        max-width: 100vw;
+        min-width: 100%;
         background-color: white;
     }
     .media-player {
@@ -150,12 +149,13 @@ const extensionType = (file: string): string | undefined => {
 
 .video-container {
     margin: 0 auto;
+    max-width: 100vw;
 }
 
 .media-player {
-    position: relative;
-    left: 50%;
-    transform: translateX(-50%);
+    aspect-ratio: 16/9;
+    width: 100%;
+    height: 100%;
 }
 
 .float-right {


### PR DESCRIPTION
### Related Item(s)
https://github.com/ramp4-pcar4/tcei-tmx-cwa-storylines/issues/63 

### Changes
- [FIX] video aspect ratio so that is is consistent across all different browser resolutions

### Testing
Resize the browser and check that the thumbnail of video panels are not cut off.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/494)
<!-- Reviewable:end -->
