### PR TITLE
make slideshow map components full height

### DIFF
--- a/src/components/panels/slideshow-panel.vue
+++ b/src/components/panels/slideshow-panel.vue
@@ -20,10 +20,7 @@
                             :configFileStructure="configFileStructure"
                             :slideIdx="slideIdx"
                             :isSlideshowItem="true"
-                            class="carousel-item"
-                            :class="{
-                                'map-max-height': panelConfig.type === 'map'
-                            }"
+                            :class="panelConfig.type === 'map' ? 'map-carousel-item' : 'carousel-item'"
                         ></panel>
                     </slide>
 
@@ -109,13 +106,12 @@ window.addEventListener('resize', () => {
     padding-top: 5px;
 }
 
-.toc-horizontal .map-max-height {
-    height: calc(100vh - 4rem - 2.75rem) !important;
+.toc-horizontal .map-carousel-item {
+    height: calc(100vh - 4rem - 2.75rem - 2rem); // an extra 2rem is removed for the bottom navigation
 }
-.toc-vertical .map-max-height {
-    height: calc(100vh - 4rem) !important;
+.toc-vertical .map-carousel-item {
+    height: calc(100vh - 4rem - 2rem);
 }
-
 .carousel {
     height: auto;
     text-align: left;
@@ -187,7 +183,7 @@ window.addEventListener('resize', () => {
     }
 }
 .carousel-item {
-    // Max height of the carousel is 80vh, but set height to 100% to items appear in the center of the container.
+    // Max height of the carousel is 80vh, but set height to 100% so items appear in the center of the container.
     align-self: center;
     max-height: 80vh;
     top: 0px;
@@ -199,8 +195,9 @@ window.addEventListener('resize', () => {
         max-width: 100vw;
         background-color: white;
     }
-    .carousel-item {
-        max-height: 48vh;
+    .carousel-item,
+    .map-carousel-item {
+        max-height: 48vh !important;
         overflow-y: auto;
     }
     :deep(.fullscreenButton) {


### PR DESCRIPTION
### Related Item(s)
#508 

### Changes
- Map components within a slideshow panel will now take up the full screen height (whilst considering title, caption and the bottom slideshow navigation bar). 

### Notes
This should fix the problem mentioned in the original issue. It is worth noting, however, that this issue may still appear for similar maps that use a Web Mercator basemap.

From the Slack channel:

> Me: Is this expected extent behaviour? It appears that the map gets zoomed out quite a bit when you reduce the map width to ~1175px. It also only appears to happen when using a Web Mercator basemap.

![rampextent](https://github.com/user-attachments/assets/8f2021ae-c140-4331-99d8-cdf5fece7641)

Response from @james-rae:
>prooobably. You give it an extent.  ESRI then has a div of certain size, and that extent, and needs to position the map so the extent fits in the div. You're squeezing in, meaning less room for the width of the extent.  Zooming out shrinks it, so it fits. You can attempt to adjust the extent and make it snugger



### Testing
Steps:
1. Open the demo link.
2. Ensure that any maps that are contained within a slideshow take up the full height of the screen.
3. Ensure that they also respect mobile resolutions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/518)
<!-- Reviewable:end -->
