### PR TITLE
bump npm version to 3.5.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ramp-storylines_demo-scenarios-pcar",
     "description": "A user-configurable story product featuring interactive maps, charts and dynamic multimedia content alongside text.",
-    "version": "3.5.10",
+    "version": "3.5.11",
     "private": false,
     "license": "MIT",
     "type": "module",


### PR DESCRIPTION
Bumps the NPM version to 3.5.11. Includes the HTML history changes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines/616)
<!-- Reviewable:end -->
