### PR TITLE
enable Highchart pattern fills

### DIFF
--- a/public/00000000-0000-0000-0000-000000000000/charts/en/chartConfig.json
+++ b/public/00000000-0000-0000-0000-000000000000/charts/en/chartConfig.json
@@ -20,24 +20,7 @@
         }
     },
     "xAxis": {
-        "categories": [
-            2004,
-            2005,
-            2006,
-            2007,
-            2008,
-            2009,
-            2010,
-            2011,
-            2012,
-            2013,
-            2014,
-            2015,
-            2016,
-            2017,
-            2018,
-            2019
-        ],
+        "categories": [2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019],
         "title": {
             "text": "Year"
         }
@@ -47,7 +30,9 @@
             "name": "Facility emissions (kilotonnes of carbon dioxide equivalent)",
             "data": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 33.96, 23.08, 17.5],
             "type": "column",
-            "color": "#0f4c6a"
+            "color": {
+                "patternIndex": 0
+            }
         },
         {
             "name": "Reporting threshold",

--- a/src/components/panels/helpers/chart.vue
+++ b/src/components/panels/helpers/chart.vue
@@ -15,7 +15,6 @@
 <script setup lang="ts">
 import type { PropType } from 'vue';
 import { inject, onMounted, ref } from 'vue';
-import { useRoute } from 'vue-router';
 import {
     ChartPanel,
     ConfigFileStructure,
@@ -29,10 +28,12 @@ import Highcharts from 'highcharts';
 import dataModule from 'highcharts/modules/data';
 import exporting from 'highcharts/modules/exporting';
 import exportData from 'highcharts/modules/export-data';
+import patternFill from 'highcharts/modules/pattern-fill';
 
 dataModule(Highcharts);
 exporting(Highcharts);
 exportData(Highcharts);
+patternFill(Highcharts);
 
 interface CSVFile {
     url: string;


### PR DESCRIPTION
### Related Item(s)
https://github.com/ramp4-pcar4/custom-projects/issues/337

### Changes
- Adds and enables the Highcharts `pattern-fill` module.


### Testing
Steps:
1. Open the demo page.
2. Scroll down to the `Highcharts Demo (╯°□°)╯︵ ┻━┻` slide.
3. Notice that the bar chart is now using a pattern.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines/617)
<!-- Reviewable:end -->
