### PR TITLE
Fix context menu translations in RESPECT plugin component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ramp-storylines_demo-scenarios-pcar",
     "description": "A user-configurable story product featuring interactive maps, charts and dynamic multimedia content alongside text.",
-    "version": "3.5.8",
+    "version": "3.5.9",
     "private": false,
     "license": "MIT",
     "type": "module",

--- a/src/components/panels/helpers/chart.vue
+++ b/src/components/panels/helpers/chart.vue
@@ -56,7 +56,6 @@ const props = defineProps({
 
 const { t } = useI18n();
 const el = ref();
-const route = useRoute();
 
 const chartOptions = ref<DQVChartConfig>({} as DQVChartConfig);
 const title = ref('');
@@ -78,30 +77,25 @@ const menuOptions = [
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const $papa: any = inject('$papa');
 
+// add FR translations strings to highcharts configuration as required
+const menuLabels = {
+    viewFullscreen: t('chart.viewFullscreen'),
+    printChart: t('chart.printChart'),
+    downloadPNG: t('chart.downloadPNG'),
+    downloadJPEG: t('chart.downloadJPEG'),
+    downloadPDF: t('chart.downloadPDF'),
+    downloadSVG: t('chart.downloadSVG'),
+    downloadCSV: t('chart.downloadCSV'),
+    downloadXLS: t('chart.downloadXLS'),
+    viewData: t('chart.viewData')
+};
+
 onMounted(() => {
     const isMobile = el.value.clientWidth <= 640;
 
     // If the client width is over 640 (not on mobile), add the `View Data Table` option to charts.
     if (!isMobile) {
         menuOptions.push('viewData');
-    }
-
-    // add FR translations strings to highcharts configuration as required
-    const frMenuLabels = {
-        viewFullscreen: t('chart.viewFullscreen'),
-        printChart: t('chart.printChart'),
-        downloadPNG: t('chart.downloadPNG'),
-        downloadJPEG: t('chart.downloadJPEG'),
-        downloadPDF: t('chart.downloadPDF'),
-        downloadSVG: t('chart.downloadSVG'),
-        downloadCSV: t('chart.downloadCSV'),
-        downloadXLS: t('chart.downloadXLS'),
-        viewData: t('chart.viewData')
-    };
-    if ((route && (route.params.lang as string)) === 'fr') {
-        Highcharts.setOptions({
-            lang: frMenuLabels
-        });
     }
 
     if (props.config.config) {
@@ -111,6 +105,7 @@ onMounted(() => {
         loading.value = false;
 
         // Set up hamburger menu options.
+        chartOptions.value.lang = menuLabels;
         if (chartOptions.value.exporting) {
             chartOptions.value.exporting.buttons = {
                 contextButton: {
@@ -184,6 +179,7 @@ const parseJSONFile = (jsonData: DQVChartConfig): void => {
     loading.value = false;
 
     // Set up hamburger menu options.
+    chartOptions.value.lang = menuLabels;
     if (chartOptions.value.exporting) {
         chartOptions.value.exporting.buttons = {
             contextButton: {
@@ -221,6 +217,9 @@ const parseCSVFile = (data: CSVFile): void => {
 
     // extract general chart options that applies to all chart types
     const defaultOptions = {
+        lang: {
+            menuLabels
+        },
         chart: {
             renderTo: 'dv-chart-container',
             type: dqvOptions?.type,

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -79,6 +79,17 @@ export interface LineSeriesData {
 }
 
 export interface DQVChartConfig {
+    lang?: {
+        viewFullscreen: string;
+        printChart: string;
+        downloadPNG: string;
+        downloadJPEG: string;
+        downloadPDF: string;
+        downloadSVG: string;
+        downloadCSV: string;
+        downloadXLS: string;
+        viewData: string;
+    };
     chart: {
         type: string;
     };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -47,7 +47,8 @@ export default defineConfig(() => {
                 external: ['vue', 'ramp-pcar'],
                 output: {
                     globals: {
-                        vue: 'Vue'
+                        vue: 'Vue',
+                        'vue-papa-parse': 'VuePapaParse'
                     },
                     inlineDynamicImports: true,
                     dir: 'dist'


### PR DESCRIPTION
### Related Item(s)
Similar to https://github.com/ramp4-pcar4/highcharts-accessible-configuration-kit/issues/127

### Changes
- fixes issue of Highchart context menu not translating strings when using chart plugin component in RESPECT 

### Notes
Will publish to NPM when approved 

### Testing
Ensure context menu strings are properly translated on Storylines itself

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines/602)
<!-- Reviewable:end -->
