### PR TITLE
Add timeslider support for date fields

### DIFF
--- a/StoryRampSchema.json
+++ b/StoryRampSchema.json
@@ -413,6 +413,11 @@
                             "type": "string",
                             "description": "The layer attribute that should be queried based on the slider values."
                         },
+                        "arcgisDate": {
+                            "type": "boolean",
+                            "description": "Whether the slider value should be converted into an arcGIS date/time format for the query",
+                            "default": "false"
+                        },
                         "layers": {
                             "type": "array",
                             "description": "An optional array of layer IDs for the slider to affect.",
@@ -468,12 +473,31 @@
             "description": "A formatter for use in the timeslider. Used to alias slider values into user readable versions.",
             "oneOf": [
                 {
+                    "$ref": "#/$defs/timeSliderDateFormatter"
+                },
+                {
                     "$ref": "#/$defs/timeSliderValuesFormatter"
                 },
                 {
                     "$ref": "#/$defs/timeSliderRangesFormatter"
                 }
             ]
+        },
+
+        "timeSliderDateFormatter": {
+            "type": "object",
+            "description": "A formatter that uses slider values as JS timestamps and converts them to readable formats",
+            "properties": {
+                "mode": {
+                    "type": "string",
+                    "enum": ["date"]
+                },
+                "format": {
+                    "type": "string",
+                    "description": "A format string describing the output of the formatter. 'Y' - year, 'M' - month, 'D' - day, 'h' - hour, 'm' - minute, 's' - second. Number of the same letter in a row is the length of the output (YY = 05, YYYY = 2025)."
+                }
+            },
+            "required": ["mode", "format"]
         },
 
         "timeSliderValuesFormatter": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "ramp-storylines_demo-scenarios-pcar",
-    "version": "3.2.8",
+    "version": "3.2.9",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "ramp-storylines_demo-scenarios-pcar",
-            "version": "3.2.8",
+            "version": "3.2.9",
             "license": "MIT",
             "dependencies": {
                 "@rollup/plugin-dsv": "^3.0.4",
@@ -21,6 +21,7 @@
                 "nouislider": "^15.5.0",
                 "ramp-pcar": "^4.10.2",
                 "scrollama": "^3.2.0",
+                "throttle-debounce": "^5.0.2",
                 "vue": "^3.4.37",
                 "vue-class-component": "^8.0.0-rc.1",
                 "vue-fullscreen": "^3.1.1",
@@ -36,6 +37,7 @@
                 "@tsconfig/node22": "^22.0.0",
                 "@types/markdown-it": "^12.0.1",
                 "@types/node": "^22.9.3",
+                "@types/throttle-debounce": "^5.0.2",
                 "@vitejs/plugin-vue": "^5.1.2",
                 "@vue/eslint-config-prettier": "^10.1.0",
                 "@vue/eslint-config-typescript": "^14.1.3",
@@ -1462,6 +1464,13 @@
             "version": "1.15.8",
             "resolved": "https://registry.npmjs.org/@types/sortablejs/-/sortablejs-1.15.8.tgz",
             "integrity": "sha512-b79830lW+RZfwaztgs1aVPgbasJ8e7AXtZYHTELNXZPsERt4ymJdjV4OccDbHQAvHrCcFpbF78jkm0R6h/pZVg==",
+            "license": "MIT"
+        },
+        "node_modules/@types/throttle-debounce": {
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/@types/throttle-debounce/-/throttle-debounce-5.0.2.tgz",
+            "integrity": "sha512-pDzSNulqooSKvSNcksnV72nk8p7gRqN8As71Sp28nov1IgmPKWbOEIwAWvBME5pPTtaXJAvG3O4oc76HlQ4kqQ==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/trusted-types": {
@@ -5901,6 +5910,15 @@
                 "node": "=22.12.0"
             }
         },
+        "node_modules/ramp-pcar/node_modules/throttle-debounce": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-3.0.1.tgz",
+            "integrity": "sha512-dTEWWNu6JmeVXY0ZYoPuH5cRIwc0MeGbJwah9KUNYSJwommQpCzTySTpEe8Gs1J23aeWEuAobe4Ag7EHVt/LOg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/rbush": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/rbush/-/rbush-4.0.1.tgz",
@@ -6713,11 +6731,12 @@
             "integrity": "sha512-/DZ1XJqhbqRkCop6s9ZFu8JrFRwmVuHg4quIRm+ziFkR3N3ec6ck6yBvJ1GYeEQZhLVwRW0rZE+C3SSJpy0RTg=="
         },
         "node_modules/throttle-debounce": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-3.0.1.tgz",
