### PR TITLE
Fix mismatch with ToC

### DIFF
--- a/src/components/panels/helpers/scrollama.vue
+++ b/src/components/panels/helpers/scrollama.vue
@@ -45,6 +45,7 @@ function setup() {
         const opts: any = {
             step: Array.from(rootElement.value.children),
             progress: 'step-progress' in attrs,
+            offset: 0.2,
             ...attrs
         };
 


### PR DESCRIPTION
### Related Item(s)
https://github.com/ramp4-pcar4/storylines-editor/issues/437

### Changes
- Set top position for the scroll behavior of slides such that the slides corresponding ToC icon is highlighted (rather than the subsequent icon)

### Testing
Steps:
1. Open a product with a vertical ToC
2. Scroll through the slides, and ensure that the correct ToC icon is highlighted
3. Click on the ToC icons and ensure that they are highlighted (rather than the subsequent icon)
4. Decrease the screen width and repeat steps 2-3

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/516)
<!-- Reviewable:end -->
