### PR TITLE
Sanitize content of text panels

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,19 @@
 {
     "name": "ramp-storylines_demo-scenarios-pcar",
-    "version": "3.3.0",
+    "version": "3.4.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "ramp-storylines_demo-scenarios-pcar",
-            "version": "3.3.0",
+            "version": "3.4.1",
             "license": "MIT",
             "dependencies": {
                 "@rollup/plugin-dsv": "^3.0.4",
                 "@tailwindcss/typography": "^0.4.0",
                 "@types/highcharts": "^7.0.0",
                 "core-js": "^3.6.5",
+                "dompurify": "^3.2.6",
                 "highcharts": "^9.3.2",
                 "highcharts-vue": "^1.4.3",
                 "intersection-observer": "^0.12.2",
@@ -3233,6 +3234,15 @@
             "optional": true,
             "engines": {
                 "node": ">=12"
+            }
+        },
+        "node_modules/dompurify": {
+            "version": "3.2.6",
+            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
+            "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
+            "license": "(MPL-2.0 OR Apache-2.0)",
+            "optionalDependencies": {
+                "@types/trusted-types": "^2.0.7"
             }
         },
         "node_modules/earcut": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
         "@tailwindcss/typography": "^0.4.0",
         "@types/highcharts": "^7.0.0",
         "core-js": "^3.6.5",
+        "dompurify": "^3.2.6",
         "highcharts": "^9.3.2",
         "highcharts-vue": "^1.4.3",
         "intersection-observer": "^0.12.2",

--- a/src/components/panels/text-panel.vue
+++ b/src/components/panels/text-panel.vue
@@ -19,6 +19,7 @@ import type { TextPanel } from '@storylines/definitions';
 
 import MarkdownIt from 'markdown-it';
 import Scrollama from './helpers/scrollama.vue';
+import DOMPurify from 'dompurify';
 
 const TextContent = defineAsyncComponent(() => import('./helpers/text-content.vue'));
 
@@ -39,8 +40,15 @@ onMounted((): void => {
     mdContent.value = md
         .render(props.config.content)
         .replace(/<table/g, '<div class="table-container"><table')
-        .replace(/<\/table>/g, '</table></div>');
+        .replace(/<\/table>/g, '</table></div>')
+        .replace(/<form>/g, '&lt;form&gt;')
+        .replace(/<\/form>/g, '&lt;/form&gt;');
 
+    mdContent.value = DOMPurify.sanitize(mdContent.value, {
+        ADD_TAGS: ['AudioPlayer'],
+        ADD_ATTR: ['transcript']
+    }).replaceAll('audioplayer', 'AudioPlayer');
+    console.log(DOMPurify.removed);
     document
         .querySelectorAll('.storyramp-app a:not([target])')
         .forEach((el: Element) => ((el as HTMLAnchorElement).target = '_blank'));


### PR DESCRIPTION
### Related Item(s)
#519

### Changes
- Sanitized the content of text panels prior to formatting it as markdown (see `text-panel` component)
  - Used the DOMPurify library: https://github.com/cure53/DOMPurify

### Testing
Should probably test this locally

Steps:
1. Within the 000.. products config try to add an external js script
   - Can try `<script>`,  `<iframe>`, `<form>`,  `<component>`, `<a>`, `<img>` , `<video>`, `<embed>`, elements with event handlers, `<meta>`, `<object>`,  `<applet>`, `<link>`, `<base>`, `<picture>`,  `<audio>`, `<source>`, `<track>`, `<svg>`, `<math>`, `<template>`, `<details>`, `<summary>`, `<dialog>`, `<bgsound>`, `<isindex>`, `<frame>`, `<frameset>`, `<noframes>`, `<noscript>`
   - Can ask chatGPT for suggestions, as there are quite a lot of possibilities
2. Ensure that none of the external scripts get executed

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines/577)
<!-- Reviewable:end -->