-            "integrity": "sha512-dTEWWNu6JmeVXY0ZYoPuH5cRIwc0MeGbJwah9KUNYSJwommQpCzTySTpEe8Gs1J23aeWEuAobe4Ag7EHVt/LOg==",
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-5.0.2.tgz",
+            "integrity": "sha512-B71/4oyj61iNH0KeCamLuE2rmKuTO5byTOSVwECM5FA7TiAiAW+UqTKZ9ERueC4qvgSttUhdmq1mXC3kJqGX7A==",
+            "license": "MIT",
             "engines": {
-                "node": ">=10"
+                "node": ">=12.22"
             }
         },
         "node_modules/timezone-groups": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
         "nouislider": "^15.5.0",
         "ramp-pcar": "^4.10.2",
         "scrollama": "^3.2.0",
+        "throttle-debounce": "^5.0.2",
         "vue": "^3.4.37",
         "vue-class-component": "^8.0.0-rc.1",
         "vue-fullscreen": "^3.1.1",
@@ -47,8 +48,9 @@
     },
     "devDependencies": {
         "@tsconfig/node22": "^22.0.0",
-        "@types/node": "^22.9.3",
         "@types/markdown-it": "^12.0.1",
+        "@types/node": "^22.9.3",
+        "@types/throttle-debounce": "^5.0.2",
         "@vitejs/plugin-vue": "^5.1.2",
         "@vue/eslint-config-prettier": "^10.1.0",
         "@vue/eslint-config-typescript": "^14.1.3",

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -215,6 +215,7 @@ export interface TimeSliderConfig {
     range: number[];
     start: number[];
     attribute: string;
+    arcgisDate?: boolean;
     layers?: string[];
     animation: {
         playMode?: TimeSliderPlayMode;
@@ -243,8 +244,14 @@ export interface RangeFormatter extends TimeSliderFormatter {
     separator?: string;
 }
 
+export interface DateFormatter extends TimeSliderFormatter {
+    mode: TimeSliderFormat.Date;
+    format: string;
+}
+
 export enum TimeSliderFormat {
     None = 'none',
+    Date = 'date',
     Ranges = 'ranges',
     Values = 'values'
 }

--- a/src/lang/lang.csv
+++ b/src/lang/lang.csv
@@ -26,3 +26,15 @@ chart.downloadSVG,Download SVG,1,Télécharger SVG,1
 chart.downloadCSV,Download CSV,1,Télécharger CSV,1
 chart.downloadXLS,Download XLS,1,Télécharger XLS,1
 chart.viewData,View data table,1,Afficher le tableau de données,1
+month.jan,January,1,Janvier,1
+month.feb,February,1,Février,1
+month.mar,March,1,Mars,1
+month.apr,April,1,Avril,1
+month.may,May,1,Mai,1
+month.jun,June,1,Juin,1
+month.jul,July,1,Juillet,1
+month.aug,August,1,Août,1
+month.sep,September,1,Septembre,1
+month.oct,October,1,Octobre,1
+month.nov,November,1,Novembre,1
+month.dec,December,1,Décembre,1


### PR DESCRIPTION
### Related Item(s)
https://github.com/ramp4-pcar4/tcei-tmx-cwa-storylines/issues/121

### Changes
- [FEATURE] add `date` formatter option to timeslider
- [FEATURE] add `arcgisDate` option to timeslider to convert slider value to arcgis format for queries

### Notes
- `date` formatter
    - treats the slider values as "epoch time" timestamps and converts that to readable dates. 
    - format is specified in config as string an example: "YYYY/M/DD" outputs something like "2025/01/17" 
      - Y for year, M for month, D for day, h for hour, m for minute, s for seconds. Number of the letter = length of output (except for month). if YYYY is 2025 then YY would be 25
- arcgis date queries
  - arcgis stores date fields with epoch time but is not queryable with them. `arcgisDate` option flags for conversion to arcgis format eg: `TIMESTAMP '2025-01-17 00:00:00'`
- adds a debounce to the slider update so that layer redraws aren't spammed if someone is dragging though many values

### Testing
Steps:
1. Open testing page and scroll to timeslider map
2. See fancy date formats

Like the other formatting PR the layer doesnt match with any of these values so expect nothing on the map. I tested the actual querying thoroughly with project specific layers.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/534)
<!-- Reviewable:end -->
