### PR TITLE
fix empty background image property behaving incorrectly

### DIFF
--- a/src/components/story/story-content.vue
+++ b/src/components/story/story-content.vue
@@ -125,7 +125,7 @@ onMounted(() => {
 
 const handleSlideChange = (event: number): void => {
     const img = (props.config.slides[event] as Slide).backgroundImage;
-    backgroundImage.value = img ? img : 'none';
+    backgroundImage.value = !!img ? img : 'none';
     const cssClasses = (props.config.slides[event] as Slide).bgCssClasses;
     backgroundCss.value = cssClasses ? cssClasses : '';
 };


### PR DESCRIPTION
### Related Item(s)
#490 

### Changes
- Fixes an issue where background images would behave strangely if some slides assign the empty string to the backgroundImage property.

### Testing
This fix worked in the past so it shouldn't need any extensive testing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/536)
<!-- Reviewable:end -->
