### PR TITLE
add better way to detect WET template

### DIFF
--- a/src/components/story/story.vue
+++ b/src/components/story/story.vue
@@ -100,9 +100,9 @@ const route = useRoute();
 
 const { locale } = useI18n();
 
-const footerPadding = computed(
-    () => !window.location.href.includes('index-ca-en.html') && !window.location.href.includes('index-ca-fr.html')
-);
+// 'wb-cont' is a class used to define the body content of the WET template.
+// If it is not present, we need to add padding to the footer.
+const footerPadding = computed(() => !document.getElementById('wb-cont'));
 
 const footerPaddingStyle = computed(() => {
     measure();


### PR DESCRIPTION
### Related Item(s)
#583 

### Changes
- Replaces our existing way of detecting whether the page is using the WET template with a new way that doesn't care about the file name.

### Notes
The app should be nested in the element with the `wb-cont` id when using the WET template. ~~Having issues rebasing this branch, looking into a fix for it.~~

### Testing
Steps:
1. Open the demo link without the WET template ([link](https://ramp4-pcar4.github.io/storylines/fix-583/?lang=en&uid=00000000-0000-0000-0000-000000000000)).
2. Ensure that the element with the `footer-padding` class is showing up (it's a child of the `storyramp-app` div when using inspect element).
3. Open the demo link that uses the WET template ([link](https://ramp4-pcar4.github.io/storylines/fix-583/index-ca-en.html?lang=en&uid=00000000-0000-0000-0000-000000000000)).
4. Ensure that the element does not appear.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines/618)
<!-- Reviewable:end -->
