### PR TITLE
Added minimum size for slides so that the ToC won't be misaligned

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ramp-storylines_demo-scenarios-pcar",
     "description": "A user-configurable story product featuring interactive maps, charts and dynamic multimedia content alongside text.",
-    "version": "3.5.1",
+    "version": "3.5.3",
     "private": false,
     "license": "MIT",
     "type": "module",

--- a/src/components/panels/image-panel.vue
+++ b/src/components/panels/image-panel.vue
@@ -6,7 +6,7 @@
                 :src="lazyLoad && slideIdx > 2 ? '' : state.src"
                 :class="[config.class, config.caption ? 'rounded-t-lg' : 'rounded-lg']"
                 :alt="config.altText || ''"
-                :style="{ width: `${config.width}px`, height: `${config.height}px` }"
+                :style="{ width: `${config.width}px`, height: `${config.height}px`}"
                 class="graphic-image mx-auto flex object-contain sm:max-w-screen sm:max-h-screen"
             />
         </fullscreen>

--- a/src/components/panels/text-panel.vue
+++ b/src/components/panels/text-panel.vue
@@ -2,7 +2,7 @@
     <scrollama
         class="text-panel prose max-w-none mb-5 mx-1 py-5"
         :class="{ 'has-background': background }"
-        :style="{ color: config.textColour ?? '#000' }"
+        :style="{ color: config.textColour ?? '#000'}"
     >
         <component v-if="config.title" :is="config.titleTag || 'h2'" class="px-10 mb-0 chapter-title top-20">
             {{ config.title }}

--- a/src/components/story/story-content.vue
+++ b/src/components/story/story-content.vue
@@ -44,6 +44,7 @@
                     :data-chapter-index="idx"
                     :id="`${idx}-${slide.title.toLowerCase().replaceAll(' ', '-')}`"
                     :name="`${idx}-${slide.title.toLowerCase().replaceAll(' ', '-')}`"
+                    :ref="idx === config.slides.length - 1 ? setLastSlideHeight : null"
                 >
                     <storylines-slide
                         :config="slide"
@@ -76,7 +77,7 @@ import StorylinesSlide from './slide.vue';
 import Scrollama from '@storylines/components/panels/helpers/scrollama.vue';
 
 const route = useRoute();
-const emit = defineEmits(['step']);
+const emit = defineEmits(['step', 'last-slide-height']);
 
 const props = defineProps({
     config: {
@@ -145,6 +146,12 @@ onMounted(() => {
     // as you scroll down.
     handleSlideChange(0);
 });
+
+const setLastSlideHeight = (element: HTMLElement | null) => {
+    if (element) {
+        emit('last-slide-height', element.offsetHeight);
+    }
+};
 
 // Determines whether the slide corresponding to the provided index
 const slideInRange = (index) => {

--- a/src/components/story/story.vue
+++ b/src/components/story/story.vue
@@ -60,6 +60,7 @@
                     :headerHeight="headerHeight"
                     @step="updateActiveIndex"
                     :targetIndex="targetIndex"
+                    @last-slide-height="handleLastSlideHeight"
                 />
             </div>
 
@@ -78,12 +79,13 @@
                 {{ $t('story.date') }}
                 {{ config.dateModified }}
             </div>
+            <div class="footer-padding" v-if="footerPadding" :style="{ height: `calc(100dvh - ${lastSlideHeight + 260}px)` }"></div>
         </div>
     </div>
 </template>
 
 <script setup lang="ts">
-import { getCurrentInstance, onBeforeUnmount, onMounted, ref } from 'vue';
+import { computed, getCurrentInstance, onBeforeUnmount, onMounted, ref } from 'vue';
 import { useRoute, type RouteLocationNormalized } from 'vue-router';
 
 import MobileMenu from './mobile-menu.vue';
@@ -96,12 +98,21 @@ import { EventBus } from '../../event-bus';
 
 const route = useRoute();
 
+const footerPadding = computed(
+    () => !window.location.href.includes('index-ca-en.html') && !window.location.href.includes('index-ca-fr.html')
+);
+
 const config = ref<StoryRampConfig | undefined>(undefined);
 const loadStatus = ref('loading');
 const activeChapterIndex = ref(-1);
 const targetIndex = ref(-1);
 const headerHeight = ref(0);
 const lang = ref('en');
+const lastSlideHeight = ref(0);
+
+const handleLastSlideHeight = (height: number) => {
+    lastSlideHeight.value = height;
+};
 
 onMounted(() => {
     EventBus.on('scroll-to-slide', (params) => {


### PR DESCRIPTION
### Related Item(s)
Issue [#628](https://github.com/ramp4-pcar4/storylines-editor/issues/628) on storylines-editor

### Changes
- Added a minimum height to the different slide types so that the top of the slide can always reach the top of the viewport even at the bottom of the product and thus highlighting will be aligned

### Testing
Steps:
1. Scroll to the bottom of the product
2. Notice the slides are correctly highlighting

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="256" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines/582)
<!-- Reviewable:end -->
