### PR TITLE
Add French translation for exit fullscreen and context button hover

### DIFF
--- a/src/components/panels/helpers/chart.vue
+++ b/src/components/panels/helpers/chart.vue
@@ -79,7 +79,9 @@ const $papa: any = inject('$papa');
 
 // add FR translations strings to highcharts configuration as required
 const menuLabels = {
+    contextButtonTitle: t('chart.contextButtonTitle'),
     viewFullscreen: t('chart.viewFullscreen'),
+    exitFullscreen: t('chart.exitFullscreen'),
     printChart: t('chart.printChart'),
     downloadPNG: t('chart.downloadPNG'),
     downloadJPEG: t('chart.downloadJPEG'),

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -80,7 +80,9 @@ export interface LineSeriesData {
 
 export interface DQVChartConfig {
     lang?: {
+        contextButtonTitle: string;
         viewFullscreen: string;
+        exitFullscreen: string;
         printChart: string;
         downloadPNG: string;
         downloadJPEG: string;

--- a/src/lang/lang.csv
+++ b/src/lang/lang.csv
@@ -25,7 +25,9 @@ video.transcript,Transcript,1,Transcription,0
 audio.transcript.show,View Transcript,1,Afficher la transcription,0
 audio.transcript.hide,Hide Transcript,1,Cacher la transcription,0
 audio.transcript.none,No transcript available,1,Aucune transcription disponible,0
+chart.contextButtonTitle,Chart context menu,1,Tableau menu contextuel,1
 chart.viewFullscreen,View in full screen,1,Plein Écran,1
+chart.exitFullscreen,Exit full screen,1,Quitter le plein écran,1
 chart.printChart,Print chart,1,Imprimer,1
 chart.downloadPNG,Download PNG,1,Télécharger PNG,1
 chart.downloadJPEG,Download JPEG,1,Télécharger JPEG,1


### PR DESCRIPTION
### Changes
- Added French translations for the contextmenu tooltip and exit fullscreen (Highcharts)
- This also fixes it in RESPECT

### Testing
Steps:
1. Switch to French
2. Hover over context menu button, notice French
3. Enter fullscreen
4. Notice exit fullscreen in French

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines/639)
<!-- Reviewable:end -->
