### PR TITLE
Add timeslider append mode

### DIFF
--- a/StoryRampSchema.json
+++ b/StoryRampSchema.json
@@ -421,6 +421,23 @@
                                 "description": "A layer ID"
                             }
                         },
+                        "animation": {
+                            "type": "object",
+                            "description": "Configuration for the timeslider animation/play function",
+                            "properties": {
+                                "playMode": {
+                                    "type": "string",
+                                    "description": "The mode to determine behaviour when the play button is used. By default it loops through the values one at a time.",
+                                    "default": "distinct",
+                                    "enum": ["distinct", "append"]
+                                },
+                                "interval": {
+                                    "type": "number",
+                                    "description": "The interval between steps in the animation in ms. 1400 is default.",
+                                    "default": "1400"
+                                }
+                            }
+                        },
                         "sliderConfig": {
                             "type": "object",
                             "description": "A noUiSlider config object."

--- a/public/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000_en.json
+++ b/public/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000_en.json
@@ -496,6 +496,10 @@
                     "timeSlider": {
                         "range": [2010, 2019],
                         "start": [2010, 2010],
+                        "animation": {
+                            "playMode": "append",
+                            "interval": 500
+                        },
                         "attribute": "Reporting_Year___Année"
                     },
                     "type": "map"

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -216,7 +216,16 @@ export interface TimeSliderConfig {
     start: number[];
     attribute: string;
     layers?: string[];
+    animation: {
+        playMode?: TimeSliderPlayMode;
+        interval?: number;
+    };
     sliderConfig?: nouiOptions;
+}
+
+export enum TimeSliderPlayMode {
+    Append = 'append',
+    Distinct = 'distinct'
 }
 
 export interface DynamicPanel extends BasePanel {


### PR DESCRIPTION
### Related Item(s)
https://github.com/ramp4-pcar4/tcei-tmx-cwa-storylines/issues/126

### Changes
- [FEATURE] Adds 'append' mode to timeslider and ability to configure the play mode
- [FEATURE] Interval between timeslider animation steps is configurable

### Notes
New animation config snippet example:
```json
"animation": {
    "playMode": "append",
    "interval": 500
}
```

### Testing
Steps:
1. Scroll down to the map with a timeslider
2. Press play and see only the right handle move (and faster than normal!)
3. See data show up on map but not disappear (until it loops)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/530)
<!-- Reviewable:end -->
