### PR TITLE
Correct tooltip locations for vertical and horizontal configs

### DIFF
--- a/src/components/story/chapter-menu.vue
+++ b/src/components/story/chapter-menu.vue
@@ -7,16 +7,18 @@
             <button
                 class="flex items-center flex-shrink-0 px-2 py-1 mx-1 overflow-hidden"
                 :aria-label="$t('chapters.menu')"
+                :tabindex="isMenuOpen ? 0 : -1"
                 @click="isMenuOpen = !isMenuOpen"
-                v-tippy="{
-                    delay: '200',
-                    placement: 'right',
-                    content: $t('chapters.title'),
-                    onShow: () => !isMenuOpen,
-                    animateFill: true
-                }"
             >
                 <svg
+                    v-tippy="{
+                        delay: 200,
+                        placement: 'right',
+                        content: $t('chapters.title'),
+                        onShow: () => !isMenuOpen,
+                        animateFill: true,
+                        animation: 'chapter-menu'
+                    }"
                     class="flex-shrink-0"
                     width="24"
                     height="24"

--- a/src/components/story/horizontal-menu.vue
+++ b/src/components/story/horizontal-menu.vue
@@ -25,7 +25,7 @@
                     target
                     v-tippy="{
                         delay: '200',
-                        placement: 'bottom',
+                        placement: 'top',
                         content: $t('chapters.return'),
                         animateFill: true,
                         animation: 'chapter-menu'


### PR DESCRIPTION
### Related Item(s)
Issue #572 

### Changes
Vertical ToC: tooltip for chapters is moved next to the button rather than far away
Horizontal ToC: tooltip for return to top now shows above the button like all the other tooltips

### Testing
Steps:
1. On vertical config: hover over chapters hamburger button
2. Notice tooltip displaying next to the button
3. Switch to horizontal config
4. Hover over return to top button
5. Notice tooltip displaying above the button

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines/574)
<!-- Reviewable:end -->
