### PR TITLE
reset breadcrumbs when loading a new product

### DIFF
--- a/index-ca-en.html
+++ b/index-ca-en.html
@@ -69,6 +69,13 @@
             document.addEventListener('Storylines-Loaded', (payload) => {
                 const breadcrumbs = payload.detail.config.breadcrumbs ?? []; // default to an empty array if this property isn't defined.
                 const breadcrumbList = document.querySelectorAll('#wb-bc > .container > .breadcrumb')[0];
+                const firstElement = breadcrumbList.children[0]; // should be the `Canada.ca` breadcrumb.
+
+                // Reset the breadcrumb list.
+                breadcrumbList.innerHTML = ``;
+
+                // Add the `Canada.ca` element back to the list of breadcrumbs.
+                breadcrumbList.appendChild(firstElement);
 
                 // Create an HTML li element for each of the breadcrumbs to add and then append them to the breadcrumb list.
                 breadcrumbs.forEach((b) => {

--- a/index-ca-fr.html
+++ b/index-ca-fr.html
@@ -67,8 +67,15 @@
             });
 
             document.addEventListener('Storylines-Loaded', (payload) => {
-                const breadcrumbs = payload.detail.config.breadcrumbs;
+                const breadcrumbs = payload.detail.config.breadcrumbs ?? []; // default to an empty array if this property isn't defined.
                 const breadcrumbList = document.querySelectorAll('#wb-bc > .container > .breadcrumb')[0];
+                const firstElement = breadcrumbList.children[0]; // should be the `Canada.ca` breadcrumb.
+
+                // Reset the breadcrumb list.
+                breadcrumbList.innerHTML = ``;
+
+                // Add the `Canada.ca` element back to the list of breadcrumbs.
+                breadcrumbList.appendChild(firstElement);
 
                 // Create an HTML li element for each of the breadcrumbs to add and then append them to the breadcrumb list.
                 breadcrumbs.forEach((b) => {


### PR DESCRIPTION
### Related Item(s)
#509 

### Changes
- Adds a few lines of code to empty the breadcrumb list when loading a new product.

### Testing
Steps:
1. Open the demo link.
2. Ensure that breadcrumbs are loading as expected. They should appear as soon as the product loads.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/510)
<!-- Reviewable:end -->
