### PR TITLE
display inline images within text panels in RESPECT preview mode

### DIFF
--- a/src/components/panels/dynamic-panel.vue
+++ b/src/components/panels/dynamic-panel.vue
@@ -21,7 +21,11 @@
                 {{ config.title }}
             </component>
 
-            <div class="px-10 md-content" v-html="md.render(config.content)"></div>
+            <TextContent
+                :content="mdContent"
+                :configFileStructure="configFileStructure"
+                @rerender="addDynamicURLs"
+            ></TextContent>
         </scrollama>
 
         <div
@@ -53,7 +57,7 @@
                 :dynamicIdx="activeIdx"
                 :ratio="false"
                 :background="background"
-                ref="content"
+                ref="panelContent"
             >
             </panel>
         </div>
@@ -62,13 +66,14 @@
 
 <script setup lang="ts">
 import type { PropType } from 'vue';
+import type { BasePanel, ConfigFileStructure, DynamicPanel } from '@storylines/definitions';
 import { defineAsyncComponent, getCurrentInstance, onMounted, ref } from 'vue';
-import { BasePanel, ConfigFileStructure, DynamicPanel } from '@storylines/definitions';
 
 import MarkdownIt from 'markdown-it';
 import Scrollama from './helpers/scrollama.vue';
 
 const panel = defineAsyncComponent(() => import('./panel.vue'));
