### PR TITLE
Fix tooltip positioning for horizontal custom ToC

### DIFF
--- a/src/components/panels/helpers/toc-item.vue
+++ b/src/components/panels/helpers/toc-item.vue
@@ -7,7 +7,7 @@
             @click="scrollToChapter(getSlideId(tocItem.slideIndex))"
             v-tippy="{
                 delay: '200',
-                placement: 'right',
+                placement: verticalToc || !parentItem ? 'right' : 'top',
                 content: getTitle(tocItem),
                 animateFill: true,
                 animation: 'chapter-menu'
@@ -43,7 +43,7 @@
             target
             v-tippy="{
                 delay: '200',
-                placement: 'right',
+                placement: verticalToc || !parentItem ? 'right' : 'top',
                 content: getTitle(tocItem),
                 animateFill: true,
                 animation: 'chapter-menu'


### PR DESCRIPTION
### Related Item(s)
#520 

### Changes
- [FIX] adjust tooltip positioning for horizontal table of contents parent items to bottom

### Testing
Test ToC tooltips - parent item labels should be positioned at top of container and sublist item labels should remain on the right.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/529)
<!-- Reviewable:end -->
