### PR TITLE
Add support for teleporting areas of interest content outside RAMP

### DIFF
--- a/StoryRampSchema.json
+++ b/StoryRampSchema.json
@@ -272,6 +272,11 @@
                     "type": "string",
                     "description": "A title that is displayed centered above this map."
                 },
+                "teleportAOI": {
+                    "type": "boolean",
+                    "description": "Whether or not to teleport areas of interest outside of RAMP instance.",
+                    "default": false
+                },
                 "points": {
                     "type": "array",
                     "description": "A list of points of interest.",

--- a/public/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000_en.json
+++ b/public/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000_en.json
@@ -49,6 +49,7 @@
                     "type": "interactive-map",
                     "scrollguard": true,
                     "title": "Map Title Test",
+                    "teleportAOI": true,
                     "points": [
                         {
                             "title": "Point of Interest A",

--- a/src/components/panels/interactive-map.vue
+++ b/src/components/panels/interactive-map.vue
@@ -1,11 +1,25 @@
 <template>
-    <div ref="el" class="h-full align-middle w-full interactive-container sticky">
-        <div class="interactive-content z-50">
-            <div v-for="(point, index) in config.points" :key="`poi-` + index" class="point-of-interest-container">
-                <PointOfInterestItem :point="point" :index="index" @poi-changed="handlePoint"></PointOfInterestItem>
+    <div ref="el" class="h-full align-middle w-full">
+        <!-- if teleporting areas of interest to side of RAMP container -->
+        <div class="flex sm:flex-row flex-col h-full w-full" v-if="config.teleportAOI">
+            <div class="overflow-x-auto overflow-y-hidden sm:self-start flex-2 sticky">
+                <div :id="`ramp-map-${slideIdx}`" class="bg-gray-200 rv-map"></div>
+            </div>
+            <div class="flex-1">
+                <div v-for="(point, index) in config.points" :key="`poi-` + index" class="point-of-interest-container">
+                    <PointOfInterestItem :point="point" :index="index" @poi-changed="handlePoint"></PointOfInterestItem>
+                </div>
             </div>
         </div>
-        <div :id="`ramp-map-${slideIdx}`" class="bg-gray-200 h-story rv-map sticky interactive-content"></div>
+
+        <div class="h-full align-middle w-full interactive-container sticky" v-else>
+            <div class="interactive-content z-50">
+                <div v-for="(point, index) in config.points" :key="`poi-` + index" class="point-of-interest-container">
+                    <PointOfInterestItem :point="point" :index="index" @poi-changed="handlePoint"></PointOfInterestItem>
+                </div>
+            </div>
+            <div :id="`ramp-map-${slideIdx}`" class="bg-gray-200 h-story rv-map sticky interactive-content"></div>
+        </div>
     </div>
 </template>
 
@@ -55,7 +69,9 @@ onMounted(() => {
 
 const init = async () => {
     // Find the map component.
-    mapComponent.value = el.value.children[1];
+    mapComponent.value = props.config.teleportAOI
+        ? el.value.children[0].children[0].children[0]
+        : el.value.children[0].children[1];
 
     fetch(props.config.config).then((data) => {
         // parse JSON data

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -165,7 +165,7 @@ export interface MapPanel extends BasePanel {
     title: string;
     scrollguard: boolean;
     teleportGrid?: boolean;
-    customTemplates: String[];
+    customTemplates: string[];
 }
 
 export interface InteractiveMapPanel extends BasePanel {
@@ -174,6 +174,7 @@ export interface InteractiveMapPanel extends BasePanel {
     title: string;
     scrollguard: boolean;
     points: PointOfInterest[];
+    teleportAOI?: boolean;
 }
 
 export interface PointOfInterest {


### PR DESCRIPTION
### Related Item(s)
For https://github.com/ramp4-pcar4/tcei-tmx-cwa-storylines/issues/74

### Changes
- [FEATURE] option to teleport areas of interest items outside of RAMP instance (to the right)

### Notes
Here is what the TCEI summaries map would look like: 

![image](https://github.com/user-attachments/assets/e7d0aad4-832d-48c8-8510-d51c474bbbf3)

Note: I kept the same styling as the old point of interests that was overlayed on top of RAMP instance but open to any styling changes now that it is side-by-side. 

### Testing
Take a look at the interactive map slide on main demo page.
