### PR TITLE
Default dynamic slide with no panels now renders + adheres to Storylines schema

### DIFF
--- a/StorylinesSchema.json
+++ b/StorylinesSchema.json
@@ -132,7 +132,7 @@
                     "items": {
                         "$ref": "#/$defs/dynamicChildItem"
                     },
-                    "minItems": 1
+                    "minItems": 0
                 },
                 "type": {
                     "type": "string",
@@ -206,7 +206,7 @@
                     "items": {
                         "$ref": "#/$defs/dynamicChildItem"
                     },
-                    "minItems": 1
+                    "minItems": 0
                 },
                 "images": {
                     "type": "array",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ramp-storylines_demo-scenarios-pcar",
     "description": "A user-configurable story product featuring interactive maps, charts and dynamic multimedia content alongside text.",
-    "version": "3.5.3",
+    "version": "3.5.4",
     "private": false,
     "license": "MIT",
     "type": "module",

--- a/src/components/panels/dynamic-panel.vue
+++ b/src/components/panels/dynamic-panel.vue
@@ -89,8 +89,11 @@ const props = defineProps({
 const el = ref();
 const content = ref();
 
-// Get the ID of the first (and default) panel.
-const defaultPanel = props.config.children[0];
+// Get the ID of the first or default panel.
+const defaultPanel = (() => {
+    const firstPanel = props.config.children?.[0];
+    return firstPanel ?? { id: 'default-panel', panel: <BasePanel>{ type: 'text', title: '', content: '' } };
+})();
 
 // By default, the active config is set to the first child in the children list.
 const activeConfig = ref<BasePanel>(defaultPanel.panel);
@@ -206,10 +209,12 @@ const clickBack = (): void => {
         top: 6.5rem;
     }
 }
+
 .toc-vertical {
     .return-button-container {
         top: 4rem;
     }
+
     .return-button-reversed {
         left: calc(100vw - 9rem);
     }
@@ -221,6 +226,7 @@ const clickBack = (): void => {
     z-index: 100;
     pointer-events: none;
 }
+
 .return-button {
     float: right;
     pointer-events: auto;
@@ -228,6 +234,7 @@ const clickBack = (): void => {
     box-shadow: 0px 2px 5px #000;
     width: 75px;
 }
+
 .return-button-reversed {
     float: right;
     left: calc(100vw - 6rem);
@@ -236,9 +243,11 @@ const clickBack = (): void => {
     box-shadow: 0px 2px 5px #000;
     width: 75px;
 }
+
 .return-button img {
     margin: 0px;
 }
+
 .has-background {
     background-color: rgba(255, 255, 255, 0.95);
     border-radius: 8px;
@@ -282,6 +291,7 @@ const clickBack = (): void => {
         display: flex;
         flex-direction: column;
     }
+
     .dynamic-content-media {
         display: flex;
         flex-direction: column-reverse;


### PR DESCRIPTION
### Related Item(s)
Storylines editor issues #[675](https://github.com/ramp4-pcar4/storylines-editor/issues/675) and #[672](https://github.com/ramp4-pcar4/storylines-editor/issues/672)

### Changes
- The default dynamic configuration now adheres to the Storylines schema: When there is no child panel, use a default panel (blank text panel), no accessing undefined values and going crazy
- New version published on npm

### Testing
Steps:
1. Have a default dynamic slide configuration
2. Storylines works! (Default blank text panel)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines/586)
<!-- Reviewable:end -->