+const TextContent = defineAsyncComponent(() => import('./helpers/text-content.vue'));
 
 const props = defineProps({
     config: {
@@ -87,7 +92,8 @@ const props = defineProps({
 });
 
 const el = ref();
-const content = ref();
+const panelContent = ref();
+const mdContent = ref('');
 
 // Get the ID of the first or default panel.
 const defaultPanel = (() => {
@@ -109,7 +115,8 @@ onMounted(() => {
         .querySelectorAll('.storyramp-app a:not([target])')
         .forEach((el: Element) => ((el as HTMLAnchorElement).target = '_blank'));
 
-    addDynamicURLs();
+    // Render the Markdown content.
+    mdContent.value = md.render(props.config.content);
 
     // Check for a switch from normal view to mobile view. Fixed text panel width will need to be adjusted.
     isMobile.value = window.innerWidth <= 640;
@@ -154,7 +161,7 @@ const addDynamicURLs = (): void => {
                 }, 10);
 
                 setTimeout(() => {
-                    const elTop = content.value?.$el.getBoundingClientRect().top;
+                    const elTop = panelContent.value?.$el.getBoundingClientRect().top;
                     window.scrollTo({
                         top: window.scrollY + elTop - calculateScrollOffset(),
                         left: 0,
@@ -168,7 +175,7 @@ const addDynamicURLs = (): void => {
 
 // Calculate the scroll offset based on whether the table of contents is horizontal or vertical.
 const calculateScrollOffset = (): number => {
-    const isHorizontal = content.value?.$el.closest('.toc-horizontal');
+    const isHorizontal = panelContent.value?.$el.closest('.toc-horizontal');
     const horizontalHeight = document.getElementById('h-navbar')?.clientHeight;
     const headerHeight = document.getElementById('story-header')!.clientHeight;
 
@@ -193,7 +200,7 @@ const clickBack = (): void => {
     }, 10);
 
     setTimeout(() => {
-        const elTop = content.value?.$el.getBoundingClientRect().top;
+        const elTop = panelContent.value?.$el.getBoundingClientRect().top;
         window.scrollTo({
             top: window.scrollY + elTop - calculateScrollOffset(),
             left: 0,

--- a/src/components/panels/helpers/text-content.vue
+++ b/src/components/panels/helpers/text-content.vue
@@ -8,10 +8,11 @@
  * To add support for a new inline component, simply import it here and add it to the `components` object.
  */
 
-import { defineAsyncComponent, h, onMounted } from 'vue';
+import { defineAsyncComponent, h, onMounted, ref, nextTick } from 'vue';
 import { useI18n } from 'vue-i18n';
 
 const { t } = useI18n();
+const mdContent = ref('');
 
 import type { PropType } from 'vue';
 import type { ConfigFileStructure } from '@storylines/definitions';
@@ -25,6 +26,8 @@ const props = defineProps({
         type: Object as PropType<ConfigFileStructure>
     }
 });
+
+const emit = defineEmits(['rerender']);
 
 const AudioPlayer = defineAsyncComponent(() => import('./audio-widget.vue'));
 const Gallery = defineAsyncComponent(() => import('./gallery-widget.vue'));
@@ -43,6 +46,74 @@ onMounted(() => {
 
         (el as HTMLAnchorElement).innerHTML = innerHTML + `<span class="sr-only"> (${t('text.newTab')})</span>`;
     });
+
+    mdContent.value = props.content;
+
+    // If in RESPECT preview mode, we need to do some extra Markdown rendering to display inline images in the text panel.
+    if (props.configFileStructure) {
+        const imagePromises: Promise<any>[] = [];
+
+        // Creates a Promise that resolves when an image is successfully fetched from the ZIP folder.
+        const _buildImagePromise = (m: RegExpMatchArray) => {
+            return new Promise((resolve) => {
+                // Grab the image source and alt text from the RegEx groups.
+                const image = m[1];
+                const altText = (m[2] !== undefined ? m[2] : m[3]) || ''; // use the alt text if it exists, default to "" if missing
+
+                const assetSrc = `${image.substring(image.indexOf('/') + 1)}`;
+                const imageFile = props.configFileStructure?.zip.file(assetSrc);
+                const imageType = assetSrc.split('.').at(-1);
+                if (imageFile) {
+                    // Convert the image to a blob so it can be displayed locally.
+                    imageFile.async(imageType === 'svg' ? 'text' : 'blob').then((res) => {
+                        resolve({
+                            matched: m[0],
+                            alt: altText,
+                            src: image,
+                            blob:
+                                imageType === 'svg'
+                                    ? URL.createObjectURL(new Blob([res], { type: 'image/svg+xml' }))
+                                    : URL.createObjectURL(res as Blob)
+                        });
+                    });
+                } else {
+                    resolve(null);
+                }
+            });
+        };
+
+        const extractMarkdownImages = (markdown: string) => {
+            let m: RegExpExecArray | null;
+
+            const htmlRe =
+                /<img[^>]*?\s+src=["'](?!(?:https?:|data:|blob:))([^"']+)["'][^>]*?(?:\s+alt="([^"]*)"|(?:\s+alt='([^']*)')?)?/g;
+
+            // Match local inline HTML image tags, i.e., <img src="/Test/assets/en/image.png" alt="alt">. Markdown images should have
+            // been converted to HTML at this point. Ignores previously "BLOBbed" URLs.
+            while ((m = htmlRe.exec(markdown)) !== null) {
+                imagePromises.push(_buildImagePromise(m));
+            }
+
+            // Once the matching images resolve, replace the image source with it's newly creating BLOB URL.
+            Promise.all(imagePromises).then((image) => {
+                image.forEach((img) => {
+                    mdContent.value = mdContent.value.replace(img.matched, `<img src="${img.blob}" alt="${img.alt}"`);
+                });
+
+                // After all images have been replaced, emit a rerender event so the parent component can perform actions as required.
+                nextTick(() => {
+                    emit('rerender');
+                });
+            });
+        };
+
+        extractMarkdownImages(mdContent.value);
+    } else {
+        // Text has been updated, emit a rerender event so the parent component can perform actions as required.
+        nextTick(() => {
+            emit('rerender');
+        });
+    }
 });
 
 const render = () => {
@@ -56,7 +127,7 @@ const render = () => {
             // Pass the configFileStructure down to the widgets. This way we don't need to include it as a prop.
             configFileStructure: props.configFileStructure
         },
-        template: `<div class="px-10 md-content object-contain">${props.content || ''}</div>`
+        template: `<div class="px-10 md-content object-contain">${mdContent.value || ''}</div>`
     };
 
     return h(r);

--- a/src/components/panels/map-panel.vue
+++ b/src/components/panels/map-panel.vue
@@ -121,7 +121,8 @@ const init = async () => {
         const mapFile = props.configFileStructure.zip.file(assetSrc);
         if (mapFile) {
             mapFile.async('string').then((res: string) => {
-                setupMap(JSON.parse(res));
+                const cleanRes = res.replace(/^\uFEFF/, ''); // Remove BOM if present.
+                setupMap(JSON.parse(cleanRes));
             });
         }
     } else {

--- a/src/components/story/introduction.vue
+++ b/src/components/story/introduction.vue
@@ -134,7 +134,7 @@ onMounted(() => {
             const bgSrc = `${background.substring(background.indexOf('/') + 1)}`;
             const bgFile = props.configFileStructure.zip.file(bgSrc);
             const bgType = bgSrc.split('.').at(-1);
-            const bgName = logo.replace(/^.*[\\/]/, '');
+            const bgName = background.replace(/^.*[\\/]/, '');
             if (bgFile) {
                 if (bgType !== 'svg') {
                     bgFile.async('blob').then((res: Blob) => {

--- a/src/components/story/story-content.vue
+++ b/src/components/story/story-content.vue
@@ -168,6 +168,8 @@ const setTargetIndex = (index) => {
 };
 
 const handleSlideChange = (event: number): void => {
+    if (props.config.slides[event] === undefined) return;
+
     const img = (props.config.slides[event] as Slide).backgroundImage;
     const altText = (props.config.slides[event] as Slide).backgroundAltText;
     backgroundImage.value = !!img ? img : 'none';


### PR DESCRIPTION
### Related Item(s)
https://github.com/ramp4-pcar4/storylines-editor/issues/760

### Changes
- Inline images within text panels will now be correctly rendered when previewing a product in RESPECT.
- The text side of dynamic panels will now use the same text component as text panels, meaning they now also support the Audio and Gallery widgets.

Bonus fixes:
- Map previews were breaking in RESPECT's preview mode because of a hidden "Byte Order Mark" (\uFEFF) at the beginning of some map configuration files. This is now being replaced so that map previews load correctly.
- Fixed an issue where previewing a product that used a background image in the introduction panel would cause the preview to crash.

### Notes
Inline images will now display **within RESPECT's preview mode**, not the Markdown editor preview. That will require changes to the RESPECT repo and will likely be a bit more difficult to implement. I'll open a new issue for this shortly (edit: https://github.com/ramp4-pcar4/storylines-editor/issues/777)

### Testing
Since this change is specific to RESPECT's preview mode, testing won't be possible with this demo. Just ensure that text panels are still working as expected.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines/619)
<!-- Reviewable:end -->
