### PR TITLE
Add title to iframe video and restore interactive map hilight

### DIFF
--- a/src/components/panels/interactive-map.vue
+++ b/src/components/panels/interactive-map.vue
@@ -147,6 +147,7 @@ const handlePoint = (id: string, oid: number, layerIndex?: number) => {
             // Add the new highlight in.
             const g = await targetLayer.getGraphic(oid, { getGeom: true, getStyle: true });
             await instance.geo.map.zoomMapTo(g.geometry, 4622324.434309, true, props.config.duration || undefined);
+            await hl.addHilight(g);
         });
     });
 };

--- a/src/components/panels/video-panel.vue
+++ b/src/components/panels/video-panel.vue
@@ -9,6 +9,7 @@
         <template v-if="config.videoType === 'YouTube'">
             <iframe
                 class="media-player"
+                :title="config.title"
                 :src="config.src"
                 :height="config.height ? `${config.height}` : '500px'"
                 allowfullscreen


### PR DESCRIPTION
### Related Item(s)
https://github.com/ramp4-pcar4/tcei-tmx-cwa-storylines/issues/115

### Changes
- [FIX] add title attribute to iframe element
- [FIX] re-add hilight functionality that was removed by mistake in interactive zoomies PR 

### Testing
Inspect `iframe` element in devtools for YouTube videos and check hilight feature in interactive map slide.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/521)
<!-- Reviewable:end -->
