### PR TITLE
Add new types to schema and definitions, Update version

### DIFF
--- a/StoryRampSchema.json
+++ b/StoryRampSchema.json
@@ -805,7 +805,7 @@
                 },
                 "type": {
                     "type": "string",
-                    "enum": ["slideshow"]
+                    "enum": ["slideshow", "slideshowImage", "slideshowChart"]
                 }
             },
             "required": ["items", "type"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "ramp-storylines_demo-scenarios-pcar",
-    "version": "3.2.9",
+    "version": "3.2.11",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "ramp-storylines_demo-scenarios-pcar",
-            "version": "3.2.9",
+            "version": "3.2.11",
             "license": "MIT",
             "dependencies": {
                 "@rollup/plugin-dsv": "^3.0.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ramp-storylines_demo-scenarios-pcar",
     "description": "A user-configurable story product featuring interactive maps, charts and dynamic multimedia content alongside text.",
-    "version": "3.2.9",
+    "version": "3.2.11",
     "private": false,
     "license": "MIT",
     "type": "module",
@@ -16,8 +16,8 @@
         "lint": "eslint . --fix",
         "format": "prettier --write src/"
     },
-    "main": "./dist/storylines-viewer.umd.js",
-    "module": "./dist/storylines-viewer.mjs",
+    "main": "./dist/storylines-viewer.umd.cjs",
+    "module": "./dist/storylines-viewer.js",
     "files": [
         "dist"
     ],

--- a/src/components/panels/panel.vue
+++ b/src/components/panels/panel.vue
@@ -82,6 +82,8 @@ const getTemplate = (): Component => {
         [PanelType.Audio]: AudioPanel,
         [PanelType.Video]: VideoPanel,
         [PanelType.Slideshow]: SlideshowPanel,
+        [PanelType.SlideshowImage]: SlideshowPanel,
+        [PanelType.SlideshowChart]: SlideshowPanel,
         [PanelType.Chart]: ChartPanel,
         [PanelType.Dynamic]: DynamicPanel,
         [PanelType.Loading]: LoadingPanel

--- a/src/components/story/story-content.vue
+++ b/src/components/story/story-content.vue
@@ -199,7 +199,9 @@ const addPanelPadding = (idx: number): string => {
         width: 1px;
         left: 0;
         // modified tailwind shadow
-        box-shadow: -3px 0px 6px 0px rgba(0, 0, 0, 0.1), -2px 0 4px 0px rgba(0, 0, 0, 0.06);
+        box-shadow:
+            -3px 0px 6px 0px rgba(0, 0, 0, 0.1),
+            -2px 0 4px 0px rgba(0, 0, 0, 0.06);
     }
 
     // above
@@ -210,7 +212,9 @@ const addPanelPadding = (idx: number): string => {
         height: 1px;
         top: 0;
         // modified tailwind shadow
-        box-shadow: 0 -3px 6px 0px rgba(0, 0, 0, 0.1), 0 -2px 4px 0px rgba(0, 0, 0, 0.06);
+        box-shadow:
+            0 -3px 6px 0px rgba(0, 0, 0, 0.1),
+            0 -2px 4px 0px rgba(0, 0, 0, 0.06);
     }
 
     // below
@@ -220,7 +224,9 @@ const addPanelPadding = (idx: number): string => {
         //width: 100%;
         height: 1px;
         bottom: 0;
-        box-shadow: 0 3px 6px 0px rgba(0, 0, 0, 0.1), 0 2px 4px 0px rgba(0, 0, 0, 0.06);
+        box-shadow:
+            0 3px 6px 0px rgba(0, 0, 0, 0.1),
+            0 2px 4px 0px rgba(0, 0, 0, 0.06);
     }
 }
 .top-menu {

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -154,6 +154,8 @@ export enum PanelType {
     Video = 'video',
     Audio = 'audio',
     Slideshow = 'slideshow',
+    SlideshowImage = 'slideshowImage',
+    SlideshowChart = 'slideshowChart',
     Dynamic = 'dynamic',
     Loading = 'loading'
 }
@@ -288,7 +290,7 @@ export interface InteractiveImagePanel extends BasePanel {
     defaultImage: Image;
     width?: number;
     height?: number;
-    class?: string;    
+    class?: string;
     caption?: string;
     reversed?: boolean;
     hideReturn?: boolean;
@@ -345,6 +347,20 @@ export interface AudioPanel extends BasePanel {
 export interface SlideshowPanel extends BasePanel {
     type: PanelType.Slideshow;
     items: Array<ChartPanel | TextPanel | ImagePanel | MapPanel>;
+    loop?: boolean;
+    caption?: string;
+}
+
+export interface SlideshowImagePanel extends BasePanel {
+    type: PanelType.SlideshowImage;
+    items: Array<ImagePanel>;
+    loop?: boolean;
+    caption?: string;
+}
+
+export interface SlideshowChartPanel extends BasePanel {
+    type: PanelType.SlideshowChart;
+    items: Array<ChartPanel>;
     loop?: boolean;
     caption?: string;
 }


### PR DESCRIPTION
### Related Item(s)
https://github.com/ramp4-pcar4/storylines-editor/issues/491

### Changes
- Fixed `dist` file names in `package.json`
- Updated version (and pushed to npm registry)
- Added two new interfaces: `SlideshowImagePanel` and `SlideshowChartPanel`. Also added two new panel types: `slideshowImage` and `slideshowChart` 
  - These are the same as regular slideshow panels, except that their `items` are restricted to `ImagePanel`'s and `ChartPanel`'s
  - Also updated the schema for `multimediaSlideshow`

### Notes
- The addition of the two new types/interfaces has not yet been published to npm. Once this PR is finalized and merged I can publish a new version

### Testing
Steps:
1. Create a new panel of type `slideshowImage`
2. Add a few images to the panel (treat it exactly as a regular `slideshow` panel)
3. Load in the product, and observe that the panel is displayed exactly as a regular `slideshow` panel
4. Repeat this process for a panel of type `slideshowChart`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/546)
<!-- Reviewable:end -->
