### PR TITLE
tweak external link glyph

### DIFF
--- a/src/assets/popout.svg
+++ b/src/assets/popout.svg
@@ -1,3 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="rgb(43,43,43)">
   <path fill-rule="evenodd" d="M15.75 2.25H21a.75.75 0 01.75.75v5.25a.75.75 0 01-1.5 0V4.81L8.03 17.03a.75.75 0 01-1.06-1.06L19.19 3.75h-3.44a.75.75 0 010-1.5zm-10.5 4.5a1.5 1.5 0 00-1.5 1.5v10.5a1.5 1.5 0 001.5 1.5h10.5a1.5 1.5 0 001.5-1.5V10.5a.75.75 0 011.5 0v8.25a3 3 0 01-3 3H5.25a3 3 0 01-3-3V8.25a3 3 0 013-3h8.25a.75.75 0 010 1.5H5.25z" clip-rule="evenodd"/>
 </svg>

--- a/src/components/story/story.vue
+++ b/src/components/story/story.vue
@@ -293,9 +293,9 @@ $font-list: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
     .prose a:not([panel]):not([target='_self'])::after {
         content: url('../../assets/popout.svg');
         display: inline-block;
-        margin-left: 0.2em;
-        height: 1em;
-        width: 1em;
+        margin-left: 3px;
+        height: 0.8em;
+        width: 0.8em;
         text-align: center;
     }
 


### PR DESCRIPTION
### Related Item(s)
https://github.com/ramp4-pcar4/custom-projects/issues/320#issuecomment-3386416628

### Changes
- Some minor external icon glyph tweaks:
  - made some small adjustments to the size of the glyph, setting it to 0.8x the text size
  - set the left padding to be a constant 3px instead of making it dynamic based on the font size
  - changed the color from rgb(0,0,0) to rgb(43,43,43)

### Testing
Steps:
1. Open the demo link.
2. Ensure that the external link glyphs are displaying correctly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines/613)
<!-- Reviewable:end -->
