### PR TITLE
Allow full timeslider configuration

### DIFF
--- a/StoryRampSchema.json
+++ b/StoryRampSchema.json
@@ -250,6 +250,44 @@
                         "type": "string",
                         "description": "The name of a Vue component that will need to be registered."
                     }
+                },
+                "timeSlider": {
+                    "type": "object",
+                    "properties": {
+                        "range": {
+                            "type": "array",
+                            "description": "An array of two numbers, specifying the start and end of the slider range.",
+                            "items": {
+                                "type": "number",
+                                "description": "Values for the start and end of the range."
+                            }
+                        },
+                        "start": {
+                            "type": "array",
+                            "description": "An array of starting locations for slider handles, the number of items dictates the number of handles.",
+                            "items": {
+                                "type": "number",
+                                "description": "The starting value for a handle."
+                            }
+                        },
+                        "attribute": {
+                            "type": "string",
+                            "description": "The layer attribute that should be queried based on the slider values."
+                        },
+                        "layers": {
+                            "type": "array",
+                            "description": "An optional array of layer IDs for the slider to affect.",
+                            "items": {
+                                "type": "string",
+                                "description": "A layer ID"
+                            }
+                        },
+                        "sliderConfig": {
+                            "type": "object",
+                            "description": "A noUiSlider config object."
+                        }
+                    },
+                    "required": ["start", "range", "attribute"]
                 }
             },
             "required": ["config", "type"]

--- a/src/components/panels/helpers/time-slider/time-slider.vue
+++ b/src/components/panels/helpers/time-slider/time-slider.vue
@@ -104,7 +104,8 @@ onMounted(() => {
                 }
                 return -1;
             }
-        }
+        },
+        ...props.config.sliderConfig,
     });
 
     slider.value.on('update', () => {

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -1,4 +1,5 @@
 import JSZip from 'jszip';
+import { Options as nouiOptions } from 'nouislider';
 
 export interface StoryRampConfig {
     title: string;
@@ -199,6 +200,7 @@ export interface TimeSliderConfig {
     start: number[];
     attribute: string;
     layers?: string[];
+    sliderConfig?: nouiOptions;
 }
 
 export interface DynamicPanel extends BasePanel {


### PR DESCRIPTION
### Changes
- [FEATURE] Allow full slider configuration through `sliderConfig` object under `timeslider` in the schema
- [FIX] Add missing timeslider schema

### Testing
Nothing explicitly to test here, I did tests locally to make sure it overrides defaults properly
