### PR TITLE
fix 'jump to section' functionality

### DIFF
--- a/StoryRampSchema.json
+++ b/StoryRampSchema.json
@@ -682,6 +682,12 @@
         "dateModified": {
             "type": "string",
             "description": "The last date that this config file was modified."
+        },
+
+        "lazyLoad": {
+            "type": "boolean",
+            "description": "If true, all images in the product will be lazy loaded.",
+            "default": true
         }
     },
 

--- a/public/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000_en.json
+++ b/public/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000_en.json
@@ -542,6 +542,7 @@
     "contextLink": "https://www.canada.ca/en/environment-climate-change/services/national-pollutant-release-inventory/tools-resources-data/exploredata.html",
     "contextLabel": "Explore National Pollutant Release Inventory data",
     "lang": "en",
+    "lazyLoad": false,
     "breadcrumbs": [
         {
             "title": "Environment and natural resources",

--- a/src/components/panels/image-panel.vue
+++ b/src/components/panels/image-panel.vue
@@ -3,7 +3,7 @@
         <fullscreen :expandable="config.fullscreen" :type="config.type">
             <img
                 ref="img"
-                :src="slideIdx > 2 ? '' : state.src"
+                :src="lazyLoad && slideIdx > 2 ? '' : state.src"
                 :class="[config.class, config.caption ? 'rounded-t-lg' : 'rounded-lg']"
                 :alt="config.altText || ''"
                 :style="{ width: `${config.width}px`, height: `${config.height}px` }"
@@ -42,6 +42,9 @@ const props = defineProps({
     },
     background: {
         type: Boolean
+    },
+    lazyLoad: {
+        type: Boolean
     }
 });
 
@@ -56,7 +59,7 @@ const observer = ref<IntersectionObserver | undefined>(undefined);
 onMounted((): void => {
     state.src = props.config.src ? props.config.src : '';
 
-    if (props.slideIdx > 2) {
+    if (props.lazyLoad && props.slideIdx > 2) {
         observer.value = new IntersectionObserver(([image]) => {
             // lazy load images
             if (image.isIntersecting) {

--- a/src/components/panels/panel.vue
+++ b/src/components/panels/panel.vue
@@ -17,6 +17,7 @@
             :lang="lang"
             :style="config.customStyles"
             :class="config.cssClasses"
+            :lazyLoad="lazyLoad"
             :background="background"
         ></component>
     </div>
@@ -55,6 +56,9 @@ const props = defineProps({
         type: String
     },
     background: {
+        type: Boolean
+    },
+    lazyLoad: {
         type: Boolean
     }
 });

--- a/src/components/story/slide.vue
+++ b/src/components/story/slide.vue
@@ -13,6 +13,7 @@
             :index="idx"
             :ratio="defaultRatio"
             :slideIdx="slideIdx"
+            :lazyLoad="lazyLoad"
             :lang="lang"
             :class="determinePanelOrder(idx)"
             :background="!!config.backgroundImage && background"
@@ -44,6 +45,9 @@ const props = defineProps({
         type: String
     },
     background: {
+        type: Boolean
+    },
+    lazyLoad: {
         type: Boolean
     }
 });

--- a/src/components/story/story-content.vue
+++ b/src/components/story/story-content.vue
@@ -46,6 +46,7 @@
                         :slideIdx="idx"
                         :lang="lang"
                         :background="hasBackground"
+                        :lazyLoad="config.lazyLoad ?? true"
                         @slide-changed="handleSlideChange"
                     ></slide>
                 </div>
@@ -107,7 +108,14 @@ onMounted(() => {
         setTimeout(() => {
             const decodedHash = decodeURIComponent(hash);
             const el = document.getElementById(decodedHash);
-            el?.scrollIntoView();
+            if (el) {
+                // Calculate the offset of the header and horizontal ToC (if applicable).
+                const offsetPosition =
+                    el?.getBoundingClientRect().top -
+                    (document.getElementById('h-navbar')?.clientHeight || 0) -
+                    (document.getElementById('story-header')?.clientHeight || 0);
+                window.scrollTo({ top: offsetPosition });
+            }
         }, 200);
     }
 

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -12,6 +12,7 @@ export interface StoryRampConfig {
     returnTop?: boolean;
     stylesheets?: string[];
     dateModified: string;
+    lazyLoad: boolean;
 }
 
 export interface ConfigFileStructure {

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -24,7 +24,10 @@ const router = createRouter({
         if (to.hash) {
             return {
                 el: decodeURIComponent(to.hash),
-                behavior: 'smooth'
+                behavior: 'smooth',
+                top:
+                    (document.getElementById('h-navbar')?.clientHeight || 0) +
+                    (document.getElementById('story-header')?.clientHeight || 0)
             };
         }
     }


### PR DESCRIPTION
### Related Item(s)
https://github.com/ramp4-pcar4/tcei-tmx-cwa-storylines/issues/80

### Changes
- Modifies the jump to section logic to consider the height of the header and horizontal table of contents (if in use) when scrolling the page to the requested section.

### Testing
`lazyLoad: false` has been added to the English `00000000-0000-0000-0000-000000000000` product.

1. Open the demo page.
2. Click on an item in the horizontal table of contents and ensure the page scrolls to the correct section.
3. Refresh the page (there should now be an anchor in the URL) and make sure the page jumps back to the correct section.
