### PR TITLE
Add support for video autoplay

### DIFF
--- a/StorylinesSchema.json
+++ b/StorylinesSchema.json
@@ -743,6 +743,11 @@
                     "type": "string",
                     "description": "Overlaying subtitles on the video, input should be a .vtt file."
                 },
+                "autoplay": {
+                    "type": "boolean",
+                    "description": "Whether the video should autoplay when the video element is created.",
+                    "default": false
+                },
                 "type": {
                     "type": "string",
                     "enum": ["video"]

--- a/public/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000_en.json
+++ b/public/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000_en.json
@@ -319,7 +319,8 @@
                                 "title": "Overtime job",
                                 "videoType": "external",
                                 "caption": "00000000-0000-0000-0000-000000000000/assets/en/video1-en.mp4.vtt",
-                                "src": "https://wet-boew.github.io/wet-boew-attachments/videos/video1-en.mp4"
+                                "src": "https://wet-boew.github.io/wet-boew-attachments/videos/video1-en.mp4",
+                                "autoplay": true
                             }
                         },
                         {
@@ -361,11 +362,13 @@
             "panel": [
                 {
                     "type": "video",
-                    "title": "What are cumulative effects?",
-                    "videoType": "YouTube",
-                    "src": "https://www.youtube.com/embed/4kTq-hnrMHI",
-                    "width": "60%",
-                    "transcript": "00000000-0000-0000-0000-000000000000/assets/en/cumulative-effects.md"
+                    "title": "Overtime job",
+                    "videoType": "local",
+                    "src": "00000000-0000-0000-0000-000000000000/assets/en/video1-en.mp4",
+                    "caption": "00000000-0000-0000-0000-000000000000/assets/en/video1-en.mp4.vtt",
+                    "transcript": "00000000-0000-0000-0000-000000000000/assets/en/cpts-lg-en.html",
+                    "width": "85%",
+                    "autoplay": true
                 }
             ],
             "includeInToc": false

--- a/src/components/panels/video-panel.vue
+++ b/src/components/panels/video-panel.vue
@@ -25,6 +25,8 @@
                 :title="config.title"
                 :height="config.height ? `${config.height}` : '500px'"
                 :poster="config.thumbnailUrl"
+                :autoplay="config.autoplay"
+                :muted="config.autoplay"
                 controls
             >
                 <source v-if="!videoBlobSrc" :type="fileType" :src="videoBlobSrc ? videoBlobSrc : config.src" />

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -337,6 +337,7 @@ export interface VideoPanel extends BasePanel {
     width?: number;
     height?: number;
     caption?: string;
+    autoplay?: boolean;
 }
 
 export interface AudioPanel extends BasePanel {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -5,5 +5,6 @@ declare module '@vue/runtime-core' {
     interface ComponentCustomProperties {
         $papa: VuePapaParse;
         $route: RouteLocationNormalized;
+        $t: (key: string, ...args: any[]) => string;
     }
 }


### PR DESCRIPTION
### Related Item(s)
https://github.com/ramp4-pcar4/custom-projects/issues/250

### Changes
- [FEATURE] add config option for enabling video autoplay (non-YT videos)

### Notes
For any video element with autoplay enabled, I had to disable sound (muted) to avoid accessibility issues. 

### Testing
Check slides with video autoplay enabled

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/story-ramp/554)
<!-- Reviewable:end -->
