### PR TITLE
Add interactive-image panel

### DIFF
--- a/StoryRampSchema.json
+++ b/StoryRampSchema.json
@@ -50,6 +50,9 @@
                         "$ref": "#/$defs/dynamicPanel"
                     },
                     {
+                        "$ref": "#/$defs/interactiveImagePanel"
+                    },
+                    {
                         "$ref": "#/$defs/interactiveMapPanel"
                     }
                 ]
@@ -178,6 +181,142 @@
                 }
             },
             "required": ["id", "panel"]
+        },
+
+        "interactiveImagePanel": {
+            "type": "object",
+            "description": "An interactive image slide component.",
+            "properties": {
+                "title": {
+                    "type": "string",
+                    "description": "The title for the text panel."
+                },
+                "titleTag": {
+                    "type": "string",
+                    "description": "An optional tag to use for the panel title. If not supplied h2 is used.",
+                    "default": "h2"
+                },
+                "panels": {
+                    "type": "array",
+                    "description": "The panels to display dynamically.",
+                    "items": {
+                        "$ref": "#/$defs/dynamicChildItem"
+                    },
+                    "minItems": 1
+                },
+                "images": {
+                    "type": "array",
+                    "description": "The images to replace the original with.",
+                    "items": {
+                        "$ref": "#/$defs/interactiveImage"
+                    },
+                    "minItems": 1
+                },
+                "zones": {
+                    "type": "array",
+                    "description": "The zones of the image to make interactive.",
+                    "items": {
+                        "$ref": "#/$defs/interactiveImageZone"
+                    },
+                    "minItems": 1
+                },
+                "defaultImage": {
+                    "$ref": "#/$defs/interactiveImage"
+                },
+                "reversed": {
+                    "type": "boolean",
+                    "description": "If true, the text slide and dynamic slide will be swapped.",
+                    "default": false
+                },
+                "hideReturn": {
+                    "type": "boolean",
+                    "description": "If true, the return button will be hidden.",
+                    "default": false
+                },
+                "contentWidth": {
+                    "type": "string",
+                    "description": "If provided, the text slide width will be set to this value. Caps out at the page width on mobile mode.",
+                    "default": ""
+                },
+                "width": {
+                    "type": "number",
+                    "description": "The image width."
+                },
+                "height": {
+                    "type": "number",
+                    "description": "The image height."
+                },
+                "caption": {
+                    "type": "string",
+                    "description": "Supporting text content for the image."
+                },
+                "class": {
+                    "type": "string",
+                    "description": "Styling class properties for the image."
+                }
+            },
+            "required": ["type", "panels", "zones", "defaultImage"]
+        },
+
+        "interactiveImage": {
+            "type": "object",
+            "description": "An image used in an interactive image panel.",
+            "properties": {
+                "src": {
+                    "type": "string",
+                    "description": "The source of the image."
+                },
+                "id": {
+                    "type": "string",
+                    "description": "An identifier for the image, used by interactive zones."
+                },
+                "altText": {
+                    "type": "string",
+                    "description": "Alt text for the image."
+                }
+            },
+            "required": ["src", "id"]
+        },
+
+        "interactiveImageZone": {
+            "type": "object",
+            "description": "One zone of an interactive image.",
+            "properties": {
+                "panelId": {
+                    "type": "string",
+                    "description": "The id of the panel to display dynamically."
+                },
+                "imageId": {
+                    "type": "string",
+                    "description": "The id of the image to show on interaction."
+                },
+                "top": {
+                    "type": "string",
+                    "description": "The 'top' css style to apply to the element. Must include units, % is preferred."
+                },
+                "left": {
+                    "type": "string",
+                    "description": "The 'left' css style to apply to the element. Must include units, % is preferred."
+                },
+                "width": {
+                    "type": "string",
+                    "description": "The 'width' css style to apply to the element. Must include units, % is preferred."
+                },
+                "height": {
+                    "type": "string",
+                    "description": "The 'height' css style to apply to the element. Must include units, % is preferred."
+                },
+                "class": {
+                    "type": "string",
+                    "description": "A css class string to apply to the element"
+                },
+                "disableHover": {
+                    "type": "boolean",
+                    "description": "Whether to disable the hover interaction. Main usecase is to only show a different image on click/keyboard input.",
+                    "default": "false"
+                }
+            },
+            "required": ["panelId", "top", "left", "width", "height"]
         },
 
         "multimediaPanel": {

--- a/public/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000_en.json
+++ b/public/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000_en.json
@@ -59,6 +59,66 @@
             ]
         },
         {
+            "title": "Interactive Image",
+            "panel": [
+                {
+                    "type": "interactive-image",
+                    "defaultImage": {
+                        "id": "default",
+                        "src":"00000000-0000-0000-0000-000000000000/assets/en/GettyImages-187242601__1554821467033__w1920.jpg"
+                    },
+                    "images": [{
+                        "id": "image-1",
+                        "src": "00000000-0000-0000-0000-000000000000/assets/en/GettyImages-516166467__1554821531978__w1920.jpg"
+                    }],
+                    "panels": [
+                        {
+                            "id": "panel-1",
+                            "panel": {
+                                "title": "Hello World",
+                                "content": "I am a text panel. I am a child of the dynamic panel config. ![](00000000-0000-0000-0000-000000000000/assets/en/GettyImages-187242601__1554821467033__w1920.jpg)",
+                                "type": "text",
+                                "cssClasses": "textPanelOutline"
+                            }
+                        },
+                        {
+                            "id": "panel-2",
+                            "panel": {
+                                "src": "00000000-0000-0000-0000-000000000000/assets/en/GettyImages-187242601__1554821467033__w1920.jpg",
+                                "type": "image"
+                            }
+                        },
+                        {
+                            "id": "panel-3",
+                            "panel": {
+                                "type": "text",
+                                "title": "MORE STUFF",
+                                "content": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris rhoncus, magna in pulvinar tincidunt, magna velit feugiat sem, nec rhoncus lectus tortor quis turpis. Vivamus erat velit, feugiat at nisl lacinia, pulvinar tempus nunc. Nulla suscipit vulputate dapibus. Fusce tincidunt neque nunc, sed porta lacus elementum vitae. Suspendisse imperdiet interdum ipsum, id aliquet lectus aliquet sit amet. Aliquam erat volutpat. Nulla convallis nisl sodales nunc ullamcorper pulvinar. Nulla ornare justo id sapien porta gravida. Cras condimentum, felis id pretium malesuada, lorem lorem viverra nisi, sit amet molestie mi nulla nec velit. Integer semper lorem scelerisque tellus iaculis finibus. Aliquam efficitur sodales elit nec sodales. Sed vitae ipsum quis eros vulputate luctus."
+                            }
+                        }
+                    ],
+                    "zones": [
+                        {
+                            "panelId": "panel-2",
+                            "top": "5%",
+                            "left": "5%",
+                            "width": "25%",
+                            "height": "25%"
+                        },
+                        {
+                            "panelId": "panel-3",
+                            "imageId": "image-1",
+                            "top": "20%",
+                            "left": "80%",
+                            "width": "10%",
+                            "height": "50%"
+                        }
+                    ]
+                }
+            ],
+            "includeInToc": false
+        },
+        {
             "title": "Community Directory PowerBI Map",
             "panel": [
                 {

--- a/src/components/panels/interactive-image-panel.vue
+++ b/src/components/panels/interactive-image-panel.vue
@@ -1,0 +1,331 @@
+<template>
+    <div
+        ref="el"
+        :id="key"
+        class="story-slide w-full h-full flex flex-col"
+        :class="!!config.reversed ? 'sm:flex-row-reverse' : 'sm:flex-row'"
+    >
+        <div
+            class="sticky max-w-none min-w-0 mb-5 mx-1 py-0 sm:py-5"
+            :class="{ 'has-background': background, 'flex-1': !!config.contentWidth === false }"
+            :style="{
+                width: !isMobile ? `${config.contentWidth}` : undefined
+            }"
+        >
+            <component
+                :is="config.titleTag || 'h2'"
+                class="px-10 mb-0 chapter-title top-20"
+                :style="activeIdx !== defaultPanel.id ? 'margin-top: 0px;' : ''"
+            >
+                {{ config.title }}
+            </component>
+
+            <div class="md-content relative">
+                <img
+                    ref="img"
+                    :src="activeImage?.src || ''"
+                    :class="config.class"
+                    :alt="activeImage?.altText || ''"
+                    :style="{ width: `${config.width}px`, height: `${config.height}px` }"
+                    class="mx-auto flex object-contain sm:max-w-screen sm:max-h-screen"
+                />
+                <div 
+                    v-for="zone in config.zones" 
+                    class="absolute cursor-pointer interactive-zone" 
+                    tabindex="0" 
+                    :class="zone.class" 
+                    :style="{ width: `${zone.width}`, height: `${zone.height}`, top: `${zone.top}`, left: `${zone.left}` }" 
+                    @focusin="zoneMouseEnter(zone)" 
+                    @focusout="zoneMouseLeave(zone)" 
+                    @keypress.enter="zoneClick(zone)" 
+                    @click="zoneClick(zone)" 
+                    @mouseenter="zoneMouseEnter(zone)" 
+                    @mouseleave="zoneMouseLeave(zone)">
+                </div>
+            </div>
+        </div>
+
+        <div
+            :class="
+                activeConfig.type !== 'text'
+                    ? `top-0 sm:self-start flex-1 z-40 dynamic-content-media sm:flex-col min-w-0`
+                    : 'flex-1 dynamic-content-text'
+            "
+        >
+            <span class="return-button-container" v-if="activeIdx !== defaultPanel.id && !config.hideReturn">
+                <button
+                    class="py-1 text-base absolute"
+                    :class="!!config.reversed === false ? 'return-button right-0' : 'return-button-reversed'"
+                    @click="clickBack"
+                >
+                    <img
+                        style="display: inline; margin: 0px"
+                        src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAB4AAAAeCAYAAAA7MK6iAAAABmJLR0QA/wD/AP+gvaeTAAAB4UlEQVRIie3WP08WQRAG8J+2SolRQaLyKvR+BTsVaQnfwD9YCH4PS6I2ViAS1GhMKLWESkzUmBAT7azECoS8Fjcvqxe52zuMseBJNpebe2ae2dmdveUA/wiHGnCHcBWXcBqDYf+CT3iOp/j8t5IbwCy20a0ZO3gUie0L4/geQTcxhwmM4EiMkbDNB6eLDYy1Fb2lmEEXj3E2w2cYi9Lsp5qKjofjNm43dcZ0+O9oMPNBqbxtRHuYkcp+MsfhgVTe/WIpYt2rIw4pyrtp7zU9hlW8zhDuRKxtqf3+iJuR4VyF6FpwVjKEKdqri+tVpJdBmqgRXYv3HEyGz4sq0scgnSvZ+/Emvr3D8UxRij7v4n0VaSNIfSX7qvpTqzfKa98n7e5dHG6QeS66bZw+hOP5kr1c6hMNYo7+4reL8ozX43mhZP+Ki3gbgZblb65erPUq0o3Ibn6P723aaSH416pIp6QDZLhCfAWvMkQ72MIPNQcI3I8MFzMC1+FJxJrNIQ9IbTW9D9E7EeObBptxTPqtzbQU7flfaeo8JV0ElhTrVYeOVN4dxdnfCmNS2bcUB/6koqWOxhgN20JweuW93Fa0h37cVezMnMveQxlr2uR6Oyhdb8/4/Xq7rvj7PIv3A/w/+Am/TqGFCMnpPgAAAABJRU5ErkJggg=="
+                        :alt="$t('dynamic.back')"
+                    />
+                    {{ $t('dynamic.back') }}
+                </button>
+            </span>
+            <panel
+                class="flex-2"
+                :config="activeConfig"
+                :configFileStructure="configFileStructure"
+                :slideIdx="slideIdx"
+                :dynamicIdx="activeIdx"
+                :ratio="false"
+                :background="background"
+                ref="content"
+            >
+            </panel>
+        </div>
+    </div>
+</template>
+
+<script setup lang="ts">
+import type { PropType } from 'vue';
+import { defineAsyncComponent, getCurrentInstance, onMounted, ref } from 'vue';
+import { BasePanel, ConfigFileStructure, Image, InteractiveImagePanel, InteractiveImageZone } from '@storylines/definitions';
+
+const panel = defineAsyncComponent(() => import('./panel.vue'));
+
+const props = defineProps({
+    config: {
+        type: Object as PropType<InteractiveImagePanel>,
+        required: true
+    },
+    configFileStructure: {
+        type: Object as PropType<ConfigFileStructure>
+    },
+    slideIdx: {
+        type: Number
+    },
+    background: {
+        type: Boolean
+    }
+});
+
+const el = ref();
+const content = ref();
+
+const img = ref<Element>();
+
+// Get the ID of the first (and default) panel.
+const defaultPanel = props.config.panels[0];
+
+// By default, the active config is set to the first child in the children list.
+const activeConfig = ref<BasePanel>(defaultPanel.panel);
+const currentDefaultImage = ref<Image>(props.config.defaultImage);
+const activeImage = ref<Image | undefined>(props.slideIdx && props.slideIdx > 2 ? undefined : props.config.defaultImage);
+const activeIdx = ref(defaultPanel.id);
+const isMobile = ref(false);
+
+const key = getCurrentInstance()?.vnode.key as string;
+
+const observer = ref<IntersectionObserver | undefined>(undefined);
+
+onMounted(() => {
+    if (props.slideIdx && props.slideIdx > 2) {
+        observer.value = new IntersectionObserver(([image]) => {
+            // lazy load images
+            if (image.isIntersecting) {
+                activeImage.value = currentDefaultImage.value;
+                getCurrentInstance()?.proxy?.$forceUpdate();
+                (observer.value as IntersectionObserver).disconnect();
+            }
+        });
+    }
+
+    observer.value?.observe(img.value as Element);
+
+    // Check for a switch from normal view to mobile view. Fixed text panel width will need to be adjusted.
+    isMobile.value = window.innerWidth <= 640;
+    window.addEventListener('resize', () => {
+        isMobile.value = window.innerWidth <= 640;
+    });
+});
+
+const zoneClick = (zone: InteractiveImageZone): void => {
+    // Find the panel.
+    const panel = props.config.panels.find((el) => {
+        return zone.panelId == el.id;
+    });
+    if (zone.imageId) {
+        const image = props.config.images.find((img) => {
+            return zone.imageId = img.id;
+        });
+        if (image) {
+            activeImage.value = image;
+            currentDefaultImage.value = image;
+        }
+    }
+
+    // If the panel exists, switch the displayed panel.
+    if (panel) {
+        // Quickly reset the config so the panel component can be reset.
+        activeConfig.value = {
+            type: 'loading'
+        };
+
+        setTimeout(() => {
+            activeConfig.value = panel.panel;
+            activeIdx.value = panel.id;
+        }, 10);
+
+        setTimeout(() => {
+            const elTop = isMobile ? img.value?.getBoundingClientRect().top : content.value?.$el.getBoundingClientRect().top;
+            window.scrollTo({
+                top: window.scrollY + elTop - calculateScrollOffset(),
+                left: 0,
+                behavior: 'smooth'
+            });
+        }, 50);
+    }
+}
+
+const zoneMouseEnter = (zone: InteractiveImageZone): void => {
+    console.log(zone);
+    if (zone.disableHover) {
+        return;
+    }
+    if (zone.imageId) {
+        activeImage.value = props.config.images.find((img) => {
+            return zone.imageId = img.id;
+        }) || activeImage.value;
+    }
+}
+
+const zoneMouseLeave = (zone: InteractiveImageZone): void => {
+    if (zone.disableHover) {
+        return;
+    }
+    activeImage.value = currentDefaultImage.value;
+}
+
+// Calculate the scroll offset based on whether the table of contents is horizontal or vertical.
+const calculateScrollOffset = (): number => {
+    const isHorizontal = content.value?.$el.closest('.toc-horizontal');
+    const horizontalHeight = document.getElementById('h-navbar')?.clientHeight;
+    const headerHeight = document.getElementById('story-header')!.clientHeight;
+
+    if (isHorizontal && horizontalHeight) {
+        return headerHeight + horizontalHeight;
+    } else {
+        return headerHeight;
+    }
+};
+
+/**
+ * When clicking the back button, change the panel back to the default (first) panel.
+ */
+const clickBack = (): void => {
+    activeConfig.value = {
+        type: 'loading'
+    };
+
+    setTimeout(() => {
+        activeConfig.value = defaultPanel.panel;
+        activeIdx.value = defaultPanel.id;
+        currentDefaultImage.value = props.config.defaultImage;
+        activeImage.value = currentDefaultImage.value;
+    }, 10);
+
+    setTimeout(() => {
+        const elTop = content.value?.$el.getBoundingClientRect().top;
+        window.scrollTo({
+            top: window.scrollY + elTop - calculateScrollOffset(),
+            left: 0,
+            behavior: 'smooth'
+        });
+    }, 50);
+};
+</script>
+
+<style scoped lang="scss">
+.toc-horizontal {
+    .return-button-container {
+        top: 6.5rem;
+    }
+}
+.toc-vertical {
+    .return-button-container {
+        top: 4rem;
+    }
+    .return-button-reversed {
+        left: calc(100vw - 9rem);
+    }
+}
+
+.interactive-zone {
+    box-shadow: 2px 2px 10px black;
+}
+
+.return-button-container {
+    position: sticky;
+    text-align: right;
+    z-index: 100;
+    pointer-events: none;
+}
+.return-button {
+    float: right;
+    pointer-events: auto;
+    background: #fff;
+    box-shadow: 0px 2px 5px #000;
+    width: 75px;
+}
+.return-button-reversed {
+    float: right;
+    left: calc(100vw - 6rem);
+    pointer-events: auto;
+    background: #fff;
+    box-shadow: 0px 2px 5px #000;
+    width: 75px;
+}
+.return-button img {
+    margin: 0px;
+}
+.has-background {
+    background-color: rgba(255, 255, 255, 0.95);
+    border-radius: 8px;
+}
+
+@media screen and (max-width: 640px) {
+
+    .return-button-container {
+        position: sticky;
+        text-align: right;
+        margin-bottom: 10px;
+        top: 4rem !important;
+    }
+
+    .return-button {
+        position: sticky;
+        opacity: 0.7;
+    }
+
+    .return-button-reversed {
+        position: absolute;
+        float: right;
+        pointer-events: auto;
+        background: #fff;
+        box-shadow: 0px 2px 5px #000;
+        width: 75px;
+    }
+
+    .toc-vertical .return-button-reversed {
+        left: calc(100vw - 6rem);
+    }
+
+    .return-button:hover {
+        opacity: 1;
+    }
+
+    .dynamic-content-text {
+        display: flex;
+        flex-direction: column;
+    }
+    .dynamic-content-media {
+        display: flex;
+        flex-direction: column-reverse;
+    }
+}
+</style>

--- a/src/components/panels/panel.vue
+++ b/src/components/panels/panel.vue
@@ -32,6 +32,7 @@ import TextPanel from './text-panel.vue';
 import MapPanel from './map-panel.vue';
 import InteractiveMap from './interactive-map.vue';
 import ImagePanel from './image-panel.vue';
+import InteractiveImagePanel from './interactive-image-panel.vue';
 import AudioPanel from './audio-panel.vue';
 import VideoPanel from './video-panel.vue';
 import SlideshowPanel from './slideshow-panel.vue';
@@ -77,6 +78,7 @@ const getTemplate = (): Component => {
         [PanelType.Map]: MapPanel,
         [PanelType.InteractiveMap]: InteractiveMap,
         [PanelType.Image]: ImagePanel,
+        [PanelType.InteractiveImage]: InteractiveImagePanel,
         [PanelType.Audio]: AudioPanel,
         [PanelType.Video]: VideoPanel,
         [PanelType.Slideshow]: SlideshowPanel,

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -135,6 +135,7 @@ export interface Slide {
 export enum PanelType {
     Text = 'text',
     Image = 'image',
+    InteractiveImage = 'interactive-image',
     Map = 'map',
     InteractiveMap = 'interactive-map',
     Chart = 'chart',
@@ -221,6 +222,40 @@ export interface DynamicPanel extends BasePanel {
 export interface DynamicChildItem {
     id: string;
     panel: BasePanel;
+}
+
+export interface InteractiveImagePanel extends BasePanel {
+    type: PanelType.InteractiveImage;
+    title: string;
+    titleTag: string;
+    zones: InteractiveImageZone[];
+    panels: DynamicChildItem[];
+    images: Image[];
+    defaultImage: Image;
+    width?: number;
+    height?: number;
+    class?: string;    
+    caption?: string;
+    reversed?: boolean;
+    hideReturn?: boolean;
+    contentWidth?: string;
+}
+
+export interface InteractiveImageZone {
+    imageId?: string;
+    panelId: string;
+    class?: string;
+    top: string;
+    left: string;
+    width: string;
+    height: string;
+    disableHover?: boolean;
+}
+
+export interface Image {
+    src: string;
+    id: string;
+    altText?: string;
 }
 
 export interface ImagePanel extends BasePanel {


### PR DESCRIPTION
### Changes
- [FEATURE] Adds the `interactive-image` panel, to fix issues with the hacky implementation in a project and to make it reusable.

### Notes
A large portion of the panel file is taken from dynamic panels. The change looks large but it shouldn't be too crazy to look through.

### Testing
Steps:
1. Scroll down to the new slide
2. Hover over the left zone, see nothing change
3. Click the zone, see the right panel change like a dynamic panel
4. Hover the right zone, see a new image
3. Click and see the image stay and the right panel update

Please test in mobile, keyboard etc. Things worked for me but who knows what happens when things become a demo.
