### PR TITLE
remove duplicate class names

### DIFF
--- a/index-ca-en.html
+++ b/index-ca-en.html
@@ -102,10 +102,6 @@
             defFooter.outerHTML = wet.builder.footer({});
         </script>
 
-        <script>
-            document.write(wet.builder.refFooter({}));
-        </script>
-
         <script type="module" src="/src/main.ts"></script>
 
         <style>

--- a/index-ca-fr.html
+++ b/index-ca-fr.html
@@ -102,10 +102,6 @@
             defFooter.outerHTML = wet.builder.footer({});
         </script>
 
-        <script>
-            document.write(wet.builder.refFooter({}));
-        </script>
-
         <script type="module" src="/src/main.ts"></script>
 
         <style>

--- a/src/app.vue
+++ b/src/app.vue
@@ -1,5 +1,5 @@
 <template>
-    <div id="app" class="storyramp-app bg-white">
+    <div class="bg-white">
         <router-view :key="$route.path"></router-view>
     </div>
 </template>


### PR DESCRIPTION
### Related Item(s)
https://github.com/ramp4-pcar4/tcei-tmx-cwa-storylines/issues/112

### Changes
- Fixes WCAG errors relating to duplicate `app` and `wb-rsz` classes. I assumed that the error would pop up for `storyramp-app` as well once we fixed `app` so I removed that duplicate as well.

### Notes

I'm not exactly sure what the difference between `wet.builder.footer({})` and `wet.builder.refFooter({})` is, but removing the latter fixed the issue with `wb-rsz` being added twice and everything still seems to work properly.

### Testing
Steps:
1. Open the demo page.
2. Ensure that these WCAG errors no longer appear.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/517)
<!-- Reviewable:end -->
