### PR TITLE
Add formatter options to timeslider

### DIFF
--- a/StoryRampSchema.json
+++ b/StoryRampSchema.json
@@ -438,6 +438,20 @@
                                 }
                             }
                         },
+                        "formatters": {
+                            "anyOf": [
+                                {
+                                    "$ref": "#/$defs/timeSliderFormatter"
+                                },
+                                {
+                                    "type": "array",
+                                    "description": "An array of formatters that will take the values in the slider and make them readable.",
+                                    "items": {
+                                        "$ref": "#/$defs/timeSliderFormatter"
+                                    }
+                                }
+                            ]
+                        },
                         "sliderConfig": {
                             "type": "object",
                             "description": "A noUiSlider config object."
@@ -447,6 +461,68 @@
                 }
             },
             "required": ["config", "type"]
+        },
+
+        "timeSliderFormatter": {
+            "type": "object",
+            "description": "A formatter for use in the timeslider. Used to alias slider values into user readable versions.",
+            "oneOf": [
+                {
+                    "$ref": "#/$defs/timeSliderValuesFormatter"
+                },
+                {
+                    "$ref": "#/$defs/timeSliderRangesFormatter"
+                }
+            ]
+        },
+
+        "timeSliderValuesFormatter": {
+            "type": "object",
+            "description": "A formatter which maps slider values to the element at that index in the 'values' array.",
+            "properties": {
+                "mode": {
+                    "type": "string",
+                    "enum": ["values"]
+                },
+                "values": {
+                    "type": "array",
+                    "description": "An array of labels",
+                    "items": {
+                        "type": "string",
+                        "description": "A label for use in the timeslider"
+                    }
+                }
+            },
+            "required": ["mode", "values"]
+        },
+
+        "timeSliderRangesFormatter": {
+            "type": "object",
+            "description": "A formatter which concatenates ranges as needed.",
+            "properties": {
+                "mode": {
+                    "type": "string",
+                    "enum": ["ranges"]
+                },
+                "ranges": {
+                    "type": "array",
+                    "description": "An array of arrays of labels",
+                    "items": {
+                        "type": "array",
+                        "description": "An array of labels, ['January', 'March'] represents the full label 'January-March'",
+                        "items": {
+                            "type": "string",
+                            "description": "A partial label"
+                        }
+                    }
+                },
+                "separator": {
+                    "type": "string",
+                    "description": "A string (default '-') to join/separate the range values",
+                    "default": "-"
+                }
+            },
+            "required": ["mode", "ranges"]
         },
 
         "interactiveMapPanel": {

--- a/src/components/panels/helpers/time-slider/time-slider.vue
+++ b/src/components/panels/helpers/time-slider/time-slider.vue
@@ -31,8 +31,8 @@
             </svg>
         </button>
         <span class="my-2.5 text-base range-display"
-            ><span class="">{{ range[0] }}</span
-            ><span class="" v-if="range[1]"> - {{ range[1] }}</span></span
+            ><span class="">{{ displayFormat ? (displayFormat as any).to(parseInt(range[0]), 0) : range[0] }}</span
+            ><span class="" v-if="range[1]"> - {{ displayFormat ? (displayFormat as any).to(parseInt(range[1]), 1) : range[1] }}</span></span
         >
         <button
             class="absolute right-4 minimize-button"
@@ -63,8 +63,8 @@
 <script setup lang="ts">
 import type { PropType } from 'vue';
 import { onMounted, ref } from 'vue';
-import { TimeSliderConfig, TimeSliderPlayMode } from '@storylines/definitions';
-import noUiSlider, { type API, PipsMode } from 'nouislider';
+import { type RangeFormatter, TimeSliderPlayMode, type TimeSliderConfig, TimeSliderFormat, type TimeSliderFormatter, type ValueFormatter } from '@storylines/definitions';
+import noUiSlider, { type API, type Formatter, type Options, PipsMode } from 'nouislider';
 
 const props = defineProps({
     config: {
@@ -85,9 +85,20 @@ const slider = ref<API>();
 const range = ref<string[]>(['', '']);
 const intervalID = ref(-1);
 
+const displayFormat = ref<Formatter | undefined>();
+let internalFormat: Formatter | undefined;
+let pipsFormat: Formatter | undefined;
+
 onMounted(() => {
-    sliderElement.value = sliderTarget.value as HTMLElement;
-    slider.value = noUiSlider.create(sliderElement.value, {
+    if (props.config.formatters) {
+        if (!Array.isArray(props.config.formatters)) {
+            setUpFormatters([props.config.formatters]);
+        } else {
+            setUpFormatters(props.config.formatters);
+        }
+    }
+
+    const sliderConfig: Options = {
         start: props.config.start,
         range: {
             min: props.config.range[0],
@@ -95,6 +106,8 @@ onMounted(() => {
         },
         connect: true,
         step: 1,
+        format: internalFormat,
+        ariaFormat: pipsFormat,
         pips: {
             mode: PipsMode.Steps,
             density: 1,
@@ -106,7 +119,12 @@ onMounted(() => {
             }
         },
         ...props.config.sliderConfig
-    });
+    };
+
+    sliderConfig.pips!.format = pipsFormat;
+
+    sliderElement.value = sliderTarget.value as HTMLElement;
+    slider.value = noUiSlider.create(sliderElement.value, sliderConfig);
 
     slider.value.on('update', () => {
         const sliderValues = slider.value!.get() as string | string[];
@@ -156,7 +174,7 @@ onMounted(() => {
 /**
  * Begins looping through the values on the time slider
  */
- const startLoop = () => {
+const startLoop = () => {
     const sliderValues = slider.value!.get(true) as number | number[];
     if (Array.isArray(sliderValues)) {
         slider.value!.set(sliderValues.map(() => sliderValues[0]));
@@ -172,7 +190,7 @@ const moveHandle = () => {
     const sliderValues = slider.value!.get(true) as number | number[];
     let newValues;
     if (Array.isArray(sliderValues)) {
-        const nextMove = slider.value.steps()[sliderValues.length - 1][1]
+        const nextMove = slider.value!.steps()[sliderValues.length - 1][1]
         switch (props.config.animation?.playMode) {
             case TimeSliderPlayMode.Append:
                 // move only rightmost handle to the right
@@ -211,6 +229,53 @@ const minimizeToggle = () => {
         (el.value.parentElement as HTMLElement).classList.remove('minimized');
     }
 };
+
+const setUpFormatters = (formatters: TimeSliderFormatter[]) => {
+    // Display format
+    displayFormat.value = createFormat(formatters.find(formatter => formatter.display === true)
+                            || formatters.find(formatter => formatter.display === undefined));
+    // Internal format
+    internalFormat = createFormat(formatters.find(formatter => formatter.internal === true));
+    // Pip format
+    pipsFormat = createFormat(formatters.find(formatter =>  formatter.pips === true)
+                        || formatters.find(formatter =>  formatter.pips === undefined));
+}
+
+const createFormat = (formatter: TimeSliderFormatter | undefined): Formatter | undefined => {
+    if (formatter === undefined) {
+        return undefined;
+    }
+
+    switch (formatter.mode) {
+        case TimeSliderFormat.Values:
+            const valueFormatter = formatter as ValueFormatter;
+            return {
+                to: (val: number, index?: number) => {
+                    return valueFormatter.values[val - 1];
+                },
+                from: (val: string) => {
+                    return valueFormatter.values.indexOf(val);
+                }
+            }
+    
+        case TimeSliderFormat.Ranges:
+            const rangeFormatter = formatter as RangeFormatter;
+            return {
+                to: (val: number, index?: number) => {
+                    if (index !== undefined) {
+                        return rangeFormatter.ranges[val - 1][index]
+                    } else {
+                        return rangeFormatter.ranges[val - 1].join( rangeFormatter.separator || '-');
+                    }
+                },
+                from: (val: string) => {
+                    return rangeFormatter.ranges.indexOf(val.split( rangeFormatter.separator || '-'));
+                }
+            }
+        default:
+            return undefined;
+    }
+}
 </script>
 
 <style lang="scss">

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -221,6 +221,32 @@ export interface TimeSliderConfig {
         interval?: number;
     };
     sliderConfig?: nouiOptions;
+    formatters: TimeSliderFormatter[];
+}
+
+export interface TimeSliderFormatter {
+    mode: TimeSliderFormat;
+    internal?: boolean;
+    pips?: boolean;
+    aria?: boolean;
+    display?: boolean;
+}
+
+export interface ValueFormatter extends TimeSliderFormatter {
+    mode: TimeSliderFormat.Values;
+    values: string[];
+}
+
+export interface RangeFormatter extends TimeSliderFormatter {
+    mode: TimeSliderFormat.Ranges;
+    ranges: string[][];
+    separator?: string;
+}
+
+export enum TimeSliderFormat {
+    None = 'none',
+    Ranges = 'ranges',
+    Values = 'values'
 }
 
 export enum TimeSliderPlayMode {


### PR DESCRIPTION
### Related Item(s)
https://github.com/ramp4-pcar4/tcei-tmx-cwa-storylines/issues/121

### Changes
- [FEATURE] Adds two formatter modes to the timeslider, `values` and `ranges`
    - `values` uses the slider value as an index for the array of labels
    - `ranges` is similar but allows concatenation of ranges in the label above the slider, it also requires a 2d array

### Notes
`ranges`
![image](https://github.com/user-attachments/assets/d76a0065-f165-42c2-8526-8e5bc453e42c)

`values` 
![image](https://github.com/user-attachments/assets/357b1857-85f5-495a-b292-915db244a36d)

No formatter
![image](https://github.com/user-attachments/assets/2e6ce604-e2be-4d08-81af-2f97c190ae50)


### Testing
Steps:
1. Go to map with timeslider
2. See fancy labeling

## NOTE: I had to change the values for the slider for this test, nothing will show on the map for the affected layer. I will undo the config change before merge

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/533)
<!-- Reviewable:end -->
