### PR TITLE
Rename sublist dropdown class

### DIFF
--- a/src/components/story/chapter-menu.vue
+++ b/src/components/story/chapter-menu.vue
@@ -184,7 +184,7 @@
                     </toc-item>
 
                     <!-- Dropdown for sublists -->
-                    <ul v-show="isSublistToggled(idx)" class="dropdown-menu">
+                    <ul v-show="isSublistToggled(idx)" class="sublist-menu">
                         <li
                             v-for="(subItem, subIdx) in item.sublist"
                             :key="subIdx"
@@ -352,7 +352,7 @@ const updateActiveIdx = () => {
     }
 }
 
-.dropdown-menu {
+.sublist-menu {
     > li {
         font-weight: normal;
         :deep(svg) {

--- a/src/components/story/horizontal-menu.vue
+++ b/src/components/story/horizontal-menu.vue
@@ -70,7 +70,7 @@
                     </toc-item>
 
                     <!-- Dropdown for sublists -->
-                    <ul v-show="sublistToggled === idx" class="dropdown-menu">
+                    <ul v-show="sublistToggled === idx" class="sublist-menu">
                         <li
                             v-for="(subItem, subIdx) in item.sublist"
                             :key="subIdx"
@@ -189,7 +189,7 @@ const hideSublists = (): void => {
 const handleMouseClick = (event: MouseEvent): void => {
     const target = event.target as HTMLElement;
     const tocItem = target.closest('.toc-item');
-    const sublistItem = target.closest('.dropdown-menu');
+    const sublistItem = target.closest('.sublist-menu');
 
     // ignore if clicking on sublist toggle button, its svg icon or any sublist item in dropdown
     if ((tocItem && tocItem.querySelector('button')?.contains(target)) || sublistItem) {
@@ -292,7 +292,7 @@ const handleFocus = (idx: number) => {
     background-color: #e0e0e0;
 }
 
-.dropdown-menu {
+.sublist-menu {
     position: absolute;
     width: 100%;
     background-color: rgb(241, 242, 244);

--- a/src/components/story/mobile-menu.vue
+++ b/src/components/story/mobile-menu.vue
@@ -161,7 +161,7 @@
                     </toc-item>
 
                     <!-- Dropdown for sublists -->
-                    <ul v-show="isSublistToggled(idx)" class="dropdown-menu">
+                    <ul v-show="isSublistToggled(idx)" class="sublist-menu">
                         <li
                             v-for="(subItem, subIdx) in item.sublist"
                             :key="subIdx"
@@ -322,7 +322,7 @@ const updateActiveIdx = () => {
     }
 }
 
-.dropdown-menu {
+.sublist-menu {
     > li {
         font-weight: normal;
         :deep(svg) {


### PR DESCRIPTION
### Related Item(s)
#520 

### Changes
- [FIX] rename sublist dropdown menu to avoid conflict with WET styling

### Testing
Test the custom table of contents on the Canada.ca template demo pages

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/526)
<!-- Reviewable:end -->
