### PR TITLE
add a separator between horizontal ToC items

### DIFF
--- a/public/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000_en.json
+++ b/public/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000_en.json
@@ -482,7 +482,8 @@
                         }
                     ]
                 }
-            ]
+            ],
+            "includeInToc": false
         },
         {
             "title": "Hybrid chart with bar and line",
@@ -535,7 +536,7 @@
             "includeInToc": false
         }
     ],
-    "tocOrientation": "vertical",
+    "tocOrientation": "horizontal",
     "stylesheets": ["00000000-0000-0000-0000-000000000000/styles/main.css"],
     "contextLink": "https://www.canada.ca/en/environment-climate-change/services/national-pollutant-release-inventory/tools-resources-data/exploredata.html",
     "contextLabel": "Explore National Pollutant Release Inventory data",

--- a/src/components/story/horizontal-menu.vue
+++ b/src/components/story/horizontal-menu.vue
@@ -37,7 +37,14 @@
                     }}</span>
                 </router-link>
             </li>
-            <li v-for="(slide, idx) in slides" :key="idx" :class="{ 'is-active': lastActiveIdx === slide.index }">
+            <li
+                v-for="(slide, idx) in slides"
+                :key="idx"
+                :class="{
+                    'is-active': lastActiveIdx === slide.index,
+                    separator: (!returnToTop && idx !== 0) || returnToTop
+                }"
+            >
                 <!-- using router-link causes a page refresh which breaks plugin -->
                 <a
                     class="flex items-center px-2 py-1 mx-1 cursor-pointer"
@@ -188,5 +195,19 @@ const updateActiveIdx = () => {
         background-color: var(--sr-accent-colour);
         font-weight: bold;
     }
+}
+.separator {
+    position: relative;
+}
+
+.separator::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 50%;
+    transform: translateY(-50%);
+    height: 80%;
+    width: 1px;
+    background-color: #e0e0e0;
 }
 </style>


### PR DESCRIPTION
### Related Item(s)
https://github.com/ramp4-pcar4/tcei-tmx-cwa-storylines/issues/67

### Changes
- Adds a separator between individual table of contents elements.
- Temporarily swapped the ToC orientation from vertical to horizontal for the `000` product.

### Testing
Steps:
1. Open the demo link.
2. Ensure there is a separator between table of contents elements.
3. Ensure everything is working correctly on different screen resolutions.
