### PR TITLE
add captions to map panels; adjust map layout to better fit titles and captions

### DIFF
--- a/StoryRampSchema.json
+++ b/StoryRampSchema.json
@@ -239,6 +239,10 @@
                     "type": "string",
                     "description": "A title that is displayed centered above this map."
                 },
+                "caption": {
+                    "type": "string",
+                    "description": "Supporting text content for the map."
+                },
                 "customTemplates": {
                     "type": "array",
                     "description": "An array of custom template names that will need to be registered on the map component.",

--- a/public/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000_en.json
+++ b/public/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000_en.json
@@ -94,12 +94,35 @@
         },
         {
             "title": "Default RAMP4 Sample",
-            "backgroundImage": "00000000-0000-0000-0000-000000000000/assets/en/GettyImages-187242601__1554821467033__w1920.jpg",
             "panel": [
                 {
-                    "config": "00000000-0000-0000-0000-000000000000/ramp-config/test-ramp4.json",
-                    "type": "map",
-                    "scrollguard": true
+                    "type": "slideshow",
+                    "items": [
+                        {
+                            "config": "00000000-0000-0000-0000-000000000000/ramp-config/test-ramp4.json",
+                            "type": "map",
+                            "scrollguard": true,
+                            "caption": "I am a map with a caption."
+                        },
+                        {
+                            "config": "00000000-0000-0000-0000-000000000000/ramp-config/test-ramp4.json",
+                            "type": "map",
+                            "scrollguard": true,
+                            "title": "I am a map with a title."
+                        },
+                        {
+                            "config": "00000000-0000-0000-0000-000000000000/ramp-config/test-ramp4.json",
+                            "type": "map",
+                            "scrollguard": true,
+                            "title": "I have a title...",
+                            "caption": "... and a caption."
+                        },
+                        {
+                            "config": "00000000-0000-0000-0000-000000000000/ramp-config/test-ramp4.json",
+                            "type": "map",
+                            "scrollguard": true
+                        }
+                    ]
                 },
                 {
                     "title": "RAMP4 Test",

--- a/src/components/panels/helpers/point-of-interest-item.vue
+++ b/src/components/panels/helpers/point-of-interest-item.vue
@@ -14,7 +14,7 @@
             </fullscreen>
 
             <div class="point-of-interest-text" :class="{ 'no-image': !point.image }" v-if="point.title || point.text">
-                <h1 class="text-xl font-bold">{{ point.title }}</h1>
+                <h1 class="text-xl font-bold" v-html="point.title"></h1>
                 <span class="prose" v-html="mdContent"></span>
             </div>
         </div>

--- a/src/components/panels/map-panel.vue
+++ b/src/components/panels/map-panel.vue
@@ -1,5 +1,9 @@
 <template>
-    <div ref="el" class="flex flex-col h-full align-middle w-full">
+    <div
+        ref="el"
+        class="flex flex-col h-full align-middle w-full"
+        :class="{ 'map-box': !isSlideshowItem && !config.teleportGrid }"
+    >
         <div
             class="px-10 mb-0 chapter-title top-20 map-title text-center"
             :class="{ 'has-background': background }"
@@ -8,26 +12,24 @@
             {{ config.title }}
         </div>
 
-        <div class="grid-teleport flex sm:flex-row flex-col w-full sm:h-story" v-if="config.teleportGrid">
+        <div class="grid-teleport flex sm:flex-row flex-col w-full min-h-0 sm:h-story" v-if="config.teleportGrid">
             <div
-                class="storylines-grid-container flex-1 min-w-0 ramp-styles"
+                class="storylines-grid-container flex-1 min-w-0 min-h-0 ramp-styles"
                 :class="{
                     'sm:order-1 order-2': config.teleportGrid === 'left',
                     'order-2': config.teleportGrid === 'right'
                 }"
                 ref="grid"
             ></div>
-            <div
-                :id="`ramp-map-${slideIdx}`"
-                class="flex-2 min-w-0 bg-gray-200"
-                :class="config.title ? 'rv-map-title' : 'rv-map'"
-            ></div>
+            <div :id="`ramp-map-${slideIdx}`" class="rv-map flex-2 min-w-0 bg-gray-200"></div>
         </div>
+        <div :id="`ramp-map-${slideIdx}`" class="rv-map w-full bg-gray-200 sm:h-story min-h-0 flex-1" v-else></div>
+
         <div
-            :id="`ramp-map-${slideIdx}`"
-            class="w-full bg-gray-200 sm:h-story h-full"
-            :class="config.title ? 'rv-map-title' : 'rv-map'"
-            v-else
+            v-if="config.caption"
+            class="text-center text-sm max-w-full map-caption"
+            v-html="md.render(config.caption)"
+            :class="{ 'caption-has-background': background }"
         ></div>
     </div>
 </template>
@@ -35,6 +37,7 @@
 <script setup lang="ts">
 import type { PropType } from 'vue';
 import { onMounted, ref } from 'vue';
+import MarkdownIt from 'markdown-it';
 import { i18n } from '@storylines/lang';
 import { createInstance } from 'ramp-pcar';
 import { ConfigFileStructure, MapPanel, TimeSliderConfig } from '@storylines/definitions';
@@ -56,6 +59,9 @@ const props = defineProps({
     },
     background: {
         type: Boolean
+    },
+    isSlideshowItem: {
+        type: Boolean
     }
 });
 
@@ -63,6 +69,7 @@ const el = ref();
 const grid = ref();
 const intersectTimeoutHandle = ref(-1);
 const mapComponent = ref<Element | undefined>(undefined);
+const md = new MarkdownIt({ html: true });
 
 onMounted(() => {
     const observer = new IntersectionObserver(
@@ -176,30 +183,32 @@ const setupMap = (config: any) => {
     }
 }
 
-@media screen and (min-width: 640px) {
-    .toc-horizontal .rv-map,
-    .toc-horizontal .storylines-grid-container {
-        height: calc(100vh - 4rem - 2.75rem) !important; // 4rem for the header, 2.75 for the horizontal ToC.
-    }
+.toc-horizontal .storylines-grid-container {
+    height: calc(100vh - 4rem - 2.75rem) !important; // 4rem for the header, 2.75 for the horizontal ToC.
+}
 
-    .toc-vertical .rv-map {
-        height: calc(100vh - 4rem) !important;
-    }
-    .toc-horizontal .rv-map-title {
-        height: calc(100vh - 9rem - 2.75rem) !important; // 9rem for the header + title, 2.75 for the horizontal ToC.
-        width: 100%;
-    }
-
-    .toc-vertical .rv-map-title {
-        height: calc(100vh - 9rem) !important;
-        width: 100%;
-    }
+.toc-horizontal .map-box {
+    height: calc(100vh - 4rem - 2.75rem);
+}
+.toc-vertical .map-box {
+    height: calc(100vh - 4rem);
 }
 
 .has-background {
     background-color: rgba(255, 255, 255, 0.95);
+    border-radius: 8px 8px 0px 0px;
     margin-bottom: 0em !important;
     padding-bottom: 1em;
+    color: black;
+}
+
+.map-caption {
+    background-color: rgba(255, 255, 255, 1);
+}
+
+.caption-has-background {
+    background-color: rgba(255, 255, 255, 0.95);
+    border-radius: 0px 0px 8px 8px;
     color: black;
 }
 
@@ -211,7 +220,6 @@ const setupMap = (config: any) => {
     margin-bottom: 1em;
     line-height: 1.3333333;
 }
-
 @media screen and (max-width: 640px) {
     .rv-map {
         max-height: 50vh;
@@ -242,6 +250,21 @@ const setupMap = (config: any) => {
         padding-top: 0.2em;
         padding-bottom: 0.2em;
         background: #fff;
+    }
+
+    .map-box {
+        height: 50vh !important; // horizontal ToC is not visible on mobile, so don't remove the extra 2.75rem height
+    }
+}
+
+@media screen and (min-width: 640px) {
+    .toc-horizontal .rv-map,
+    .toc-horizontal .storylines-grid-container {
+        height: calc(100vh - 4rem - 2.75rem) !important; // 4rem for the header, 2.75 for the horizontal ToC.
+    }
+
+    .toc-vertical .rv-map {
+        height: calc(100vh - 4rem) !important;
     }
 }
 

--- a/src/components/panels/panel.vue
+++ b/src/components/panels/panel.vue
@@ -17,6 +17,7 @@
             :lang="lang"
             :style="config.customStyles"
             :class="config.cssClasses"
+            :isSlideshowItem="isSlideshowItem"
             :lazyLoad="lazyLoad"
             :background="background"
         ></component>
@@ -60,6 +61,10 @@ const props = defineProps({
     },
     lazyLoad: {
         type: Boolean
+    },
+    isSlideshowItem: {
+        type: Boolean,
+        required: false
     }
 });
 

--- a/src/components/panels/slideshow-panel.vue
+++ b/src/components/panels/slideshow-panel.vue
@@ -19,8 +19,11 @@
                             :config="panelConfig"
                             :configFileStructure="configFileStructure"
                             :slideIdx="slideIdx"
+                            :isSlideshowItem="true"
                             class="carousel-item"
-                            :class="{ 'overflow-y-auto': panelConfig.type === 'text' }"
+                            :class="{
+                                'map-max-height': panelConfig.type === 'map'
+                            }"
                         ></panel>
                     </slide>
 
@@ -106,6 +109,13 @@ window.addEventListener('resize', () => {
     padding-top: 5px;
 }
 
+.toc-horizontal .map-max-height {
+    height: calc(100vh - 4rem - 2.75rem) !important;
+}
+.toc-vertical .map-max-height {
+    height: calc(100vh - 4rem) !important;
+}
+
 .carousel {
     height: auto;
     text-align: left;
@@ -178,9 +188,10 @@ window.addEventListener('resize', () => {
 }
 .carousel-item {
     // Max height of the carousel is 80vh, but set height to 100% to items appear in the center of the container.
-    height: 100%;
+    align-self: center;
     max-height: 80vh;
     top: 0px;
+    overflow-y: auto;
 }
 
 @media screen and (max-width: 640px) {

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -164,6 +164,7 @@ export interface MapPanel extends BasePanel {
     fullscreen?: boolean;
     timeSlider?: TimeSliderConfig;
     title: string;
+    caption: string;
     scrollguard: boolean;
     teleportGrid?: string;
     customTemplates: string[];


### PR DESCRIPTION
### Related Item(s)
#503 

### Changes
- Added the `caption` property to map panels. When provided, the caption will appear under the map as it does for images and slideshows.
- Adjusted the structure of the map panel:
  - Instead of hardcoding the map height based on whether there's a horizontal or vertical ToC, and based on whether there's a title or not, the height of the entire panel is now simply based on the ToC orientation.
  - Within the panel, the title and caption will take up as much space as required and the map will simply fill in the rest of the available space.
- Point of interest titles now support HTML
- Removed self-start property from slideshow children. Elements should now appear in the center of the slideshow component.

### Testing
Steps:
1. Open the demo page.
2. I've added a new slideshow containing 4 maps with different scenarios (just under the interactive map panel, the text panel accompanying it is titled `RAMP4 Test`). Ensure that these are rendering correctly on desktop and mobile.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/505)
<!-- Reviewable:end -->
