### PR TITLE
HTML history mode

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,7 @@ name: Install and build
 
 on:
     workflow_call:
+    workflow_dispatch:
 
 jobs:
     install-build:
@@ -42,6 +43,8 @@ jobs:
 
             - name: Install and build
               run: |
+                  BRANCH_NAME="${{ github.head_ref || github.ref_name }}"
+                  export BASE_URL="/storylines/${BRANCH_NAME}/"
                   npm ci
                   npm run build
 

--- a/index-ca-en.html
+++ b/index-ca-en.html
@@ -28,39 +28,13 @@
         <div id="def-footer"></div>
 
         <script type="text/javascript">
-            // URL Parsing for Language Switch
-            var url = new URL(window.location.href);
-            var hashParams = url.hash.split('/');
-
-            // If there's an empty item at the end of the paramater list (occurs if there's a trailing slash in the URL), clear it.
-            if (hashParams.at(-1).length === 0) {
-                hashParams.pop();
-            }
-
-            // If content after the last slash in the URL is an anchor, clear it.
-            if (hashParams.at(-1).startsWith('#')) {
-                hashParams.pop();
-            }
-
-            // Finally, extract the StoryRAMP ID from the URL. If it has an anchor tag in it, remove it since it's not useful on the new page.
-            var productID = hashParams.pop();
-
-            if (productID.includes('#')) {
-                productID = productID.split('#')[0];
-            }
-
-            // Check to see if the 'editor' route is included in the URL. If so, keep it.
-            var hasEditor = hashParams.pop() === 'editor';
-
-            // Build new URL route.
-            var newURLRoute = hasEditor ? 'editor/' + productID : productID;
 
             var defTop = document.getElementById('def-top');
             defTop.outerHTML = wet.builder.top({
                 lngLinks: [
                     {
                         lang: 'fr',
-                        href: 'index-ca-fr.html#/fr/' + newURLRoute,
+                        href: window.location.href.replace('ca-en.html', 'ca-fr.html').replace('/en/', '/fr/').replace('lang=en', 'lang=fr'),
                         text: 'Français'
                     }
                 ]

--- a/index-ca-fr.html
+++ b/index-ca-fr.html
@@ -28,39 +28,13 @@
         <div id="def-footer"></div>
 
         <script type="text/javascript">
-            // URL Parsing for Language Switch
-            var url = new URL(window.location.href);
-            var hashParams = url.hash.split('/');
-
-            // If there's an empty item at the end of the paramater list (occurs if there's a trailing slash in the URL), clear it.
-            if (hashParams.at(-1).length === 0) {
-                hashParams.pop();
-            }
-
-            // If content after the last slash in the URL is an anchor, clear it.
-            if (hashParams.at(-1).startsWith('#')) {
-                hashParams.pop();
-            }
-
-            // Finally, extract the StoryRAMP ID from the URL. If it has an anchor tag in it, remove it since it's not useful on the new page.
-            var productID = hashParams.pop();
-
-            if (productID.includes('#')) {
-                productID = productID.split('#')[0];
-            }
-
-            // Check to see if the 'editor' route is included in the URL. If so, keep it.
-            var hasEditor = hashParams.pop() === 'editor';
-
-            // Build new URL route.
-            var newURLRoute = hasEditor ? 'editor/' + productID : productID;
 
             var defTop = document.getElementById('def-top');
             defTop.outerHTML = wet.builder.top({
                 lngLinks: [
                     {
                         lang: 'en',
-                        href: 'index-ca-en.html#/en/' + newURLRoute,
+                        href: window.location.href.replace('ca-fr.html', 'ca-en.html').replace('/fr/', '/en/').replace('lang=fr', 'lang=en'),
                         text: 'English'
                     }
                 ]

--- a/index-lp-ca-en.html
+++ b/index-lp-ca-en.html
@@ -80,35 +80,8 @@
     </div>
 
     <script type="text/javascript">
-        // URL Parsing for Language Switch
-        var url = new URL(window.location.href);
-        var hashParams = url.hash.split('/');
-
-        // If there's an empty item at the end of the paramater list (occurs if there's a trailing slash in the URL), clear it.
-        if (hashParams.at(-1).length === 0) {
-            hashParams.pop();
-        }
-
-        // If content after the last slash in the URL is an anchor, clear it.
-        if (hashParams.at(-1).startsWith('#')) {
-            hashParams.pop();
-        }
-
-        // Finally, extract the StoryRAMP ID from the URL. If it has an anchor tag in it, remove it since it's not useful on the new page.
-        var productID = hashParams.pop();
-
-        if (productID.includes('#')) {
-            productID = productID.split('#')[0];
-        }
-
-        // Check to see if the 'editor' route is included in the URL. If so, keep it.
-        var hasEditor = hashParams.pop() === 'editor';
-
-        // Build new URL route.
-        var newURLRoute = hasEditor ? 'editor/' + productID : productID;
-
         var langChange = document.getElementById('langToggle');
-        langChange.href = 'index-lp-ca-fr.html#/fr/' + newURLRoute;
+        langChange.href = window.location.href.replace('ca-en.html', 'ca-fr.html').replace('/en/', '/fr/').replace('lang=en', 'lang=fr'),
 
         document.addEventListener('Storylines-Loaded', (payload) => {
             const breadcrumbs = payload.detail.config.breadcrumbs ?? []; // default to an empty array if this property isn't defined.

--- a/index-lp-ca-fr.html
+++ b/index-lp-ca-fr.html
@@ -81,35 +81,8 @@
     </div>
 
     <script type="text/javascript">
-        // URL Parsing for Language Switch
-        var url = new URL(window.location.href);
-        var hashParams = url.hash.split('/');
-
-        // If there's an empty item at the end of the paramater list (occurs if there's a trailing slash in the URL), clear it.
-        if (hashParams.at(-1).length === 0) {
-            hashParams.pop();
-        }
-
-        // If content after the last slash in the URL is an anchor, clear it.
-        if (hashParams.at(-1).startsWith('#')) {
-            hashParams.pop();
-        }
-
-        // Finally, extract the StoryRAMP ID from the URL. If it has an anchor tag in it, remove it since it's not useful on the new page.
-        var productID = hashParams.pop();
-
-        if (productID.includes('#')) {
-            productID = productID.split('#')[0];
-        }
-
-        // Check to see if the 'editor' route is included in the URL. If so, keep it.
-        var hasEditor = hashParams.pop() === 'editor';
-
-        // Build new URL route.
-        var newURLRoute = hasEditor ? 'editor/' + productID : productID;
-
         var langChange = document.getElementById('langToggle');
-        langChange.href = 'index-lp-ca-en.html#/en/' + newURLRoute;
+        langChange.href = window.location.href.replace('ca-fr.html', 'ca-en.html').replace('/fr/', '/en/').replace('lang=fr', 'lang=en'),
 
         document.addEventListener('Storylines-Loaded', (payload) => {
             const breadcrumbs = payload.detail.config.breadcrumbs ?? []; // default to an empty array if this property isn't defined.

--- a/public/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000_en.json
+++ b/public/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000_en.json
@@ -2,7 +2,7 @@
     "title": "Test StoryRAMP",
     "introSlide": {
         "logo": {
-            "src": "00000000-0000-0000-0000-000000000000/assets/en/logo.svg",
+            "src": "{BASE_URL}00000000-0000-0000-0000-000000000000/assets/en/logo.svg",
             "altText": "Logo"
         },
         "title": "Test StoryRAMP",
@@ -10,20 +10,20 @@
         "buttonColour": "#fff",
         "titleColour": "#fff",
         "subtitleColour": "#fff",
-        "backgroundImage": "00000000-0000-0000-0000-000000000000/assets/en/bg.jpg"
+        "backgroundImage": "{BASE_URL}00000000-0000-0000-0000-000000000000/assets/en/bg.jpg"
     },
     "slides": [
         {
             "title": "Overview",
-            "backgroundImage": "00000000-0000-0000-0000-000000000000/assets/en/GettyImages-516166467__1554821531978__w1920.jpg",
+            "backgroundImage": "{BASE_URL}00000000-0000-0000-0000-000000000000/assets/en/GettyImages-516166467__1554821531978__w1920.jpg",
             "panel": [
                 {
                     "title": "Overview",
-                    "content": "<Gallery caption='I am a caption for the above gallery.'><GalleryItem credit='Credit: Rick Astley' src='00000000-0000-0000-0000-000000000000/assets/en/bg.jpg' /><GalleryItem src='00000000-0000-0000-0000-000000000000/assets/en/GettyImages-187242601__1554821467033__w1920.jpg' alt='An image displaying a flowchart for Canadas National Pollutant Release Inventory' /><GalleryItem src='00000000-0000-0000-0000-000000000000/assets/en/GettyImages-516166467__1554821531978__w1920.jpg' /></Gallery>**Oil Sands Extraction** is part of the National Pollutant Release Inventory's (NPRI) Sector Overview series. This sector overview explores NPRI substances released, disposed, and transferred by this industry. It also summarizes what steps facilities in this sector take to mitigate their environmental impacts. <AudioPlayer src='https://www.w3schools.com/html/horse.ogg' title='An audio clip with no transcript.'></AudioPlayer> <AudioPlayer src='00000000-0000-0000-0000-000000000000/assets/en/horse.ogv' title='An audio clip with a transcript.' transcript='This audio clip has a transcript. Transcripts support <a href=\"https://google.ca\">HTML</a> and *Markdown*.<br /><br />Curabitur at felis non libero suscipit fermentum. Duis volutpat, ante et scelerisque luctus, sem nulla placerat leo, at aliquet libero justo id nulla. Integer at dui nec magna posuere fringilla. Nunc euismod bibendum augue. Cras nec ligula velit. Donec in laoreet leo.'></AudioPlayer> Businesses, institutions and other facilities across Canada must report their releases, transfers and disposals of pollutants to air, water and land annually to the Government of Canada's NPRI. The information collected is public, helps governments set environmental priorities and monitor environmental performance, and provides Canadians with an opportunity to learn about pollution in their surroundings.",
+                    "content": "<Gallery caption='I am a caption for the above gallery.'><GalleryItem credit='Credit: Rick Astley' src='{BASE_URL}00000000-0000-0000-0000-000000000000/assets/en/bg.jpg' /><GalleryItem src='{BASE_URL}00000000-0000-0000-0000-000000000000/assets/en/GettyImages-187242601__1554821467033__w1920.jpg' alt='An image displaying a flowchart for Canadas National Pollutant Release Inventory' /><GalleryItem src='{BASE_URL}00000000-0000-0000-0000-000000000000/assets/en/GettyImages-516166467__1554821531978__w1920.jpg' /></Gallery>**Oil Sands Extraction** is part of the National Pollutant Release Inventory's (NPRI) Sector Overview series. This sector overview explores NPRI substances released, disposed, and transferred by this industry. It also summarizes what steps facilities in this sector take to mitigate their environmental impacts. <AudioPlayer src='https://www.w3schools.com/html/horse.ogg' title='An audio clip with no transcript.'></AudioPlayer> <AudioPlayer src='{BASE_URL}00000000-0000-0000-0000-000000000000/assets/en/horse.ogv' title='An audio clip with a transcript.' transcript='This audio clip has a transcript. Transcripts support <a href=\"https://google.ca\">HTML</a> and *Markdown*.<br /><br />Curabitur at felis non libero suscipit fermentum. Duis volutpat, ante et scelerisque luctus, sem nulla placerat leo, at aliquet libero justo id nulla. Integer at dui nec magna posuere fringilla. Nunc euismod bibendum augue. Cras nec ligula velit. Donec in laoreet leo.'></AudioPlayer> Businesses, institutions and other facilities across Canada must report their releases, transfers and disposals of pollutants to air, water and land annually to the Government of Canada's NPRI. The information collected is public, helps governments set environmental priorities and monitor environmental performance, and provides Canadians with an opportunity to learn about pollution in their surroundings.",
                     "type": "text"
                 },
                 {
-                    "src": "00000000-0000-0000-0000-000000000000/assets/en/NPRIpictogramme-2016data-EN__1553797637582__w1430.jpg",
+                    "src": "{BASE_URL}00000000-0000-0000-0000-000000000000/assets/en/NPRIpictogramme-2016data-EN__1553797637582__w1430.jpg",
                     "type": "image",
                     "caption": "This is a caption for the image."
                 }
@@ -37,12 +37,12 @@
                     "title": "Interactive Image test",
                     "defaultImage": {
                         "id": "default",
-                        "src": "00000000-0000-0000-0000-000000000000/assets/en/GettyImages-187242601__1554821467033__w1920.jpg"
+                        "src": "{BASE_URL}00000000-0000-0000-0000-000000000000/assets/en/GettyImages-187242601__1554821467033__w1920.jpg"
                     },
                     "images": [
                         {
                             "id": "image-1",
-                            "src": "00000000-0000-0000-0000-000000000000/assets/en/GettyImages-516166467__1554821531978__w1920.jpg"
+                            "src": "{BASE_URL}00000000-0000-0000-0000-000000000000/assets/en/GettyImages-516166467__1554821531978__w1920.jpg"
                         }
                     ],
                     "panels": [
@@ -50,7 +50,7 @@
                             "id": "panel-1",
                             "panel": {
                                 "title": "Hello World",
-                                "content": "<Gallery maxWidth='30%' caption='I am a gallery that only has one image' maxPerRow=3><GalleryItem src='00000000-0000-0000-0000-000000000000/assets/en/bg.jpg' /></Gallery> I am a text panel. I am a child of the dynamic panel config. ![](00000000-0000-0000-0000-000000000000/assets/en/GettyImages-187242601__1554821467033__w1920.jpg)",
+                                "content": "<Gallery maxWidth='30%' caption='I am a gallery that only has one image' maxPerRow=3><GalleryItem src='{BASE_URL}00000000-0000-0000-0000-000000000000/assets/en/bg.jpg' /></Gallery> I am a text panel. I am a child of the dynamic panel config. ![]({BASE_URL}00000000-0000-0000-0000-000000000000/assets/en/GettyImages-187242601__1554821467033__w1920.jpg)",
                                 "type": "text",
                                 "cssClasses": "textPanelOutline"
                             }
@@ -58,7 +58,7 @@
                         {
                             "id": "panel-2",
                             "panel": {
-                                "src": "00000000-0000-0000-0000-000000000000/assets/en/GettyImages-187242601__1554821467033__w1920.jpg",
+                                "src": "{BASE_URL}00000000-0000-0000-0000-000000000000/assets/en/GettyImages-187242601__1554821467033__w1920.jpg",
                                 "type": "image"
                             }
                         },
@@ -96,7 +96,7 @@
             "title": "Community Directory PowerBI Map",
             "panel": [
                 {
-                    "config": "00000000-0000-0000-0000-000000000000/ramp-config/CommunityDirectory.json",
+                    "config": "{BASE_URL}00000000-0000-0000-0000-000000000000/ramp-config/CommunityDirectory.json",
                     "type": "map",
                     "teleportGrid": "right",
                     "scrollguard": true
@@ -108,7 +108,7 @@
             "title": "Interactive Map",
             "panel": [
                 {
-                    "config": "00000000-0000-0000-0000-000000000000/ramp-config/OilSandsFacilityLocations2019.json",
+                    "config": "{BASE_URL}00000000-0000-0000-0000-000000000000/ramp-config/OilSandsFacilityLocations2019.json",
                     "type": "interactive-map",
                     "scrollguard": true,
                     "title": "Map Title Test",
@@ -116,7 +116,7 @@
                         {
                             "title": "Point of Interest A",
                             "text": "This is a test point of interest. This is *a test* to make sure **markdown** works. Below is a link to Google.<br /><br /><a href='https://google.ca/'>Link to Google</a>",
-                            "image": "00000000-0000-0000-0000-000000000000/assets/en/NPRIpictogramme-2016data-EN__1553797637582__w1430.jpg",
+                            "image": "{BASE_URL}00000000-0000-0000-0000-000000000000/assets/en/NPRIpictogramme-2016data-EN__1553797637582__w1430.jpg",
                             "altText": "An image.",
                             "target": {
                                 "layerId": "OilSandsFacilityLocations2019",
@@ -135,14 +135,14 @@
                             "title": "Point of Interest C",
                             "text": "This is a third point of interest. This one includes an image, but also has a ton of text. Maecenas quis ipsum eleifend, finibus erat ut, finibus eros. Pellentesque facilisis iaculis nunc ut luctus. Curabitur luctus pulvinar nulla, id viverra orci viverra id. Nulla eget eleifend est. Maecenas quis ipsum eleifend, finibus erat ut, finibus eros. Pellentesque facilisis iaculis nunc ut luctus. Curabitur luctus pulvinar nulla, id viverra orci viverra id. Nulla eget eleifend est. Maecenas quis ipsum eleifend, finibus erat ut, finibus eros. Pellentesque facilisis iaculis nunc ut luctus. Curabitur luctus pulvinar nulla, id viverra orci viverra id. Nulla eget eleifend est. Maecenas quis ipsum eleifend, finibus erat ut, finibus eros. Pellentesque facilisis iaculis nunc ut luctus. Curabitur luctus pulvinar nulla, id viverra orci viverra id. Nulla eget eleifend est.",
                             "altText": "Another image.",
-                            "image": "00000000-0000-0000-0000-000000000000/assets/en/GettyImages-187242601__1554821467033__w1920.jpg",
+                            "image": "{BASE_URL}00000000-0000-0000-0000-000000000000/assets/en/GettyImages-187242601__1554821467033__w1920.jpg",
                             "target": {
                                 "layerId": "OilSandsFacilityLocations2019",
                                 "oid": 5
                             }
                         },
                         {
-                            "image": "00000000-0000-0000-0000-000000000000/assets/en/GettyImages-187242601__1554821467033__w1920.jpg",
+                            "image": "{BASE_URL}00000000-0000-0000-0000-000000000000/assets/en/GettyImages-187242601__1554821467033__w1920.jpg",
                             "altText": "A third image.",
                             "target": {
                                 "layerId": "OilSandsFacilityLocations2019",
@@ -158,7 +158,7 @@
             "title": "Scrolly Map Tests",
             "panel": [
                 {
-                    "config": "00000000-0000-0000-0000-000000000000/ramp-config/WQMS-map-6.json",
+                    "config": "{BASE_URL}00000000-0000-0000-0000-000000000000/ramp-config/WQMS-map-6.json",
                     "type": "interactive-map",
                     "scrollguard": true,
                     "title": "Scrolly Map Tests",
@@ -200,26 +200,26 @@
                     "type": "slideshow",
                     "items": [
                         {
-                            "config": "00000000-0000-0000-0000-000000000000/ramp-config/test-ramp4.json",
+                            "config": "{BASE_URL}00000000-0000-0000-0000-000000000000/ramp-config/test-ramp4.json",
                             "type": "map",
                             "scrollguard": true,
                             "caption": "I am a map with a caption."
                         },
                         {
-                            "config": "00000000-0000-0000-0000-000000000000/ramp-config/test-ramp4.json",
+                            "config": "{BASE_URL}00000000-0000-0000-0000-000000000000/ramp-config/test-ramp4.json",
                             "type": "map",
                             "scrollguard": true,
                             "title": "I am a map with a title."
                         },
                         {
-                            "config": "00000000-0000-0000-0000-000000000000/ramp-config/test-ramp4.json",
+                            "config": "{BASE_URL}00000000-0000-0000-0000-000000000000/ramp-config/test-ramp4.json",
                             "type": "map",
                             "scrollguard": true,
                             "title": "I have a title...",
                             "caption": "... and a caption."
                         },
                         {
-                            "config": "00000000-0000-0000-0000-000000000000/ramp-config/test-ramp4.json",
+                            "config": "{BASE_URL}00000000-0000-0000-0000-000000000000/ramp-config/test-ramp4.json",
                             "type": "map",
                             "scrollguard": true
                         }
@@ -235,21 +235,21 @@
         },
         {
             "title": "Dynamic Panel Test",
-            "backgroundImage": "00000000-0000-0000-0000-000000000000/assets/en/GettyImages-516166467__1554821531978__w1920.jpg",
+            "backgroundImage": "{BASE_URL}00000000-0000-0000-0000-000000000000/assets/en/GettyImages-516166467__1554821531978__w1920.jpg",
             "backgroundAltText": "Background image for dynamic panel",
             "panel": [
                 {
                     "title": "This Slide Is Dynamic!",
                     "type": "dynamic",
                     "reversed": true,
-                    "content": "You can click on one of the following links to change the right panel.\n\n- <a panel='panel-1'>Text Panel</a>\n- <a panel='panel-2'>Image Panel</a>\n- <a panel='panel-3'>Charts Panel</a>\n- <a panel='panel-4'>Map Panel</a>\n- <a panel='panel-5'>Longer text section with table</a>\n- <a href='#/en/00000000-0000-0000-0000-000000000000#2-oil-sands-deposits' target='_self'>Self target link</a>\n- <a panel='panel-6'>Video externally hosted</a>\n- <a panel='panel-7'>Video locally hosted</a>\n\nFun stuff.",
+                    "content": "You can click on one of the following links to change the right panel.\n\n- <a panel='panel-1'>Text Panel</a>\n- <a panel='panel-2'>Image Panel</a>\n- <a panel='panel-3'>Charts Panel</a>\n- <a panel='panel-4'>Map Panel</a>\n- <a panel='panel-5'>Longer text section with table</a>\n- <a href='#/en/{BASE_URL}00000000-0000-0000-0000-000000000000#2-oil-sands-deposits' target='_self'>Self target link</a>\n- <a panel='panel-6'>Video externally hosted</a>\n- <a panel='panel-7'>Video locally hosted</a>\n\nFun stuff.",
                     "contentWidth": "60%",
                     "children": [
                         {
                             "id": "panel-1",
                             "panel": {
                                 "title": "Hello World",
-                                "content": "I am a text panel. I am a child of the dynamic panel config. ![](00000000-0000-0000-0000-000000000000/assets/en/GettyImages-187242601__1554821467033__w1920.jpg)",
+                                "content": "I am a text panel. I am a child of the dynamic panel config. ![]({BASE_URL}00000000-0000-0000-0000-000000000000/assets/en/GettyImages-187242601__1554821467033__w1920.jpg)",
                                 "type": "text",
                                 "cssClasses": "textPanelOutline"
                             }
@@ -257,7 +257,7 @@
                         {
                             "id": "panel-2",
                             "panel": {
-                                "src": "00000000-0000-0000-0000-000000000000/assets/en/GettyImages-187242601__1554821467033__w1920.jpg",
+                                "src": "{BASE_URL}00000000-0000-0000-0000-000000000000/assets/en/GettyImages-187242601__1554821467033__w1920.jpg",
                                 "type": "image"
                             }
                         },
@@ -268,12 +268,12 @@
                                 "items": [
                                     {
                                         "type": "chart",
-                                        "src": "00000000-0000-0000-0000-000000000000/charts/en/chartConfig.json",
+                                        "src": "{BASE_URL}00000000-0000-0000-0000-000000000000/charts/en/chartConfig.json",
                                         "caption": "caption for a chart"
                                     },
                                     {
                                         "type": "chart",
-                                        "src": "00000000-0000-0000-0000-000000000000/charts/en/1 Mount royal.csv",
+                                        "src": "{BASE_URL}00000000-0000-0000-0000-000000000000/charts/en/1 Mount royal.csv",
                                         "options": {
                                             "title": "Selenium releases and disposals in 2019",
                                             "subtitle": "",
@@ -287,7 +287,7 @@
                         {
                             "id": "panel-4",
                             "panel": {
-                                "config": "00000000-0000-0000-0000-000000000000/ramp-config/OilSandsFacilityLocations2019.json",
+                                "config": "{BASE_URL}00000000-0000-0000-0000-000000000000/ramp-config/OilSandsFacilityLocations2019.json",
                                 "type": "map",
                                 "scrollguard": true
                             }
@@ -307,7 +307,7 @@
                                 "type": "video",
                                 "title": "Overtime job",
                                 "videoType": "external",
-                                "caption": "00000000-0000-0000-0000-000000000000/assets/en/video1-en.mp4.vtt",
+                                "caption": "{BASE_URL}00000000-0000-0000-0000-000000000000/assets/en/video1-en.mp4.vtt",
                                 "src": "https://wet-boew.github.io/wet-boew-attachments/videos/video1-en.mp4",
                                 "autoplay": true
                             }
@@ -318,9 +318,9 @@
                                 "type": "video",
                                 "title": "Overtime job",
                                 "videoType": "local",
-                                "src": "00000000-0000-0000-0000-000000000000/assets/en/video1-en.mp4",
-                                "caption": "00000000-0000-0000-0000-000000000000/assets/en/video1-en.mp4.vtt",
-                                "transcript": "00000000-0000-0000-0000-000000000000/assets/en/cpts-lg-en.html"
+                                "src": "{BASE_URL}00000000-0000-0000-0000-000000000000/assets/en/video1-en.mp4",
+                                "caption": "{BASE_URL}00000000-0000-0000-0000-000000000000/assets/en/video1-en.mp4.vtt",
+                                "transcript": "{BASE_URL}00000000-0000-0000-0000-000000000000/assets/en/cpts-lg-en.html"
                             }
                         }
                     ]
@@ -353,9 +353,9 @@
                     "type": "video",
                     "title": "Overtime job",
                     "videoType": "local",
-                    "src": "00000000-0000-0000-0000-000000000000/assets/en/video1-en.mp4",
-                    "caption": "00000000-0000-0000-0000-000000000000/assets/en/video1-en.mp4.vtt",
-                    "transcript": "00000000-0000-0000-0000-000000000000/assets/en/cpts-lg-en.html",
+                    "src": "{BASE_URL}00000000-0000-0000-0000-000000000000/assets/en/video1-en.mp4",
+                    "caption": "{BASE_URL}00000000-0000-0000-0000-000000000000/assets/en/video1-en.mp4.vtt",
+                    "transcript": "{BASE_URL}00000000-0000-0000-0000-000000000000/assets/en/cpts-lg-en.html",
                     "width": "85%",
                     "autoplay": true
                 }
@@ -371,7 +371,7 @@
                     "type": "text"
                 },
                 {
-                    "config": "00000000-0000-0000-0000-000000000000/ramp-config/OilSandsDeposits.json",
+                    "config": "{BASE_URL}00000000-0000-0000-0000-000000000000/ramp-config/OilSandsDeposits.json",
                     "type": "map",
                     "scrollguard": true
                 }
@@ -387,7 +387,7 @@
                     "type": "text"
                 },
                 {
-                    "src": "00000000-0000-0000-0000-000000000000/assets/en/GettyImages-187242601__1554821467033__w1920.jpg",
+                    "src": "{BASE_URL}00000000-0000-0000-0000-000000000000/assets/en/GettyImages-187242601__1554821467033__w1920.jpg",
                     "type": "image",
                     "fullscreen": false
                 }
@@ -395,7 +395,7 @@
         },
         {
             "title": "In-situ extraction",
-            "backgroundImage": "00000000-0000-0000-0000-000000000000/assets/en/GettyImages-187242601__1554821467033__w1920.jpg",
+            "backgroundImage": "{BASE_URL}00000000-0000-0000-0000-000000000000/assets/en/GettyImages-187242601__1554821467033__w1920.jpg",
 
             "panel": [
                 {
@@ -404,7 +404,7 @@
                     "type": "text"
                 },
                 {
-                    "src": "00000000-0000-0000-0000-000000000000/assets/en/Slide 3 - mine vs insitu.jpg",
+                    "src": "{BASE_URL}00000000-0000-0000-0000-000000000000/assets/en/Slide 3 - mine vs insitu.jpg",
                     "type": "image"
                 }
             ]
@@ -418,7 +418,7 @@
                     "type": "text"
                 },
                 {
-                    "config": "00000000-0000-0000-0000-000000000000/ramp-config/OilSandsFacilityLocations2019.json",
+                    "config": "{BASE_URL}00000000-0000-0000-0000-000000000000/ramp-config/OilSandsFacilityLocations2019.json",
                     "type": "map",
                     "title": "Map Title Test"
                 }
@@ -435,31 +435,31 @@
                 {
                     "items": [
                         {
-                            "src": "00000000-0000-0000-0000-000000000000/assets/en/substances/1_AuroraNorth_RelDisp.PNG",
+                            "src": "{BASE_URL}00000000-0000-0000-0000-000000000000/assets/en/substances/1_AuroraNorth_RelDisp.PNG",
                             "type": "image"
                         },
                         {
-                            "src": "00000000-0000-0000-0000-000000000000/assets/en/substances/2_FortHills_RelDisp.PNG",
+                            "src": "{BASE_URL}00000000-0000-0000-0000-000000000000/assets/en/substances/2_FortHills_RelDisp.PNG",
                             "type": "image"
                         },
                         {
-                            "src": "00000000-0000-0000-0000-000000000000/assets/en/substances/3_Horizon_RelDisp.PNG",
+                            "src": "{BASE_URL}00000000-0000-0000-0000-000000000000/assets/en/substances/3_Horizon_RelDisp.PNG",
                             "type": "image"
                         },
                         {
-                            "src": "00000000-0000-0000-0000-000000000000/assets/en/substances/4_Kearl_RelDisp.PNG",
+                            "src": "{BASE_URL}00000000-0000-0000-0000-000000000000/assets/en/substances/4_Kearl_RelDisp.PNG",
                             "type": "image"
                         },
                         {
-                            "src": "00000000-0000-0000-0000-000000000000/assets/en/substances/5_MuskegJackpine_R5_RelDisp.PNG",
+                            "src": "{BASE_URL}00000000-0000-0000-0000-000000000000/assets/en/substances/5_MuskegJackpine_R5_RelDisp.PNG",
                             "type": "image"
                         },
                         {
-                            "src": "00000000-0000-0000-0000-000000000000/assets/en/substances/6_Suncor_RelDisp.PNG",
+                            "src": "{BASE_URL}00000000-0000-0000-0000-000000000000/assets/en/substances/6_Suncor_RelDisp.PNG",
                             "type": "image"
                         },
                         {
-                            "src": "00000000-0000-0000-0000-000000000000/assets/en/substances/7_Syncrude_RelDisp.PNG",
+                            "src": "{BASE_URL}00000000-0000-0000-0000-000000000000/assets/en/substances/7_Syncrude_RelDisp.PNG",
                             "type": "image"
                         }
                     ],
@@ -479,7 +479,7 @@
                     "type": "text"
                 },
                 {
-                    "config": "00000000-0000-0000-0000-000000000000/ramp-config/ReleasesandDisposalsbyMiningFacilitiesin2019(satellite).json",
+                    "config": "{BASE_URL}00000000-0000-0000-0000-000000000000/ramp-config/ReleasesandDisposalsbyMiningFacilitiesin2019(satellite).json",
                     "type": "map"
                 }
             ]
@@ -493,7 +493,7 @@
                     "type": "text"
                 },
                 {
-                    "src": "00000000-0000-0000-0000-000000000000/assets/en/slide 6 - mining trends.jpg",
+                    "src": "{BASE_URL}00000000-0000-0000-0000-000000000000/assets/en/slide 6 - mining trends.jpg",
                     "type": "image"
                 }
             ],
@@ -503,11 +503,11 @@
             "title": "Reported mine tailings from oil sands surface mining facilities",
             "panel": [
                 {
-                    "src": "00000000-0000-0000-0000-000000000000/assets/en/tailings/AuroraNorth_Tailings.PNG",
+                    "src": "{BASE_URL}00000000-0000-0000-0000-000000000000/assets/en/tailings/AuroraNorth_Tailings.PNG",
                     "type": "image"
                 },
                 {
-                    "src": "00000000-0000-0000-0000-000000000000/assets/en/tailings/FortHills_Tailings.PNG",
+                    "src": "{BASE_URL}00000000-0000-0000-0000-000000000000/assets/en/tailings/FortHills_Tailings.PNG",
                     "type": "image"
                 }
             ]
@@ -521,7 +521,7 @@
                     "type": "text"
                 },
                 {
-                    "config": "00000000-0000-0000-0000-000000000000/ramp-config/ReleasesandDisposalsbyMiningFacilitiesin2019(satellite).json",
+                    "config": "{BASE_URL}00000000-0000-0000-0000-000000000000/ramp-config/ReleasesandDisposalsbyMiningFacilitiesin2019(satellite).json",
                     "type": "map"
                 }
             ],
@@ -536,7 +536,7 @@
                     "type": "text"
                 },
                 {
-                    "config": "00000000-0000-0000-0000-000000000000/ramp-config/TailingsfromMiningFacilities2010to2019(timeslider).json",
+                    "config": "{BASE_URL}00000000-0000-0000-0000-000000000000/ramp-config/TailingsfromMiningFacilities2010to2019(timeslider).json",
                     "timeSlider": {
                         "range": [2010, 2019],
                         "start": [2010, 2010],
@@ -560,7 +560,7 @@
                     "type": "text"
                 },
                 {
-                    "src": "00000000-0000-0000-0000-000000000000/assets/en/Slide 10 - SAGD vs CSS.jpg",
+                    "src": "{BASE_URL}00000000-0000-0000-0000-000000000000/assets/en/Slide 10 - SAGD vs CSS.jpg",
                     "type": "image"
                 }
             ],
@@ -575,7 +575,7 @@
                     "type": "text"
                 },
                 {
-                    "config": "00000000-0000-0000-0000-000000000000/ramp-config/ReleasestoAirbyInSituFacilitiesforAllSubstancesin2019.json",
+                    "config": "{BASE_URL}00000000-0000-0000-0000-000000000000/ramp-config/ReleasestoAirbyInSituFacilitiesforAllSubstancesin2019.json",
                     "type": "map"
                 }
             ],
@@ -594,12 +594,12 @@
                     "items": [
                         {
                             "type": "chart",
-                            "src": "00000000-0000-0000-0000-000000000000/charts/en/chartConfig.json",
+                            "src": "{BASE_URL}00000000-0000-0000-0000-000000000000/charts/en/chartConfig.json",
                             "caption": "Caption for first chart"
                         },
                         {
                             "type": "chart",
-                            "src": "00000000-0000-0000-0000-000000000000/charts/en/Total releases of ethylene glycol for 2019, by province_en.csv",
+                            "src": "{BASE_URL}00000000-0000-0000-0000-000000000000/charts/en/Total releases of ethylene glycol for 2019, by province_en.csv",
                             "options": {
                                 "title": "Figure 2: Total releases of ethylene glycol for 2019, by province",
                                 "xAxisLabel": "Quantity (tonnes)",
@@ -610,7 +610,7 @@
                         },
                         {
                             "type": "chart",
-                            "src": "00000000-0000-0000-0000-000000000000/charts/en/EG_releases_2019_en.csv",
+                            "src": "{BASE_URL}00000000-0000-0000-0000-000000000000/charts/en/EG_releases_2019_en.csv",
                             "options": {
                                 "title": "Figure 1: Percentage of total ethylene glycol releases for 2019, by sector",
                                 "subtitle": "",
@@ -636,7 +636,7 @@
                     "items": [
                         {
                             "type": "chart",
-                            "src": "00000000-0000-0000-0000-000000000000/charts/en/hybridChartConfig.json"
+                            "src": "{BASE_URL}00000000-0000-0000-0000-000000000000/charts/en/hybridChartConfig.json"
                         },
                         {
                             "title": "NPRI data",
@@ -645,12 +645,12 @@
                             "customStyles": "border: 2px solid black;"
                         },
                         {
-                            "config": "00000000-0000-0000-0000-000000000000/ramp-config/ReleasesandDisposalsbyMiningFacilitiesin2019(satellite).json",
+                            "config": "{BASE_URL}00000000-0000-0000-0000-000000000000/ramp-config/ReleasesandDisposalsbyMiningFacilitiesin2019(satellite).json",
                             "type": "map",
                             "scrollguard": true
                         },
                         {
-                            "src": "00000000-0000-0000-0000-000000000000/assets/en/Top10SubstancesTailings2019.png",
+                            "src": "{BASE_URL}00000000-0000-0000-0000-000000000000/assets/en/Top10SubstancesTailings2019.png",
                             "type": "image"
                         }
                     ]
@@ -667,7 +667,7 @@
                     "type": "text"
                 },
                 {
-                    "src": "00000000-0000-0000-0000-000000000000/assets/en/GettyImages-516166467__1554821531978__w1920.jpg",
+                    "src": "{BASE_URL}00000000-0000-0000-0000-000000000000/assets/en/GettyImages-516166467__1554821531978__w1920.jpg",
                     "type": "image"
                 }
             ],
@@ -675,22 +675,22 @@
         },
         {
             "title": "another chart slide",
-            "backgroundImage": "00000000-0000-0000-0000-000000000000/assets/en/GettyImages-187242601__1554821467033__w1920.jpg",
+            "backgroundImage": "{BASE_URL}00000000-0000-0000-0000-000000000000/assets/en/GettyImages-187242601__1554821467033__w1920.jpg",
             "panel": [
                 {
                     "type": "chart",
-                    "src": "00000000-0000-0000-0000-000000000000/charts/en/hybridChartConfig.json",
+                    "src": "{BASE_URL}00000000-0000-0000-0000-000000000000/charts/en/hybridChartConfig.json",
                     "caption": "Caption for chart"
                 },
                 {
-                    "src": "00000000-0000-0000-0000-000000000000/assets/en/GettyImages-516166467__1554821531978__w1920.jpg",
+                    "src": "{BASE_URL}00000000-0000-0000-0000-000000000000/assets/en/GettyImages-516166467__1554821531978__w1920.jpg",
                     "type": "image"
                 }
             ]
         }
     ],
     "tocOrientation": "vertical",
-    "stylesheets": ["00000000-0000-0000-0000-000000000000/styles/main.css"],
+    "stylesheets": ["{BASE_URL}00000000-0000-0000-0000-000000000000/styles/main.css"],
     "contextLink": "https://www.canada.ca/en/environment-climate-change/services/national-pollutant-release-inventory/tools-resources-data/exploredata.html",
     "contextLabel": "Explore National Pollutant Release Inventory data",
     "lang": "en",

--- a/public/web.config
+++ b/public/web.config
@@ -13,5 +13,17 @@
                 <add name="Access-Control-Allow-Origin" value="*" />
             </customHeaders>
         </httpProtocol>
+        <rewrite>
+            <rules>
+                <rule name="Handle History Mode and custom 404/500" stopProcessing="true">
+                <match url="(.*)" />
+                    <conditions logicalGrouping="MatchAll">
+                        <add input="{REQUEST_FILENAME}" matchType="IsFile" negate="true" />
+                        <add input="{REQUEST_FILENAME}" matchType="IsDirectory" negate="true" />
+                    </conditions>
+                    <action type="Rewrite" url="{BASE_URL}" />
+                </rule>
+            </rules>
+        </rewrite>
     </system.webServer>
 </configuration>

--- a/src/components/panels/helpers/toc-item.vue
+++ b/src/components/panels/helpers/toc-item.vue
@@ -40,7 +40,7 @@
         </span>
 
         <router-link
-            :to="{ hash: `#${getSlideId(tocItem.slideIndex)}` }"
+            :to="{ hash: `#${getSlideId(tocItem.slideIndex)}`, query: route.query }"
             class="flex items-center px-2 py-1 mx-1"
             :class="{ 'flex-grow min-w-0': parentItem, 'pb-2': parentItem && !verticalToc }"
             target
@@ -81,10 +81,12 @@
 
 <script setup lang="ts">
 import type { PropType } from 'vue';
+import { useRoute } from 'vue-router';
 import type { MenuItem, Slide } from '@storylines/definitions';
 
 import { useI18n } from 'vue-i18n';
 const { t } = useI18n();
+const route = useRoute();
 
 const props = defineProps({
     tocItem: {
@@ -130,7 +132,7 @@ const scrollToChapter = (id: string): void => {
         emit('scroll-to-slide', props.tocItem.slideIndex);
         setTimeout(() => {
             const navbar = document.getElementById('h-navbar');
-            const header = document.getElementById('story-header');
+            const header = document.getElementById('story-header')!;
             const offset = navbar ? navbar.offsetHeight + header.offsetHeight : header.offsetHeight;
             const rect = el.getBoundingClientRect();
             const scrollTop = window.pageYOffset || document.documentElement.scrollTop;

--- a/src/components/story/introduction.vue
+++ b/src/components/story/introduction.vue
@@ -44,7 +44,7 @@
             </button>
 
             <router-link
-                :to="{ hash: '#story' }"
+                :to="{ hash: '#story', query: route.query }"
                 class="inline-block mt-10 scroll-arrow"
                 :title="$t('intro.scrollToStory')"
                 target
@@ -80,7 +80,10 @@
 <script setup lang="ts">
 import type { PropType } from 'vue';
 import { reactive, onMounted } from 'vue';
-import { ConfigFileStructure, Intro } from '@storylines/definitions';
+import { useRoute } from 'vue-router';
+import type { ConfigFileStructure, Intro } from '@storylines/definitions';
+
+const route = useRoute();
 
 const props = defineProps({
     config: {

--- a/src/components/story/story.vue
+++ b/src/components/story/story.vue
@@ -27,7 +27,7 @@
                         :active-chapter-index="activeChapterIndex"
                         :return-to-top="config.returnTop ?? true"
                         :customToc="config.tableOfContents"
-                        :slides="config.slides"
+                        :slides="config.slides as Slide[]"
                         @scroll-to-slide="setTargetIndex"
                         :lang="lang"
                     />
@@ -84,18 +84,21 @@
 </template>
 
 <script setup lang="ts">
-import { computed, getCurrentInstance, onBeforeUnmount, onMounted, ref } from 'vue';
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue';
 import { useRoute, type RouteLocationNormalized } from 'vue-router';
+import { useI18n } from 'vue-i18n';
 
 import MobileMenu from './mobile-menu.vue';
 import StoryContent from '@storylines/components/story/story-content.vue';
 import Intro from '@storylines/components/story/introduction.vue';
 
-import type { StoryRampConfig } from '@storylines/definitions';
+import type { StoryRampConfig, Slide } from '@storylines/definitions';
 import { VueSpinnerOval } from 'vue3-spinners';
 import { EventBus } from '../../event-bus';
 
 const route = useRoute();
+
+const { locale } = useI18n();
 
 const footerPadding = computed(
     () => !window.location.href.includes('index-ca-en.html') && !window.location.href.includes('index-ca-fr.html')
@@ -126,12 +129,16 @@ function measure(): void {
 
 onMounted(() => {
     window.addEventListener('resize', measure);
-    EventBus.on('scroll-to-slide', (params) => {
+    EventBus.on('scroll-to-slide', (params: any) => {
         setTargetIndex(+params.slideIndex);
     });
-    const uid = route.params.uid as string;
-    lang.value = (route.params.lang as string) ? (route.params.lang as string) : 'en';
-    if (uid) {
+    let uid = route.params.uid as string;
+    lang.value = route.params.lang as string;
+    if (uid && !uid.includes('.html')) {
+        fetchConfig(uid, lang.value || 'en');
+    } else if (route.query.uid && route.query.lang) {
+        uid = route.query.uid as string;
+        lang.value = route.query.lang as string;
         fetchConfig(uid, lang.value);
     } else {
         console.error(`Please supply the language and id URL params in the form of /[lang]/[uid].`);
@@ -142,15 +149,13 @@ onMounted(() => {
     // set page lang
     const html = document.documentElement; // returns the html tag
     html.setAttribute('lang', lang.value);
-    const instance = getCurrentInstance();
-    if (instance?.proxy?.$i18n) {
-        instance.proxy.$i18n.locale = lang.value;
-    }
+    locale.value = lang.value;
 });
 
 onBeforeUnmount(() => {
-    measureNav();
-    EventBus.off('scroll-to-slide', (params) => {
+    // TODO: was this supposed to be measure() and why
+    //measureNav();
+    EventBus.off('scroll-to-slide', (params: any) => {
         setTargetIndex(+params.slideIndex);
     });
 });
@@ -160,10 +165,7 @@ onBeforeUnmount(() => {
 const beforeRouteUpdate = (to: RouteLocationNormalized, from: RouteLocationNormalized, next: () => void): void => {
     const uid = to.params.uid as string;
     lang.value = to.params.lang as string;
-    const instance = getCurrentInstance();
-    if (instance?.proxy?.$i18n) {
-        instance.proxy.$i18n.locale = lang.value;
-    }
+    locale.value = lang.value;
     fetchConfig(uid, lang.value);
     next();
 };
@@ -181,7 +183,8 @@ const scrollToTop = () => {
 };
 
 const fetchConfig = (uid: string, lang: string): void => {
-    fetch(`${uid}/${uid}_${lang}.json`)
+    // import.meta.en.BASE_URL is the base url set for the vite build, defaults to '/'
+    fetch(import.meta.env.BASE_URL + `${uid}/${uid}_${lang}.json`)
         .then((res) => {
             res.json()
                 .then((configs: StoryRampConfig) => {

--- a/src/components/story/toc-list.vue
+++ b/src/components/story/toc-list.vue
@@ -70,7 +70,7 @@
             </a>
 
             <router-link
-                :to="{ hash: '#intro' }"
+                :to="{ hash: '#intro', query: route.query }"
                 class="flex py-1"
                 :class="{ 'items-center mx-1 px-2': tocType !== 'mobile', 'px-3': tocType === 'mobile' }"
                 target
@@ -222,8 +222,11 @@
 <script setup lang="ts">
 import type { PropType } from 'vue';
 import { computed, ref, watch, onBeforeUnmount, onMounted } from 'vue';
+import { useRoute } from 'vue-router';
 import type { MenuItem, Slide } from '@storylines/definitions';
 import TocItem from '@storylines/components/panels/helpers/toc-item.vue';
+
+const route = useRoute();
 
 const props = defineProps({
     activeChapterIndex: {

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,5 +1,4 @@
-//import StoryV from '@storylines/components/story/story.vue';
-import { createRouter, createWebHashHistory, type RouteLocationNormalized } from 'vue-router';
+import { createRouter, createWebHistory, type RouteLocation, type RouteLocationNormalized } from 'vue-router';
 import { EventBus } from '../event-bus';
 const routes = [
     {
@@ -18,14 +17,13 @@ const routes = [
 
 const router = createRouter({
     routes: routes,
-    // mode: 'history', // TODO: uncomment to change to history mode for nicer URLs (eliminating middle hash) see #100
-    history: createWebHashHistory(),
+    history: createWebHistory('' + import.meta.env.BASE_URL),
     scrollBehavior: function (to: RouteLocationNormalized, from) {
         if (to.hash) {
             EventBus.emit('scroll-to-slide', { slideIndex: to.hash.split('-')[0].split('#').at(-1) });
 
             // Delay is needed to allow slides to force load when lazy loading is enabled
-            const delay = from.href ? 100 : 1000; // routing upon a page reload needs more time
+            const delay = from.fullPath ? 100 : 1000; // routing upon a page reload needs more time
             return new Promise((resolve, reject) => {
                 setTimeout(() => {
                     resolve({
@@ -40,5 +38,14 @@ const router = createRouter({
         }
     }
 });
+
+// redirects old hash URLs to the new URLs
+router.beforeEach((to, from, next) => {
+    if (to.fullPath.startsWith('/#/')) {
+        next({ path: to.fullPath.substring(2), replace: true});
+    } else {
+        next();
+    }
+})
 
 export default router;

--- a/src/shims-tsx.d.ts
+++ b/src/shims-tsx.d.ts
@@ -11,5 +11,9 @@ declare global {
         }
     }
 
+    interface ImportMeta {
+        env: any;
+    }
+
     const RAMP: any;
 }

--- a/vite-plugins/replace-tokens.js
+++ b/vite-plugins/replace-tokens.js
@@ -1,0 +1,82 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+
+export default function replaceTokensPlugin(options) {
+    const {
+        tokens = {}, // mapping of token: replacement
+    } = options;
+
+    function replaceTokens(str) {
+        let result = str;
+        for (const [token, value] of Object.entries(tokens)) {
+            const re = new RegExp(`\\{${token}\\}`, 'g');
+            result = result.replace(re, value);
+        }
+        return result;
+    }
+
+    return {
+        name: 'vite-plugin-replace-tokens',
+
+        // DEV
+        configureServer(server) {
+            server.middlewares.use(async (req, res, next) => {
+                // Only handle GET requests for JSON files from public dir
+                if (req.method !== 'GET') {
+                    return next();
+                }
+
+                // Remove query/fragment
+                const url = req.url.split('?')[0].split('#')[0];
+                if (!/\.json$/.test(url) && !/\.config$/.test(url)) {
+                    return next();
+                }
+
+                const filePath = path.join(process.cwd(), 'public', url);
+                try {
+                    // Check file exists
+                    await fs.access(filePath);
+                    let content = await fs.readFile(filePath, 'utf-8');
+                    content = replaceTokens(content);
+                    res.setHeader('Content-Type', 'application/json');
+                    res.end(content);
+                } catch (e) {
+                next();
+                }
+            });
+        },
+
+        // BUILD
+        async closeBundle() {
+            const publicPath = path.resolve(process.cwd(), 'public');
+            const distPath = path.resolve(process.cwd(), 'dist');
+
+            async function processDirectory(productDirectory) {
+                const productPath = path.join(publicPath, productDirectory.name)
+                const entries = await fs.readdir(productPath, { withFileTypes: true });
+                for (const entry of entries) {
+                    if (/\.json$/.test(entry.name) || /\.config$/.test(entry.name)) {
+                        // its a json file, replace tokens
+                        const absPath = path.join(productPath, entry.name);
+                        const relPath = path.join('', productDirectory.name, entry.name);
+                        let content = await fs.readFile(absPath, 'utf-8');
+                        content = replaceTokens(content);
+                        // write to dist folder
+                        const outPath = path.join(distPath, relPath);
+                        await fs.mkdir(path.dirname(outPath), { recursive: true });
+                        await fs.writeFile(outPath, content, 'utf-8');
+                    }
+                }
+            }
+
+            await processDirectory({name: ''});
+            // find product folders
+            const products = await fs.readdir(publicPath, { withFileTypes: true });
+            products.forEach(async (product) => {
+                if (product.isDirectory()) {
+                    await processDirectory(product);
+                }
+            });
+        }
+    };
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,8 @@ import vue from '@vitejs/plugin-vue';
 import dsv from '@rollup/plugin-dsv';
 import path from 'path';
 import { viteStaticCopy } from 'vite-plugin-static-copy';
+//@ts-ignore
+import replaceTokensPlugin from './vite-plugins/replace-tokens.js';
 
 const baseConfig: UserConfigExport = {
     plugins: [
@@ -15,12 +17,17 @@ const baseConfig: UserConfigExport = {
                 { src: 'help', dest: './' },
                 { src: 'StorylinesSchema.json', dest: './' }
             ]
+        }),
+        replaceTokensPlugin({
+            tokens: {
+                'BASE_URL': process.env.BASE_URL || '/'
+            }
         })
     ],
     define: {
         'process.env': process.env
     },
-    base: './',
+    base: process.env.BASE_URL || '/',
     resolve: {
         alias: {
             '@storylines': path.resolve(__dirname, 'src'),
@@ -31,7 +38,7 @@ const baseConfig: UserConfigExport = {
         target: 'esnext'
     },
     server: {
-        open: '/#/en/00000000-0000-0000-0000-000000000000'
+        open: '/en/00000000-0000-0000-0000-000000000000'
     }
 };
 


### PR DESCRIPTION
This is half PR half Discussion, please point out any pitfalls you think may come along with this change.

### Related Item(s)
#609 

### Changes
- [FEATURE] Enables HTML history mode in vue, removing the `#` from the middle of the URLs
- [REFACTOR] Appease minor typescript errors

### Notes
There are some downsides to switching;
- Demo URLs cannot use the fancy new style because GitHub pages does not allow server configuration
- If the storylines deployment is not at the root of the server then the `BASE_URL` needs to be set at build time


### Testing

https://spencerwahl.github.io/storylines/main/?lang=en&uid=00000000-0000-0000-0000-000000000000

This uses the new github actions build, the PR build for this will not as the yaml file needs to be on main.

Example using new URL style will be sent elsewhere.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines/610)
<!-- Reviewable:end -->
