### PR TITLE
Handle undefined slides

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ramp-storylines_demo-scenarios-pcar",
     "description": "A user-configurable story product featuring interactive maps, charts and dynamic multimedia content alongside text.",
-    "version": "3.2.7",
+    "version": "3.2.8",
     "private": false,
     "license": "MIT",
     "repository": "https://github.com/ramp4-pcar4/story-ramp",

--- a/src/components/story/story.vue
+++ b/src/components/story/story.vue
@@ -144,6 +144,8 @@ const fetchConfig = (uid: string, lang: string): void => {
                     // set page title
                     if (config.value) {
                         document.title = config.value.title + ' - Canada.ca';
+                        // Purge undefined slides for viewing, otherwise storyline will crash
+                        config.value.slides = config.value.slides.filter((slide) => slide && Object.keys(slide).length);
                     }
                     // add stylesheets to the page, we want this to happen ASAP
                     if (config.value.stylesheets) {

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -4,7 +4,7 @@ export interface StoryRampConfig {
     title: string;
     lang: string;
     introSlide: Intro;
-    slides: Slide[];
+    slides: (Slide | {})[];
     contextLink: string;
     contextLabel: string;
     tocOrientation: string;


### PR DESCRIPTION
### Related Item(s)
#496 
Should be used with Storylines Editor ToC PR: https://github.com/ramp4-pcar4/storylines-editor/pull/409

### Changes
- [FEATURE] Allow for undefined slides in Storylines. StoryRAMP will automatically remove these slides before displaying, to prevent crashes.

### Testing
Steps:
1. Use [these instructions](https://github.com/ramp4-pcar4/story-ramp/discussions/398) to use this new code locally.
2. Open a storylines (using the https://github.com/ramp4-pcar4/storylines-editor/pull/409 branch) with undefined slides (e.g. current version of `00000000-0000-0000-0000-000000000000`)
3. Preview the language with undefined slides (french here)
4. See that the storyline preview doesn't crash, and that the undefined slide doesn't show up.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/500)
<!-- Reviewable:end -->
