### PR TITLE
Fix highlighting for items not included in custom ToC

### DIFF
--- a/public/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000_en.json
+++ b/public/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000_en.json
@@ -648,101 +648,78 @@
             "slideIndex": 0,
             "sublist": [
                 {
-                    "title": "Community Directory",
+                    "title": "Interactive Content + Maps",
                     "slideIndex": 1
                 },
                 {
-                    "title": "Interactive Map",
-                    "slideIndex": 2
-                },
-                {
-                    "title": "RAMP Carousel",
-                    "slideIndex": 3
-                },
-                {
                     "title": "Dynamic Panel",
-                    "slideIndex": 4
-                },
-                {
-                    "title": "YouTube Video",
                     "slideIndex": 5
                 },
                 {
-                    "title": "Cumulative Effects Video",
+                    "title": "YouTube Video",
                     "slideIndex": 6
                 }
             ]
         },
         {
             "title": "Oil Sands Deposits",
-            "slideIndex": 7
-        },
-        {
-            "title": "Oil Sands Extraction",
-            "slideIndex": 8,
-            "sublist": []
+            "slideIndex": 8
         },
         {
             "title": "In-situ Extraction",
-            "slideIndex": 9
+            "slideIndex": 10
         },
         {
             "title": "Where are Facilities Located?",
-            "slideIndex": 10,
+            "slideIndex": 11,
             "sublist": [
                 {
                     "title": "NPRI Substances Reported for Oil Sands Mining Faciltiies",
-                    "slideIndex": 11
-                },
-                {
-                    "title": "NPRI Substances Reported for Oil Sands Mining Facilities (2)",
                     "slideIndex": 12
                 },
                 {
-                    "title": "Criteria Air Contaminant Releases From Oil Sands Mines",
+                    "title": "NPRI Substances Reported for Oil Sands Mining Facilities (2)",
                     "slideIndex": 13
                 },
                 {
-                    "title": "Reported Mine Tailings From Oil Sands Surface Mining Facilities",
+                    "title": "Criteria Air Contaminant Releases From Oil Sands Mines",
                     "slideIndex": 14
                 },
                 {
-                    "title": "Reported Mine Tailings From Oil Sands Surface Mining Facilities (2)",
+                    "title": "Reported Mine Tailings From Oil Sands Surface Mining Facilities",
                     "slideIndex": 15
                 },
                 {
-                    "title": "Trends in Mine Tailings Reported From Surface Mining Facilities",
+                    "title": "Reported Mine Tailings From Oil Sands Surface Mining Facilities (2)",
                     "slideIndex": 16
                 },
                 {
-                    "title": "Thermal in Situ Facilities",
+                    "title": "Trends in Mine Tailings Reported From Surface Mining Facilities",
                     "slideIndex": 17
                 },
                 {
-                    "title": "NPRI Releases From Thermal in-situ Faciltiies",
+                    "title": "Thermal in Situ Facilities",
                     "slideIndex": 18
+                },
+                {
+                    "title": "NPRI Releases From Thermal in-situ Faciltiies",
+                    "slideIndex": 19
                 }
             ]
         },
         {
             "title": "Highcharts Demo (╯°□°)╯︵ ┻━┻",
-            "slideIndex": 19,
+            "slideIndex": 20,
             "sublist": [
                 {
                     "title": "Dynamic Slideshow with Hybrid Chart",
-                    "slideIndex": 20
+                    "slideIndex": 21
                 }
             ]
         },
         {
             "title": "Managing Environmental Impacts",
-            "slideIndex": 21,
-            "sublist": [
-                {
-                    "title": "Last Slide",
-                    "slideIndex": 22
-                }
-            ]
+            "slideIndex": 22
         }
     ],
     "tocOrientation": "horizontal",

--- a/public/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000_fr.json
+++ b/public/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000_fr.json
@@ -342,17 +342,7 @@
         },
         {
             "title": "Extraction de sables bitumineux",
-            "slideIndex": 2,
-            "sublist": [
-                {
-                    "title": "Extraction des sables bitumineux (2)",
-                    "slideIndex": 3
-                },
-                {
-                    "title": "Où sont situées les installations?",
-                    "slideIndex": 4
-                }
-            ]
+            "slideIndex": 2
         },
         {
             "title": "Substances de l'INRP déclarées par les installations d’exploitation minière de sables bitumineux",

--- a/src/components/story/mobile-menu.vue
+++ b/src/components/story/mobile-menu.vue
@@ -126,7 +126,7 @@
                     v-for="(item, idx) in customToc"
                     :key="idx"
                     :class="{
-                        'is-active': lastActiveIdx === item.slideIndex
+                        'is-active': lastActiveIdx === item.slideIndex || isSublistActive(item.sublist)
                     }"
                 >
                     <toc-item :tocItem="item" :slides="slides" :plugin="plugin">
@@ -196,7 +196,7 @@
 <script setup lang="ts">
 import type { PropType } from 'vue';
 import { computed, ref, watch, onMounted } from 'vue';
-import { MenuItem, Slide } from '@storylines/definitions';
+import type { MenuItem, Slide } from '@storylines/definitions';
 import TocItem from '@storylines/components/panels/helpers/toc-item.vue';
 
 const props = defineProps({
@@ -240,6 +240,22 @@ const tocSlides = computed(() => {
     return slides;
 });
 
+const customTocSlides = computed(() => {
+    if (props.customToc) {
+        // for custom ToC extract slides including nested sublist items
+        let slides: MenuItem[] = [];
+        props.customToc.forEach((item) => {
+            slides.push(item);
+            if (item.sublist && item.sublist.length) {
+                item.sublist.forEach((subItem) => {
+                    slides.push(subItem);
+                });
+            }
+        });
+        return slides;
+    }
+});
+
 watch(
     () => props.activeChapterIndex,
     () => {
@@ -273,9 +289,21 @@ const isSublistToggled = (index: number): boolean => {
     return sublistToggled.value[index];
 };
 
+const isSublistActive = (sublist: MenuItem[] | undefined): boolean => {
+    if (sublist) {
+        return sublist.some(subItem => lastActiveIdx.value === subItem.slideIndex);
+    }
+    return false;
+};
+
 const updateActiveIdx = () => {
-    const prevSlides = tocSlides.value.filter((slide) => slide.index <= props.activeChapterIndex);
-    lastActiveIdx.value = prevSlides.length ? prevSlides[prevSlides.length - 1].index : -1;
+    if (props.customToc) {
+        const prevCustomSlides: MenuItem[] = customTocSlides.value!.filter((slide) => slide.slideIndex <= props.activeChapterIndex);
+        lastActiveIdx.value = prevCustomSlides.length ? prevCustomSlides[prevCustomSlides.length - 1].slideIndex : -1;
+    } else {
+        const prevSlides = tocSlides.value.filter((slide) => slide.index <= props.activeChapterIndex);
+        lastActiveIdx.value = prevSlides.length ? prevSlides[prevSlides.length - 1].index : -1;
+    }
 };
 </script>
 


### PR DESCRIPTION
### Related Item(s)
#520 

### Changes
- [FIX] show last slide highlighting for slides excluded from table of contents
- [FIX] adjust `"tableOfContents"` for test product config to align with updated slides

### Testing
Removed some slides from configuration, verify when navigating to these slides the table of contents still highlights the last section prior to the slide.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/532)
<!-- Reviewable:end -->
