### PR TITLE
fix focus issue when tabbing through slideshow

### DIFF
--- a/src/components/panels/slideshow-panel.vue
+++ b/src/components/panels/slideshow-panel.vue
@@ -15,13 +15,19 @@
                     :touchDrag="false"
                 >
                     <slide v-for="(panelConfig, index) in config.items" :key="index" :index="index">
-                        <panel
-                            :config="panelConfig"
-                            :configFileStructure="configFileStructure"
-                            :slideIdx="slideIdx"
-                            :isSlideshowItem="true"
-                            :class="panelConfig.type === 'map' ? 'map-carousel-item' : 'carousel-item'"
-                        ></panel>
+                        <template #default="{ isActive }">
+                            <panel
+                                :config="panelConfig"
+                                :configFileStructure="configFileStructure"
+                                :slideIdx="slideIdx"
+                                :isSlideshowItem="true"
+                                :class="{
+                                    'map-carousel-item': panelConfig.type === 'map',
+                                    'carousel-item': panelConfig.type !== 'map',
+                                    hidden: !isActive
+                                }"
+                            ></panel>
+                        </template>
                     </slide>
 
                     <template #addons>


### PR DESCRIPTION
### Related Item(s)
https://github.com/ramp4-pcar4/tcei-tmx-cwa-storylines/issues/191

### Changes
- Adds the `hidden` class to panels that are not currently active in the slideshow. This should prevent the user from being able to tab to them and forces them to use the navigation buttons.

### Testing
Steps:
1. Open the demo page.
2. Scroll down to a slideshow that contains multiple maps.
3. Navigate through the slideshow using tab. Ensure that continuously pressing tab doesn't switch between slides.
