### PR TITLE
ensure map is focused before teleported grid

### DIFF
--- a/src/components/panels/map-panel.vue
+++ b/src/components/panels/map-panel.vue
@@ -14,14 +14,22 @@
 
         <div class="grid-teleport flex sm:flex-row flex-col w-full min-h-0 sm:h-story" v-if="config.teleportGrid">
             <div
-                class="storylines-grid-container flex-1 min-w-0 min-h-0 ramp-styles"
-                :class="{
-                    'sm:order-1 order-2': config.teleportGrid === 'left',
-                    'order-2': config.teleportGrid === 'right'
-                }"
+                v-if="config.teleportGrid === 'left'"
+                class="storylines-grid-container flex-1 min-w-0 min-h-0 ramp-styles order-2"
                 ref="grid"
             ></div>
-            <div :id="`ramp-map-${slideIdx}`" class="rv-map flex-2 min-w-0 bg-gray-200"></div>
+            <div
+                :id="`ramp-map-${slideIdx}`"
+                class="rv-map flex-2 min-w-0 bg-gray-200"
+                :class="{
+                    'sm:order-2 order-1': config.teleportGrid === 'left'
+                }"
+            ></div>
+            <div
+                v-if="config.teleportGrid === 'right'"
+                class="storylines-grid-container flex-1 min-w-0 min-h-0 ramp-styles"
+                ref="grid"
+            ></div>
         </div>
         <div :id="`ramp-map-${slideIdx}`" class="rv-map w-full bg-gray-200 sm:h-story min-h-0 flex-1" v-else></div>
 
@@ -92,10 +100,13 @@ onMounted(() => {
 
 const init = async () => {
     // Find the correct map component based on whether there's a title component.
-    if (props.config.title) {
-        mapComponent.value = props.config.teleportGrid ? el.value.children[1].children[1] : el.value.children[1];
+    const mapIndex = !!props.config.title ? 1 : 0;
+    if (props.config.teleportGrid === 'left') {
+        mapComponent.value = el.value.children[mapIndex].children[1];
+    } else if (props.config.teleportGrid === 'right') {
+        mapComponent.value = el.value.children[mapIndex].children[0];
     } else {
-        mapComponent.value = props.config.teleportGrid ? el.value.children[0].children[1] : el.value.children[0];
+        mapComponent.value = el.value.children[mapIndex];
     }
 
     // If the configFileStructure object is provided (editor preview mode), grab the config from there.


### PR DESCRIPTION
### Related Item(s)
https://github.com/ramp4-pcar4/tcei-tmx-cwa-storylines/issues/190

### Changes
- Modified the order of the map component and the teleport container in the map panel. This should ensure that the map is focused before the teleported panel is.

### Notes
While this now ensures that the map is focused prior to the grid when the grid is teleported to the right of the map, we will now have the same issue pop up if the grid is teleported to the left of the map. 

It doesn't seem like there's a great solution for this. Adding `tabindex` conditionally makes the focus jump all over the place. I could potentially duplicate the `div` with the `grid-teleport`  class and swap the elements depending on whether the grid is teleported to the left or right, but that adds a bunch of unnecessary duplication to the code. 

### Testing
Steps:
1. Open the demo page.
2. Tab through the `000` product until you get to the first map slide (should the third slide down from the top)
3. Ensure that the map is focused before the teleported grid.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/540)
<!-- Reviewable:end -->
